### PR TITLE
Add PackedVectors for memory-efficient storage and Arrow IPC support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = ["numpy>=1.24", "scipy>=1.10"]
 
 [project.optional-dependencies]
 dev = ["pytest>=7.0", "pytest-cov"]
+arrow = ["pyarrow>=12.0"]
 bench = ["faiss-cpu", "sentence-transformers"]
 
 [tool.setuptools.packages.find]

--- a/remex/__init__.py
+++ b/remex/__init__.py
@@ -14,13 +14,13 @@ Formerly known as polar-embed.
 
 import warnings
 
-from remex.core import Quantizer, CompressedVectors
+from remex.core import Quantizer, CompressedVectors, PackedVectors
 from remex.codebook import lloyd_max_codebook, nested_codebooks
 from remex.packing import pack, unpack, packed_nbytes
 
 __version__ = "0.5.0"
 __all__ = [
-    "Quantizer", "CompressedVectors",
+    "Quantizer", "CompressedVectors", "PackedVectors",
     "PolarQuantizer",  # deprecated alias
     "lloyd_max_codebook", "nested_codebooks",
     "pack", "unpack", "packed_nbytes",

--- a/remex/core.py
+++ b/remex/core.py
@@ -1,7 +1,7 @@
 """Core remex encoder/decoder with Matryoshka bit precision."""
 
 import numpy as np
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Iterable
 from remex.codebook import lloyd_max_codebook, nested_codebooks
 from remex.packing import pack, unpack, packed_nbytes
 from remex.rotation import haar_rotation
@@ -89,6 +89,354 @@ class CompressedVectors:
             indices = data["indices"]
 
         return cls(indices, data["norms"], d, bits)
+
+    def save_arrow(self, path: str, seed: Optional[int] = None, **extra_metadata):
+        """Save to Arrow IPC (Feather v2) format, packing indices for storage.
+
+        Requires pyarrow (optional dependency).
+
+        Args:
+            path: Output file path.
+            seed: Quantizer seed to store in schema metadata.
+            **extra_metadata: Additional key-value pairs for schema metadata.
+        """
+        packed = PackedVectors.from_compressed(self)
+        packed.save_arrow(path, seed=seed, **extra_metadata)
+
+    @classmethod
+    def load_arrow(cls, path: str) -> "CompressedVectors":
+        """Load from Arrow IPC (Feather v2) format, unpacking to uint8 indices.
+
+        Args:
+            path: Arrow IPC file path.
+
+        Returns:
+            CompressedVectors with unpacked uint8 indices.
+        """
+        packed = PackedVectors.load_arrow(path)
+        return packed.to_compressed()
+
+
+class PackedVectors:
+    """Memory-efficient packed storage for quantized vectors.
+
+    Stores indices bit-packed in memory, unpacking rows on demand.
+    Uses 2-4x less RAM than CompressedVectors for sub-byte bit widths.
+
+    Use ``from_compressed()`` to convert from CompressedVectors,
+    ``from_rows()`` to reconstruct from database rows, or
+    ``load()`` / ``load_arrow()`` to read from disk.
+
+    Search is supported via ``Quantizer.search_adc()`` and
+    ``Quantizer.search_twostage()``.  Cached ``search()`` is not
+    supported — use ``to_compressed()`` to convert back if needed.
+    """
+
+    __slots__ = ("_packed", "norms", "d", "bits", "n", "_row_bytes", "_row_aligned")
+
+    def __init__(
+        self,
+        packed: np.ndarray,
+        norms: np.ndarray,
+        n: int,
+        d: int,
+        bits: int,
+    ):
+        """
+        Args:
+            packed: (n, row_bytes) uint8 array of bit-packed indices.
+            norms: (n,) float32 array of vector norms.
+            n: Number of vectors.
+            d: Vector dimension.
+            bits: Bits per coordinate.
+        """
+        self._packed = packed  # (n, row_bytes) uint8
+        self.norms = norms
+        self.n = n
+        self.d = d
+        self.bits = bits
+        self._row_bytes = packed_nbytes(1, d, bits)
+        self._row_aligned = (d * bits) % 8 == 0
+
+    def unpack_rows(self, start: int, end: int) -> np.ndarray:
+        """Decompress a contiguous row slice to uint8 indices.
+
+        Args:
+            start: First row index (inclusive).
+            end: Last row index (exclusive).
+
+        Returns:
+            (end - start, d) uint8 array of indices.
+        """
+        n_rows = end - start
+        if self._row_aligned:
+            flat = self._packed[start:end].ravel()
+            return unpack(flat, self.bits, n_rows * self.d).reshape(n_rows, self.d)
+        else:
+            result = np.empty((n_rows, self.d), dtype=np.uint8)
+            for i in range(n_rows):
+                result[i] = unpack(self._packed[start + i], self.bits, self.d)
+            return result
+
+    def unpack_at(self, idx: np.ndarray) -> np.ndarray:
+        """Decompress arbitrary row indices to uint8 indices.
+
+        Args:
+            idx: Array of row indices to unpack.
+
+        Returns:
+            (len(idx), d) uint8 array of indices.
+        """
+        idx = np.asarray(idx)
+        if idx.ndim == 0:
+            idx = idx.reshape(1)
+        rows = self._packed[idx]  # (len(idx), row_bytes)
+        if self._row_aligned:
+            flat = rows.ravel()
+            return unpack(flat, self.bits, len(idx) * self.d).reshape(len(idx), self.d)
+        else:
+            result = np.empty((len(idx), self.d), dtype=np.uint8)
+            for i in range(len(idx)):
+                result[i] = unpack(rows[i], self.bits, self.d)
+            return result
+
+    @classmethod
+    def from_compressed(cls, compressed: CompressedVectors) -> "PackedVectors":
+        """Convert a CompressedVectors to packed in-memory format.
+
+        Args:
+            compressed: CompressedVectors with unpacked uint8 indices.
+
+        Returns:
+            PackedVectors with bit-packed indices.
+        """
+        n, d, bits = compressed.n, compressed.d, compressed.bits
+        row_bytes = packed_nbytes(1, d, bits)
+        row_aligned = (d * bits) % 8 == 0
+        if row_aligned:
+            packed_flat = pack(compressed.indices.ravel(), bits)
+            packed = packed_flat.reshape(n, row_bytes)
+        else:
+            packed = np.empty((n, row_bytes), dtype=np.uint8)
+            for i in range(n):
+                packed[i] = pack(compressed.indices[i], bits)
+        return cls(packed, compressed.norms.copy(), n, d, bits)
+
+    @classmethod
+    def from_rows(
+        cls,
+        rows: Iterable,
+        norms: np.ndarray,
+        d: int,
+        bits: int,
+    ) -> "PackedVectors":
+        """Reconstruct from database packed byte rows.
+
+        Args:
+            rows: Iterable of bytes/bytearray/ndarray, one per vector.
+            norms: (n,) float32 array of vector norms.
+            d: Vector dimension.
+            bits: Bits per coordinate.
+
+        Returns:
+            PackedVectors instance.
+        """
+        row_list = []
+        for r in rows:
+            if isinstance(r, (bytes, bytearray)):
+                row_list.append(np.frombuffer(r, dtype=np.uint8))
+            else:
+                row_list.append(np.asarray(r, dtype=np.uint8))
+        packed = np.stack(row_list)
+        n = len(row_list)
+        return cls(packed, np.asarray(norms, dtype=np.float32), n, d, bits)
+
+    def at_precision(self, target_bits: int) -> "PackedVectors":
+        """Derive a lower-bit representation via Matryoshka right-shift.
+
+        Unpacks in chunks, right-shifts, and repacks at target_bits.
+
+        Args:
+            target_bits: Target bit precision (1 to self.bits).
+
+        Returns:
+            New PackedVectors at the target precision.
+        """
+        if target_bits < 1 or target_bits > self.bits:
+            raise ValueError(
+                f"target_bits must be 1-{self.bits}, got {target_bits}"
+            )
+        if target_bits == self.bits:
+            return self
+
+        shift = self.bits - target_bits
+        row_bytes_target = packed_nbytes(1, self.d, target_bits)
+        target_aligned = (self.d * target_bits) % 8 == 0
+        packed_target = np.empty((self.n, row_bytes_target), dtype=np.uint8)
+
+        chunk = 4096
+        for start in range(0, self.n, chunk):
+            end = min(start + chunk, self.n)
+            indices = self.unpack_rows(start, end)
+            shifted = (indices >> shift).astype(np.uint8)
+            if target_aligned:
+                packed_flat = pack(shifted.ravel(), target_bits)
+                packed_target[start:end] = packed_flat.reshape(
+                    end - start, row_bytes_target
+                )
+            else:
+                for i in range(end - start):
+                    packed_target[start + i] = pack(shifted[i], target_bits)
+
+        return PackedVectors(
+            packed_target, self.norms.copy(), self.n, self.d, target_bits
+        )
+
+    def to_compressed(self) -> CompressedVectors:
+        """Convert to CompressedVectors by unpacking all indices."""
+        indices = self.unpack_rows(0, self.n)
+        return CompressedVectors(indices, self.norms.copy(), self.d, self.bits)
+
+    def subset(self, idx: np.ndarray) -> "PackedVectors":
+        """Return a PackedVectors containing only the given row indices."""
+        idx = np.asarray(idx)
+        return PackedVectors(
+            self._packed[idx].copy(),
+            self.norms[idx].copy(),
+            len(idx),
+            self.d,
+            self.bits,
+        )
+
+    @property
+    def nbytes(self) -> int:
+        """Packed memory footprint in bytes."""
+        return self._packed.nbytes + self.norms.nbytes
+
+    @property
+    def resident_bytes(self) -> int:
+        """Actual RAM footprint (same as nbytes — no caches)."""
+        return self._packed.nbytes + self.norms.nbytes
+
+    @property
+    def compression_ratio(self) -> float:
+        """Ratio vs float32 storage."""
+        return (self.n * self.d * 4) / self.nbytes
+
+    def save(self, path: str):
+        """Save to compressed .npz file."""
+        np.savez_compressed(
+            path,
+            packed_indices=self._packed.ravel(),
+            norms=self.norms,
+            d=np.int32(self.d),
+            bits=np.int32(self.bits),
+            n=np.int32(self.n),
+        )
+
+    @classmethod
+    def load(cls, path: str) -> "PackedVectors":
+        """Load from .npz file, keeping indices packed."""
+        data = np.load(path)
+        d = int(data["d"])
+        bits = int(data["bits"])
+        n = int(data["n"])
+        row_bytes = packed_nbytes(1, d, bits)
+        packed_flat = data["packed_indices"]
+        packed = packed_flat.reshape(n, row_bytes)
+        return cls(packed, data["norms"], n, d, bits)
+
+    def save_arrow(self, path: str, seed: Optional[int] = None, **extra_metadata):
+        """Save to Arrow IPC (Feather v2) format.
+
+        Stores packed indices as FixedSizeBinary and norms as Float32,
+        with quantizer parameters in schema-level metadata.
+
+        Requires pyarrow (optional dependency).
+
+        Args:
+            path: Output file path.
+            seed: Quantizer seed to store in metadata.
+            **extra_metadata: Additional key-value pairs for schema metadata.
+        """
+        try:
+            import pyarrow as pa
+            import pyarrow.feather as feather
+        except ImportError:
+            raise ImportError(
+                "pyarrow is required for Arrow IPC format: "
+                "pip install pyarrow"
+            )
+
+        row_bytes = self._row_bytes
+        metadata = {
+            b"d": str(self.d).encode(),
+            b"bits": str(self.bits).encode(),
+            b"n": str(self.n).encode(),
+        }
+        if seed is not None:
+            metadata[b"seed"] = str(seed).encode()
+        for k, v in extra_metadata.items():
+            key = k.encode() if isinstance(k, str) else k
+            metadata[key] = str(v).encode()
+
+        schema = pa.schema(
+            [
+                pa.field("norms", pa.float32()),
+                pa.field("packed_indices", pa.binary(row_bytes)),
+            ],
+            metadata=metadata,
+        )
+
+        # Build arrays from flat buffers for efficiency
+        norms_arr = pa.array(self.norms.tolist(), type=pa.float32())
+        packed_buf = pa.py_buffer(self._packed.tobytes())
+        packed_arr = pa.FixedSizeBinaryArray.from_buffers(
+            pa.binary(row_bytes), self.n, [None, packed_buf]
+        )
+
+        table = pa.table(
+            {"norms": norms_arr, "packed_indices": packed_arr}, schema=schema
+        )
+        feather.write_feather(table, path)
+
+    @classmethod
+    def load_arrow(cls, path: str, memory_map: bool = False) -> "PackedVectors":
+        """Load from Arrow IPC (Feather v2) format.
+
+        Args:
+            path: Arrow IPC file path.
+            memory_map: If True, memory-map the file for zero-copy access.
+
+        Returns:
+            PackedVectors with packed indices.
+        """
+        try:
+            import pyarrow.feather as feather
+        except ImportError:
+            raise ImportError(
+                "pyarrow is required for Arrow IPC format: "
+                "pip install pyarrow"
+            )
+
+        table = feather.read_table(path, memory_map=memory_map)
+        metadata = table.schema.metadata
+        d = int(metadata[b"d"])
+        bits = int(metadata[b"bits"])
+        n = int(metadata[b"n"])
+        row_bytes = packed_nbytes(1, d, bits)
+
+        norms = table.column("norms").to_numpy().astype(np.float32)
+
+        # Extract packed data from contiguous Arrow buffer
+        packed_col = table.column("packed_indices")
+        chunk = packed_col.chunk(0)
+        buffers = chunk.buffers()
+        data_buf = buffers[1]
+        packed_flat = np.frombuffer(data_buf, dtype=np.uint8)[: n * row_bytes]
+        packed = packed_flat.reshape(n, row_bytes).copy()
+
+        return cls(packed, norms, n, d, bits)
 
 
 class Quantizer:
@@ -189,7 +537,7 @@ class Quantizer:
         Caches the dequantized rotated representation for subsequent queries.
 
         Args:
-            compressed: Encoded corpus.
+            compressed: Encoded corpus (CompressedVectors only).
             query: (d,) query vector.
             k: Number of results.
             precision: Bit precision for search (1 to self.bits).
@@ -199,7 +547,17 @@ class Quantizer:
 
         Returns:
             (indices, scores): top-k corpus indices and approximate scores.
+
+        Raises:
+            TypeError: If passed a PackedVectors (use search_adc or
+                search_twostage instead, or convert with to_compressed()).
         """
+        if isinstance(compressed, PackedVectors):
+            raise TypeError(
+                "PackedVectors does not support cached search(). "
+                "Use search_adc() or search_twostage(), or convert "
+                "with packed.to_compressed() first."
+            )
         query = np.asarray(query, dtype=np.float32)
         q_rot = self.R @ query
 
@@ -215,7 +573,7 @@ class Quantizer:
 
     def search_adc(
         self,
-        compressed: CompressedVectors,
+        compressed,
         query: np.ndarray,
         k: int = 10,
         precision: Optional[int] = None,
@@ -232,8 +590,11 @@ class Quantizer:
         uses dramatically less RAM. Ideal for the coarse stage of
         two-stage retrieval, or when memory is constrained.
 
+        Accepts both CompressedVectors and PackedVectors. When given
+        PackedVectors, indices are unpacked on demand per chunk.
+
         Args:
-            compressed: Encoded corpus.
+            compressed: Encoded corpus (CompressedVectors or PackedVectors).
             query: (d,) query vector.
             k: Number of results.
             precision: Bit precision (1 to self.bits). None = full.
@@ -246,16 +607,18 @@ class Quantizer:
         q_rot = self.R @ query
 
         centroids = self._resolve_centroids(compressed, precision)
-        indices = self._resolve_indices(compressed, precision)
-
-        # Build ADC lookup table: table[j, i] = centroid_i * q_rot_j
-        # centroids are (n_levels,), same for all dims
         table = np.outer(q_rot, centroids).astype(np.float32)
-        # table shape: (d, n_levels)
 
-        scores = self._adc_score_chunked(
-            table, indices, compressed.norms, chunk_size
-        )
+        if isinstance(compressed, PackedVectors):
+            shift = 0 if (precision is None or precision == self.bits) else (self.bits - precision)
+            scores = self._adc_score_packed(
+                table, compressed, shift, chunk_size
+            )
+        else:
+            indices = self._resolve_indices(compressed, precision)
+            scores = self._adc_score_chunked(
+                table, indices, compressed.norms, chunk_size
+            )
 
         if k >= compressed.n:
             topk_idx = np.argsort(-scores)
@@ -266,7 +629,7 @@ class Quantizer:
 
     def search_twostage(
         self,
-        compressed: CompressedVectors,
+        compressed,
         query: np.ndarray,
         k: int = 10,
         candidates: int = 500,
@@ -283,12 +646,16 @@ class Quantizer:
         Stage 2 (fine): Dequantize only the candidate vectors at full
         precision, then rerank by exact (quantized) inner product.
 
+        Accepts both CompressedVectors and PackedVectors. When given
+        PackedVectors, indices are unpacked on demand per chunk (coarse)
+        and only for the candidate rows (fine).
+
         Memory profile at 100k vectors, d=384:
           - Single-stage search():    154 MB  (cached n*d float32)
           - Two-stage search_twostage: ~39 MB  (uint8 indices + 6 MB temp)
 
         Args:
-            compressed: Encoded corpus.
+            compressed: Encoded corpus (CompressedVectors or PackedVectors).
             query: (d,) query vector.
             k: Final number of results.
             candidates: Number of coarse candidates (stage 1).
@@ -306,16 +673,22 @@ class Quantizer:
         query = np.asarray(query, dtype=np.float32)
         q_rot = self.R @ query
         coarse_k = min(candidates, compressed.n)
+        is_packed = isinstance(compressed, PackedVectors)
 
         # Stage 1: ADC coarse scan — no float32 cache needed
         coarse_centroids = self._resolve_centroids(compressed, coarse_precision)
-        coarse_indices = self._resolve_indices(compressed, coarse_precision)
-
         coarse_table = np.outer(q_rot, coarse_centroids).astype(np.float32)
 
-        coarse_scores = self._adc_score_chunked(
-            coarse_table, coarse_indices, compressed.norms, coarse_chunk_size
-        )
+        if is_packed:
+            coarse_shift = self.bits - coarse_precision
+            coarse_scores = self._adc_score_packed(
+                coarse_table, compressed, coarse_shift, coarse_chunk_size
+            )
+        else:
+            coarse_indices = self._resolve_indices(compressed, coarse_precision)
+            coarse_scores = self._adc_score_chunked(
+                coarse_table, coarse_indices, compressed.norms, coarse_chunk_size
+            )
 
         if coarse_k >= compressed.n:
             coarse_idx = np.argsort(-coarse_scores)
@@ -324,7 +697,10 @@ class Quantizer:
 
         # Stage 2: full-precision rerank on small candidate set
         fine_centroids = self._resolve_centroids(compressed, None)
-        fine_indices = compressed.indices[coarse_idx]
+        if is_packed:
+            fine_indices = compressed.unpack_at(coarse_idx)
+        else:
+            fine_indices = compressed.indices[coarse_idx]
 
         X_hat_cand = fine_centroids[fine_indices]  # (candidates, d)
 
@@ -379,6 +755,39 @@ class Quantizer:
             # Then sum over d → (chunk,) inner-product contribution
             chunk_scores = table[dim_idx, chunk_idx].sum(axis=1)
             scores[start:end] = chunk_scores * norms[start:end]
+
+        return scores
+
+    @staticmethod
+    def _adc_score_packed(
+        table: np.ndarray,
+        packed: "PackedVectors",
+        shift: int,
+        chunk_size: int,
+    ) -> np.ndarray:
+        """Score packed vectors via ADC, unpacking chunks on demand.
+
+        Args:
+            table: (d, n_levels) float32 lookup table.
+            packed: PackedVectors with bit-packed indices.
+            shift: Right-shift to apply for precision reduction (0 = full).
+            chunk_size: Rows per chunk (controls peak memory).
+
+        Returns:
+            (n,) float32 approximate inner-product scores.
+        """
+        n = packed.n
+        d = table.shape[0]
+        dim_idx = np.arange(d)
+        scores = np.empty(n, dtype=np.float32)
+
+        for start in range(0, n, chunk_size):
+            end = min(start + chunk_size, n)
+            chunk_idx = packed.unpack_rows(start, end)  # (chunk, d) uint8
+            if shift > 0:
+                chunk_idx = chunk_idx >> shift
+            chunk_scores = table[dim_idx, chunk_idx].sum(axis=1)
+            scores[start:end] = chunk_scores * packed.norms[start:end]
 
         return scores
 

--- a/tests/test_packed_vectors.py
+++ b/tests/test_packed_vectors.py
@@ -1,0 +1,445 @@
+"""Tests for PackedVectors (issue #16) and Arrow IPC format (issue #23).
+
+Covers:
+- PackedVectors creation, conversion, and round-trip correctness
+- Memory savings vs CompressedVectors
+- On-demand unpack_rows / unpack_at
+- at_precision() Matryoshka derivation
+- from_rows() database reconstruction
+- ADC search and two-stage search with PackedVectors
+- Arrow IPC save/load round-trip
+- Arrow schema metadata preservation
+"""
+
+import numpy as np
+import pytest
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from remex import Quantizer, CompressedVectors, PackedVectors
+from remex.packing import packed_nbytes
+
+
+# ------------------------------------------------------------------
+# Fixtures
+# ------------------------------------------------------------------
+
+@pytest.fixture
+def rng():
+    return np.random.default_rng(42)
+
+
+@pytest.fixture
+def setup(rng):
+    d = 128
+    n = 2000
+    pq = Quantizer(d=d, bits=4)
+    corpus = rng.standard_normal((n, d)).astype(np.float32)
+    corpus /= np.linalg.norm(corpus, axis=1, keepdims=True)
+    query = rng.standard_normal(d).astype(np.float32)
+    query /= np.linalg.norm(query)
+    compressed = pq.encode(corpus)
+    packed = PackedVectors.from_compressed(compressed)
+    return pq, compressed, packed, query
+
+
+@pytest.fixture
+def setup_2bit(rng):
+    d = 384
+    n = 1000
+    pq = Quantizer(d=d, bits=2)
+    corpus = rng.standard_normal((n, d)).astype(np.float32)
+    corpus /= np.linalg.norm(corpus, axis=1, keepdims=True)
+    compressed = pq.encode(corpus)
+    packed = PackedVectors.from_compressed(compressed)
+    return pq, compressed, packed
+
+
+# ------------------------------------------------------------------
+# PackedVectors creation and conversion
+# ------------------------------------------------------------------
+
+class TestPackedVectorsCreation:
+
+    def test_from_compressed_preserves_data(self, setup):
+        _, comp, packed, _ = setup
+        # Unpack all and compare to original indices
+        unpacked = packed.unpack_rows(0, packed.n)
+        np.testing.assert_array_equal(unpacked, comp.indices)
+
+    def test_from_compressed_preserves_norms(self, setup):
+        _, comp, packed, _ = setup
+        np.testing.assert_array_equal(packed.norms, comp.norms)
+
+    def test_attributes_match(self, setup):
+        _, comp, packed, _ = setup
+        assert packed.n == comp.n
+        assert packed.d == comp.d
+        assert packed.bits == comp.bits
+
+    def test_to_compressed_roundtrip(self, setup):
+        _, comp, packed, _ = setup
+        comp2 = packed.to_compressed()
+        np.testing.assert_array_equal(comp2.indices, comp.indices)
+        np.testing.assert_array_equal(comp2.norms, comp.norms)
+        assert comp2.d == comp.d
+        assert comp2.bits == comp.bits
+
+    @pytest.mark.parametrize("bits", [1, 2, 3, 4, 8])
+    def test_roundtrip_all_bits(self, rng, bits):
+        d = 128
+        pq = Quantizer(d=d, bits=bits)
+        X = rng.standard_normal((100, d)).astype(np.float32)
+        comp = pq.encode(X)
+        packed = PackedVectors.from_compressed(comp)
+        comp2 = packed.to_compressed()
+        np.testing.assert_array_equal(comp2.indices, comp.indices)
+
+
+# ------------------------------------------------------------------
+# Memory savings
+# ------------------------------------------------------------------
+
+class TestPackedMemory:
+
+    def test_packed_smaller_than_unpacked(self, setup):
+        _, comp, packed, _ = setup
+        # 4-bit: packed should be ~half of uint8 indices
+        assert packed.nbytes < comp.nbytes_unpacked
+
+    def test_2bit_compression(self, setup_2bit):
+        _, comp, packed = setup_2bit
+        # 2-bit: packed indices should be ~1/4 of uint8
+        packed_idx_bytes = packed._packed.nbytes
+        unpacked_idx_bytes = comp.indices.nbytes
+        assert packed_idx_bytes < unpacked_idx_bytes * 0.35
+
+    def test_resident_bytes_no_cache(self, setup):
+        _, _, packed, _ = setup
+        expected = packed._packed.nbytes + packed.norms.nbytes
+        assert packed.resident_bytes == expected
+
+    def test_compression_ratio(self, setup):
+        _, _, packed, _ = setup
+        # 4-bit d=128: ratio should be reasonable
+        assert packed.compression_ratio > 5.0
+
+
+# ------------------------------------------------------------------
+# Row unpacking
+# ------------------------------------------------------------------
+
+class TestUnpacking:
+
+    def test_unpack_rows_slice(self, setup):
+        _, comp, packed, _ = setup
+        chunk = packed.unpack_rows(10, 20)
+        np.testing.assert_array_equal(chunk, comp.indices[10:20])
+
+    def test_unpack_rows_full(self, setup):
+        _, comp, packed, _ = setup
+        all_rows = packed.unpack_rows(0, packed.n)
+        np.testing.assert_array_equal(all_rows, comp.indices)
+
+    def test_unpack_at_arbitrary(self, setup):
+        _, comp, packed, _ = setup
+        idx = np.array([0, 5, 100, 999])
+        rows = packed.unpack_at(idx)
+        np.testing.assert_array_equal(rows, comp.indices[idx])
+
+    def test_unpack_at_single(self, setup):
+        _, comp, packed, _ = setup
+        row = packed.unpack_at(np.array([42]))
+        np.testing.assert_array_equal(row, comp.indices[42:43])
+
+
+# ------------------------------------------------------------------
+# at_precision (Matryoshka)
+# ------------------------------------------------------------------
+
+class TestAtPrecision:
+
+    def test_at_full_precision_returns_self(self, setup):
+        _, _, packed, _ = setup
+        same = packed.at_precision(packed.bits)
+        assert same is packed
+
+    def test_at_lower_precision_correct(self, setup):
+        _, comp, packed, _ = setup
+        packed_2 = packed.at_precision(2)
+        # Should match right-shifting the original indices
+        expected = comp.indices >> (comp.bits - 2)
+        actual = packed_2.unpack_rows(0, packed_2.n)
+        np.testing.assert_array_equal(actual, expected)
+
+    def test_at_precision_validates_bounds(self, setup):
+        _, _, packed, _ = setup
+        with pytest.raises(ValueError):
+            packed.at_precision(0)
+        with pytest.raises(ValueError):
+            packed.at_precision(packed.bits + 1)
+
+    def test_at_precision_bits_attribute(self, setup):
+        _, _, packed, _ = setup
+        packed_2 = packed.at_precision(2)
+        assert packed_2.bits == 2
+        assert packed_2.n == packed.n
+        assert packed_2.d == packed.d
+
+
+# ------------------------------------------------------------------
+# from_rows (database reconstruction)
+# ------------------------------------------------------------------
+
+class TestFromRows:
+
+    def test_from_rows_bytes(self, setup):
+        _, comp, packed, _ = setup
+        # Extract rows as bytes
+        rows = [packed._packed[i].tobytes() for i in range(packed.n)]
+        reconstructed = PackedVectors.from_rows(rows, comp.norms, comp.d, comp.bits)
+        np.testing.assert_array_equal(
+            reconstructed.unpack_rows(0, reconstructed.n),
+            comp.indices,
+        )
+
+    def test_from_rows_ndarray(self, setup):
+        _, comp, packed, _ = setup
+        rows = [packed._packed[i] for i in range(packed.n)]
+        reconstructed = PackedVectors.from_rows(rows, comp.norms, comp.d, comp.bits)
+        np.testing.assert_array_equal(
+            reconstructed.unpack_rows(0, reconstructed.n),
+            comp.indices,
+        )
+
+
+# ------------------------------------------------------------------
+# subset
+# ------------------------------------------------------------------
+
+class TestPackedSubset:
+
+    def test_subset(self, setup):
+        _, comp, packed, _ = setup
+        idx = np.array([0, 10, 50, 100])
+        sub = packed.subset(idx)
+        assert sub.n == len(idx)
+        np.testing.assert_array_equal(
+            sub.unpack_rows(0, sub.n),
+            comp.indices[idx],
+        )
+        np.testing.assert_array_equal(sub.norms, comp.norms[idx])
+
+
+# ------------------------------------------------------------------
+# ADC search with PackedVectors
+# ------------------------------------------------------------------
+
+class TestPackedADCSearch:
+
+    def test_adc_matches_compressed(self, setup):
+        """PackedVectors ADC should match CompressedVectors ADC."""
+        pq, comp, packed, query = setup
+        idx_comp, scores_comp = pq.search_adc(comp, query, k=10)
+        idx_packed, scores_packed = pq.search_adc(packed, query, k=10)
+        np.testing.assert_array_equal(idx_comp, idx_packed)
+        np.testing.assert_allclose(scores_comp, scores_packed, rtol=1e-5)
+
+    def test_adc_precision_matches(self, setup):
+        """PackedVectors ADC at reduced precision should match."""
+        pq, comp, packed, query = setup
+        idx_comp, scores_comp = pq.search_adc(comp, query, k=10, precision=2)
+        idx_packed, scores_packed = pq.search_adc(packed, query, k=10, precision=2)
+        np.testing.assert_array_equal(idx_comp, idx_packed)
+        np.testing.assert_allclose(scores_comp, scores_packed, rtol=1e-5)
+
+    def test_adc_chunk_sizes(self, setup):
+        """Different chunk sizes should produce identical results."""
+        pq, _, packed, query = setup
+        idx_a, scores_a = pq.search_adc(packed, query, k=10, chunk_size=64)
+        idx_b, scores_b = pq.search_adc(packed, query, k=10, chunk_size=4096)
+        np.testing.assert_array_equal(idx_a, idx_b)
+        np.testing.assert_allclose(scores_a, scores_b)
+
+    def test_adc_scores_descending(self, setup):
+        pq, _, packed, query = setup
+        _, scores = pq.search_adc(packed, query, k=20)
+        assert np.all(np.diff(scores) <= 1e-7)
+
+    def test_search_raises_on_packed(self, setup):
+        """Cached search() should raise TypeError for PackedVectors."""
+        pq, _, packed, query = setup
+        with pytest.raises(TypeError, match="PackedVectors"):
+            pq.search(packed, query, k=10)
+
+
+# ------------------------------------------------------------------
+# Two-stage search with PackedVectors
+# ------------------------------------------------------------------
+
+class TestPackedTwoStage:
+
+    def test_twostage_matches_compressed(self, setup):
+        """Two-stage with PackedVectors should match CompressedVectors."""
+        pq, comp, packed, query = setup
+        idx_comp, scores_comp = pq.search_twostage(
+            comp, query, k=10, candidates=200
+        )
+        idx_packed, scores_packed = pq.search_twostage(
+            packed, query, k=10, candidates=200
+        )
+        np.testing.assert_array_equal(idx_comp, idx_packed)
+        np.testing.assert_allclose(scores_comp, scores_packed, rtol=1e-5)
+
+    def test_twostage_returns_correct_k(self, setup):
+        pq, _, packed, query = setup
+        idx, scores = pq.search_twostage(packed, query, k=10, candidates=200)
+        assert len(idx) == 10
+        assert len(scores) == 10
+
+    def test_twostage_scores_descending(self, setup):
+        pq, _, packed, query = setup
+        _, scores = pq.search_twostage(packed, query, k=10, candidates=200)
+        assert np.all(np.diff(scores) <= 1e-7)
+
+    def test_twostage_large_candidates_matches_adc(self, setup):
+        """With candidates=n, two-stage fine rerank should match full search."""
+        pq, comp, packed, query = setup
+        idx_full, _ = pq.search(comp, query, k=10)
+        idx_ts, _ = pq.search_twostage(
+            packed, query, k=10, candidates=packed.n
+        )
+        np.testing.assert_array_equal(idx_full, idx_ts)
+
+
+# ------------------------------------------------------------------
+# Serialization: .npz
+# ------------------------------------------------------------------
+
+class TestPackedSerialization:
+
+    def test_save_load_roundtrip(self, setup, tmp_path):
+        _, comp, packed, _ = setup
+        path = str(tmp_path / "packed.npz")
+        packed.save(path)
+        loaded = PackedVectors.load(path)
+        np.testing.assert_array_equal(
+            loaded.unpack_rows(0, loaded.n),
+            comp.indices,
+        )
+        np.testing.assert_array_equal(loaded.norms, comp.norms)
+        assert loaded.d == comp.d
+        assert loaded.bits == comp.bits
+        assert loaded.n == comp.n
+
+
+# ------------------------------------------------------------------
+# Arrow IPC (Feather v2) — issue #23
+# ------------------------------------------------------------------
+
+def _has_pyarrow():
+    try:
+        import pyarrow
+        return True
+    except ImportError:
+        return False
+
+
+@pytest.mark.skipif(not _has_pyarrow(), reason="pyarrow not installed")
+class TestArrowIPC:
+
+    def test_packed_save_load_roundtrip(self, setup, tmp_path):
+        _, comp, packed, _ = setup
+        path = str(tmp_path / "test.arrow")
+        packed.save_arrow(path, seed=42)
+        loaded = PackedVectors.load_arrow(path)
+        np.testing.assert_array_equal(
+            loaded.unpack_rows(0, loaded.n),
+            comp.indices,
+        )
+        np.testing.assert_allclose(loaded.norms, comp.norms)
+        assert loaded.d == comp.d
+        assert loaded.bits == comp.bits
+        assert loaded.n == comp.n
+
+    def test_compressed_save_load_roundtrip(self, setup, tmp_path):
+        """CompressedVectors.save_arrow / load_arrow round-trip."""
+        _, comp, _, _ = setup
+        path = str(tmp_path / "test.arrow")
+        comp.save_arrow(path, seed=42)
+        loaded = CompressedVectors.load_arrow(path)
+        np.testing.assert_array_equal(loaded.indices, comp.indices)
+        np.testing.assert_allclose(loaded.norms, comp.norms)
+        assert loaded.d == comp.d
+        assert loaded.bits == comp.bits
+
+    def test_schema_metadata(self, setup, tmp_path):
+        """Arrow file should contain quantizer params in schema metadata."""
+        import pyarrow.feather as feather
+        _, _, packed, _ = setup
+        path = str(tmp_path / "meta.arrow")
+        packed.save_arrow(path, seed=42, partition="shard_0")
+        table = feather.read_table(path)
+        meta = table.schema.metadata
+        assert int(meta[b"d"]) == packed.d
+        assert int(meta[b"bits"]) == packed.bits
+        assert int(meta[b"n"]) == packed.n
+        assert int(meta[b"seed"]) == 42
+        assert meta[b"partition"] == b"shard_0"
+
+    def test_arrow_columns(self, setup, tmp_path):
+        """Arrow file should have norms (float32) and packed_indices (FixedSizeBinary)."""
+        import pyarrow as pa
+        import pyarrow.feather as feather
+        _, _, packed, _ = setup
+        path = str(tmp_path / "cols.arrow")
+        packed.save_arrow(path)
+        table = feather.read_table(path)
+        assert table.schema.field("norms").type == pa.float32()
+        idx_type = table.schema.field("packed_indices").type
+        assert isinstance(idx_type, pa.FixedSizeBinaryType)
+        assert idx_type.byte_width == packed._row_bytes
+
+    def test_memory_map_load(self, setup, tmp_path):
+        """Loading with memory_map=True should produce correct results."""
+        _, comp, packed, _ = setup
+        path = str(tmp_path / "mmap.arrow")
+        packed.save_arrow(path)
+        loaded = PackedVectors.load_arrow(path, memory_map=True)
+        np.testing.assert_array_equal(
+            loaded.unpack_rows(0, loaded.n),
+            comp.indices,
+        )
+
+    @pytest.mark.parametrize("bits", [1, 2, 3, 4, 8])
+    def test_arrow_roundtrip_all_bits(self, rng, bits, tmp_path):
+        d = 128
+        pq = Quantizer(d=d, bits=bits)
+        X = rng.standard_normal((50, d)).astype(np.float32)
+        comp = pq.encode(X)
+        packed = PackedVectors.from_compressed(comp)
+
+        path = str(tmp_path / f"test_{bits}bit.arrow")
+        packed.save_arrow(path, seed=pq.seed)
+        loaded = PackedVectors.load_arrow(path)
+
+        np.testing.assert_array_equal(
+            loaded.unpack_rows(0, loaded.n),
+            comp.indices,
+        )
+
+    def test_arrow_import_error(self, setup, tmp_path, monkeypatch):
+        """Should raise ImportError with helpful message when pyarrow missing."""
+        _, _, packed, _ = setup
+        import builtins
+        real_import = builtins.__import__
+
+        def mock_import(name, *args, **kwargs):
+            if name in ("pyarrow", "pyarrow.feather"):
+                raise ImportError("No module named 'pyarrow'")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", mock_import)
+        with pytest.raises(ImportError, match="pyarrow"):
+            packed.save_arrow(str(tmp_path / "fail.arrow"))


### PR DESCRIPTION
## Summary

This PR introduces `PackedVectors`, a new memory-efficient storage format for quantized vectors that keeps indices bit-packed in memory, and adds Arrow IPC (Feather v2) serialization support for both `CompressedVectors` and `PackedVectors`.

## Key Changes

- **New `PackedVectors` class**: Stores indices bit-packed in memory, unpacking rows on demand. Achieves 2-4x RAM savings vs `CompressedVectors` for sub-byte bit widths (1-3 bits).
  - `from_compressed()`: Convert from `CompressedVectors`
  - `from_rows()`: Reconstruct from database byte rows
  - `unpack_rows()` / `unpack_at()`: On-demand decompression
  - `at_precision()`: Matryoshka-style precision reduction via right-shift
  - `subset()`: Extract a subset of vectors
  - `.npz` serialization: `save()` / `load()`

- **Arrow IPC (Feather v2) support**:
  - `PackedVectors.save_arrow()` / `load_arrow()`: Serialize packed indices as FixedSizeBinary with schema-level metadata
  - `CompressedVectors.save_arrow()` / `load_arrow()`: Convenience wrappers that convert via `PackedVectors`
  - Metadata preservation: quantizer parameters (d, bits, n, seed) stored in Arrow schema
  - Optional `memory_map` parameter for zero-copy loading

- **Search integration**:
  - `Quantizer.search_adc()`: Now accepts both `CompressedVectors` and `PackedVectors`, unpacking chunks on demand
  - `Quantizer.search_twostage()`: Supports `PackedVectors` with on-demand unpacking in coarse and fine stages
  - `Quantizer.search()`: Raises `TypeError` for `PackedVectors` (cached search not supported; users should use ADC/two-stage or convert with `to_compressed()`)

- **New helper method**: `_adc_score_packed()` for efficient ADC scoring of packed vectors with optional precision reduction

- **Export**: `PackedVectors` added to `remex.__init__.py`

- **Optional dependency**: `pyarrow>=12.0` added as optional `arrow` extra in `pyproject.toml`

## Implementation Details

- Bit-packing uses existing `pack()` / `unpack()` utilities from `remex.packing`
- Row-aligned (byte-boundary) and non-aligned bit widths handled separately for efficiency
- Chunked unpacking (default 4096 rows) balances memory usage and performance
- Arrow schema metadata stores all quantizer parameters as UTF-8 encoded strings
- Comprehensive test suite (445 lines) covering creation, conversion, memory savings, unpacking, Matryoshka precision, ADC/two-stage search, and Arrow round-trips

https://claude.ai/code/session_011gmiEgLjgSNxGF5K5wFyJR