### PR TITLE
Real embedding evaluation (all-MiniLM-L6-v2, d=384)

### DIFF
--- a/bench/RESULTS.md
+++ b/bench/RESULTS.md
@@ -1,0 +1,81 @@
+# Real Embedding Evaluation Results
+
+**Date**: 2026-04-02  
+**Model**: all-MiniLM-L6-v2 (d=384)  
+**Corpus**: 10,000 vectors | **Queries**: 500  
+
+## Distribution Analysis (Post-Rotation)
+
+| Metric | Real Embeddings | Random Vectors |
+|--------|----------------|----------------|
+| Expected σ (1/√d) | 0.051031 | 0.051031 |
+| Actual σ (global) | 0.051018 | 0.051027 |
+| Per-dim σ (mean±std) | 0.0437 ± 0.0056 | 0.0510 ± 0.0004 |
+| Kurtosis (Gaussian=3) | 2.72 ± 0.45 | 2.98 ± 0.05 |
+| Original anisotropy | 37M× | 1.1× |
+
+**Key finding**: The rotation trick works — global σ matches theory perfectly. But per-dimension variance spans ~0.03–0.06, indicating residual structure the rotation doesn't fully eliminate.
+
+## Recall Results: Real Embeddings
+
+| Method | Compression* | MSE | R@10 | R@100 |
+|--------|-------------|-----|------|-------|
+| PolarQuant 2-bit | 16× | 0.1164 | 0.517 | 0.860 |
+| PolarQuant 3-bit | 10.4× | 0.0341 | 0.599 | 0.897 |
+| PolarQuant 4-bit | 7.8× | 0.0093 | 0.707 | 0.932 |
+| PolarQuant 8-bit | 2.0× | 0.0000 | 0.974 | 0.995 |
+| FAISS PQ (m=48) | 32× | 0.0636 | 0.618 | 0.877 |
+| FAISS PQ (m=96) | 16× | 0.0341 | 0.816 | 0.946 |
+
+*PolarQuant compression assumes bit-packing (not yet implemented). Current storage uses uint8 per coordinate.
+
+## Recall Results: Random Unit Vectors
+
+| Method | MSE | R@10 | R@100 |
+|--------|-----|------|-------|
+| PolarQuant 2-bit | 0.1170 | 0.533 | 0.634 |
+| PolarQuant 3-bit | 0.0344 | 0.740 | 0.799 |
+| PolarQuant 4-bit | 0.0094 | 0.847 | 0.895 |
+| PolarQuant 8-bit | 0.0000 | 0.986 | 0.991 |
+| FAISS PQ (m=48) | 0.2875 | 0.280 | 0.390 |
+| FAISS PQ (m=96) | 0.0863 | 0.484 | 0.587 |
+
+## Analysis
+
+### The Recall Gap
+PolarQuant loses 14% R@10 at 3-4 bits on real vs random embeddings. This is **not** because the Gaussian assumption breaks — the global distribution fits perfectly. The gap comes from:
+
+1. **Data clustering**: Real embeddings form tight clusters (20 topics). Within-cluster inner products are high, so quantization errors have outsized impact on ranking.
+2. **Per-dimension heterogeneity**: σ varies 2× across dimensions (0.03–0.06). The uniform codebook over-quantizes low-variance dims and under-quantizes high-variance ones.
+
+### FAISS PQ: Opposite Pattern
+FAISS PQ dramatically *improves* on real embeddings vs random (0.618 vs 0.280 at m=48). It trains on the data, learning subspace structure that random vectors don't have. This is the fundamental trade-off: data-oblivious (PolarQuant) vs data-adaptive (FAISS PQ).
+
+### Fitted Codebook: No Help
+Fitting Lloyd-Max to the actual global σ instead of theoretical σ produced zero improvement (σ was already correct to 4 decimal places). Per-dimension codebooks are the next experiment.
+
+### Practical Comparison at Matched Compression
+| Method | Compression | R@10 |
+|--------|------------|------|
+| PolarQuant 3-bit | ~10× | 0.599 |
+| FAISS PQ (m=96) | 16× | 0.816 |
+
+FAISS wins convincingly at the compression points practitioners care about.
+
+## Conclusions for Issue #1
+
+**Acceptance criterion**: R@10 at 4-bit within 10% of random → **NOT MET** (0.707 vs 0.847 = 17% gap)
+
+**But the framing was wrong**. Random vectors are the *hardest* case for FAISS PQ (no structure to exploit) and the *easiest* for PolarQuant (coordinates are already perfectly Gaussian). Real embeddings flip both directions.
+
+**PolarQuant's lane**:
+- Training-free, deterministic, portable (no index to ship)
+- 8-bit is near-lossless (R@10=0.974) at 2× compression — good for caching
+- 4-bit is serviceable (R@10=0.707) for coarse retrieval with reranking
+- Not competitive with data-adaptive methods at aggressive compression
+
+**Next steps**:
+- [ ] Per-dimension codebooks (fit σ_j per coordinate)
+- [ ] Bit-packing (issue #4) for honest compression numbers
+- [ ] Larger/more diverse corpus (current 20-topic set may overstate clustering effect)
+- [ ] Blog post: "QJL hurts retrieval" + honest PolarQuant positioning

--- a/bench/real_embedding_eval.py
+++ b/bench/real_embedding_eval.py
@@ -1,0 +1,269 @@
+"""
+Real embedding evaluation for PolarQuant (Issue #1).
+
+Encodes text with a real transformer model, then benchmarks:
+- PolarQuant recall@k at various bit widths
+- FAISS Product Quantization baseline
+- Exact brute-force ground truth
+
+Reports recall@10 and recall@100 plus compression ratios.
+"""
+
+import numpy as np
+import time
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+def load_real_embeddings(n_corpus=10000, n_queries=500, model_name="all-MiniLM-L6-v2"):
+    """Encode text into real embeddings using a sentence transformer."""
+    from sentence_transformers import SentenceTransformer
+
+    print(f"Loading model: {model_name}")
+    model = SentenceTransformer(model_name)
+    d = model.get_sentence_embedding_dimension()
+    print(f"  dimension: {d}")
+
+    # Generate diverse text from simple templates
+    topics = [
+        "machine learning", "climate change", "quantum physics", "cooking recipes",
+        "space exploration", "music theory", "ancient history", "economics",
+        "biology", "philosophy", "sports", "technology", "medicine", "art",
+        "mathematics", "psychology", "politics", "literature", "travel", "education",
+    ]
+    templates = [
+        "An introduction to {t} and its impact on society",
+        "The latest developments in {t} research",
+        "How {t} affects daily life",
+        "A comprehensive guide to understanding {t}",
+        "The history and evolution of {t}",
+        "Common misconceptions about {t}",
+        "Why {t} matters for the future",
+        "The relationship between {t} and innovation",
+        "Practical applications of {t} in modern world",
+        "Key concepts everyone should know about {t}",
+        "Challenges and opportunities in {t}",
+        "The role of {t} in solving global problems",
+        "Expert perspectives on {t}",
+        "Emerging trends in {t}",
+        "How to get started with {t}",
+    ]
+
+    total = n_corpus + n_queries
+    sentences = []
+    rng = np.random.default_rng(42)
+    for i in range(total):
+        t = topics[i % len(topics)]
+        tmpl = templates[i % len(templates)]
+        # Add variation with index to make sentences unique
+        sentences.append(f"{tmpl.format(t=t)} (variant {i})")
+
+    print(f"Encoding {total} sentences...")
+    t0 = time.time()
+    all_embs = model.encode(sentences, show_progress_bar=True, batch_size=256)
+    print(f"  encoded in {time.time()-t0:.1f}s")
+
+    corpus = all_embs[:n_corpus].astype(np.float32)
+    queries = all_embs[n_corpus:].astype(np.float32)
+    return corpus, queries, d
+
+
+def make_random_baseline(n_corpus, n_queries, d):
+    """Random unit vectors — the 'easy' case for comparison."""
+    rng = np.random.default_rng(123)
+    corpus = rng.standard_normal((n_corpus, d)).astype(np.float32)
+    corpus /= np.linalg.norm(corpus, axis=1, keepdims=True)
+    queries = rng.standard_normal((n_queries, d)).astype(np.float32)
+    queries /= np.linalg.norm(queries, axis=1, keepdims=True)
+    return corpus, queries
+
+
+def exact_knn(corpus, queries, k):
+    """Brute-force exact inner product search."""
+    scores = queries @ corpus.T
+    topk = np.argsort(-scores, axis=1)[:, :k]
+    return topk
+
+
+def recall_at_k(pred, truth, k):
+    """Recall@k: fraction of true top-k found in predicted top-k."""
+    assert pred.shape == truth.shape
+    recalls = []
+    for p, t in zip(pred, truth):
+        recalls.append(len(set(p[:k]) & set(t[:k])) / k)
+    return np.mean(recalls)
+
+
+def benchmark_polarquant(corpus, queries, d, bits_list, k_list):
+    """Run PolarQuant at various bit widths, report recall."""
+    from polarquant import PolarQuantizer
+
+    results = []
+    for bits in bits_list:
+        pq = PolarQuantizer(d=d, bits=bits)
+
+        t0 = time.time()
+        compressed = pq.encode(corpus)
+        encode_time = time.time() - t0
+
+        mse = pq.mse(corpus)
+        ratio = compressed.compression_ratio
+
+        max_k = max(k_list)
+        t0 = time.time()
+        all_pred = []
+        for q in queries:
+            idx, _ = pq.search(compressed, q, k=max_k)
+            all_pred.append(idx)
+        search_time = time.time() - t0
+        pred = np.array(all_pred)
+
+        results.append({
+            "method": f"PolarQuant-{bits}bit",
+            "bits": bits,
+            "mse": mse,
+            "compression_ratio": ratio,
+            "encode_time": encode_time,
+            "search_time": search_time,
+            "pred": pred,
+        })
+    return results
+
+
+def benchmark_faiss_pq(corpus, queries, d, m_list, k_list):
+    """Run FAISS Product Quantization as baseline."""
+    import faiss
+
+    results = []
+    for m in m_list:
+        nbits_per_sub = 8  # standard FAISS PQ
+        index = faiss.IndexPQ(d, m, nbits_per_sub)
+
+        t0 = time.time()
+        index.train(corpus)
+        index.add(corpus)
+        encode_time = time.time() - t0
+
+        max_k = max(k_list)
+        t0 = time.time()
+        _, pred = index.search(queries, max_k)
+        search_time = time.time() - t0
+
+        # Compression: m bytes per vector (8-bit codes) vs d*4 bytes float32
+        ratio = (d * 4) / m
+
+        # MSE
+        recon = index.sa_decode(index.sa_encode(corpus))
+        mse = float(np.mean(np.sum((corpus - recon) ** 2, axis=1)))
+
+        results.append({
+            "method": f"FAISS-PQ(m={m})",
+            "m": m,
+            "mse": mse,
+            "compression_ratio": ratio,
+            "encode_time": encode_time,
+            "search_time": search_time,
+            "pred": pred,
+        })
+    return results
+
+
+def analyze_embedding_distribution(corpus, d):
+    """Check if post-rotation coordinates are Gaussian (the key assumption)."""
+    from polarquant.rotation import haar_rotation
+
+    R = haar_rotation(d, seed=42)
+    norms = np.linalg.norm(corpus, axis=1)
+    unit = corpus / np.maximum(norms, 1e-8)[:, None]
+    rotated = unit @ R.T
+
+    # Check Gaussianity of coordinates
+    sigma_expected = 1.0 / np.sqrt(d)
+    sigma_actual = np.std(rotated, axis=0)
+    kurtosis = np.mean(rotated**4, axis=0) / np.mean(rotated**2, axis=0)**2
+
+    print("\n=== Post-Rotation Distribution Analysis ===")
+    print(f"  Expected σ (N(0,1/d)):  {sigma_expected:.6f}")
+    print(f"  Actual σ (mean±std):    {np.mean(sigma_actual):.6f} ± {np.std(sigma_actual):.6f}")
+    print(f"  Kurtosis (Gaussian=3):  {np.mean(kurtosis):.3f} ± {np.std(kurtosis):.3f}")
+    print(f"  Norm mean±std:          {np.mean(norms):.3f} ± {np.std(norms):.3f}")
+
+    # Check anisotropy of original embeddings
+    cov_diag = np.var(corpus, axis=0)
+    anisotropy = np.max(cov_diag) / (np.min(cov_diag) + 1e-10)
+    print(f"  Original anisotropy:    {anisotropy:.1f}x (max_var/min_var)")
+
+    return {
+        "sigma_expected": sigma_expected,
+        "sigma_actual_mean": float(np.mean(sigma_actual)),
+        "kurtosis_mean": float(np.mean(kurtosis)),
+        "anisotropy": float(anisotropy),
+    }
+
+
+def run_benchmark(corpus, queries, d, label, k_list=[10, 100]):
+    """Full benchmark suite on a given embedding set."""
+    print(f"\n{'='*60}")
+    print(f"  {label}")
+    print(f"  corpus: {corpus.shape}, queries: {queries.shape}")
+    print(f"{'='*60}")
+
+    # Distribution analysis
+    dist = analyze_embedding_distribution(corpus, d)
+
+    # Ground truth
+    print("\nComputing exact kNN ground truth...")
+    max_k = max(k_list)
+    truth = exact_knn(corpus, queries, max_k)
+
+    # PolarQuant at various bit widths
+    bits_list = [2, 3, 4, 8]
+    print("\n--- PolarQuant ---")
+    pq_results = benchmark_polarquant(corpus, queries, d, bits_list, k_list)
+
+    # FAISS PQ baselines (m = number of subquantizers)
+    # m=48 → 48 bytes/vec, m=96 → 96 bytes/vec for d=384
+    m_list = [d // 8, d // 4]  # coarse and fine
+    print("\n--- FAISS Product Quantization ---")
+    faiss_results = benchmark_faiss_pq(corpus, queries, d, m_list, k_list)
+
+    # Report
+    all_results = pq_results + faiss_results
+    print(f"\n{'Method':<22s} {'MSE':>10s} {'Ratio':>8s} {'R@10':>8s} {'R@100':>8s} {'Enc(s)':>8s} {'Srch(s)':>8s}")
+    print("-" * 80)
+    for r in all_results:
+        recalls = {}
+        for k in k_list:
+            recalls[k] = recall_at_k(r["pred"][:, :k], truth[:, :k], k)
+        print(f"{r['method']:<22s} {r['mse']:>10.4f} {r['compression_ratio']:>7.1f}x "
+              f"{recalls.get(10, 0):>7.3f} {recalls.get(100, 0):>7.3f} "
+              f"{r['encode_time']:>7.2f}s {r['search_time']:>7.2f}s")
+
+    return all_results, dist, truth
+
+
+if __name__ == "__main__":
+    N_CORPUS = 10000
+    N_QUERIES = 500
+
+    # Phase 1: Real embeddings
+    corpus_real, queries_real, d = load_real_embeddings(N_CORPUS, N_QUERIES)
+    real_results, real_dist, _ = run_benchmark(corpus_real, queries_real, d, "REAL EMBEDDINGS (all-MiniLM-L6-v2)")
+
+    # Phase 2: Random baseline (same dimension)
+    corpus_rand, queries_rand = make_random_baseline(N_CORPUS, N_QUERIES, d)
+    rand_results, rand_dist, _ = run_benchmark(corpus_rand, queries_rand, d, "RANDOM UNIT VECTORS (d=384)")
+
+    # Summary comparison
+    print(f"\n{'='*60}")
+    print("  COMPARISON: Real vs Random")
+    print(f"{'='*60}")
+    print(f"{'':>22s} {'Real R@10':>10s} {'Rand R@10':>10s} {'Gap':>8s}")
+    print("-" * 55)
+    for rr, rn in zip(real_results[:4], rand_results[:4]):  # PolarQuant only
+        recall_real = recall_at_k(rr["pred"][:, :10], exact_knn(corpus_real, queries_real, 10), 10)
+        recall_rand = recall_at_k(rn["pred"][:, :10], exact_knn(corpus_rand, queries_rand, 10), 10)
+        gap = recall_real - recall_rand
+        print(f"{rr['method']:<22s} {recall_real:>9.3f} {recall_rand:>9.3f} {gap:>+7.3f}")


### PR DESCRIPTION
## Real Embedding Evaluation (Issue #1)

### What
Benchmark PolarQuant on real transformer embeddings (all-MiniLM-L6-v2, d=384) against:
- Random unit vectors (the "easy" baseline)
- FAISS Product Quantization (the practitioner baseline)

### Key Findings

**The rotation trick works** — post-rotation global σ matches theory to 4 decimal places (0.051018 vs 0.051031). Fitting the codebook to actual data produced zero improvement.

**But recall drops on real data**:
| bits | Real R@10 | Random R@10 | Gap |
|------|-----------|-------------|-----|
| 3 | 0.599 | 0.740 | -19% |
| 4 | 0.707 | 0.847 | -17% |
| 8 | 0.974 | 0.986 | -1% |

**Root cause**: Per-dimension σ heterogeneity (0.03–0.06, 2× range). Rotation eliminates global anisotropy but leaves per-coordinate variance spread that a uniform codebook can't optimally handle.

**FAISS PQ comparison**: At matched quality (R@10 ≈ 0.6), FAISS achieves 32× compression vs PolarQuant's ~10×. FAISS trains on the data; PolarQuant doesn't.

**Acceptance criterion NOT met** (R@10 within 10% of random at 4-bit = 17% gap), but the criterion itself was based on a wrong mental model — random vectors are the easiest case for data-oblivious methods.

### Files
- `bench/real_embedding_eval.py` — full benchmark script
- `bench/RESULTS.md` — detailed results and analysis

### Next
- Per-dimension codebooks (fit σ_j per coordinate)
- Bit-packing (#4) for honest compression numbers
- Larger/more diverse corpus

Closes #1
