### PR TITLE
Investigate mixed-precision quantization via residual-error tail selection (#34)

### DIFF
--- a/bench/RESULTS.md
+++ b/bench/RESULTS.md
@@ -104,6 +104,10 @@ Despite the 61% σ deviation, 4-bit R@10 > 0.83 and 8-bit is essentially lossles
 
 See [docs/specter2-case-study.md](../docs/specter2-case-study.md) for full analysis.
 
+## Research investigations
+
+- [docs/research/hybrid-precision-quantization.md](../docs/research/hybrid-precision-quantization.md) — Ported OjaKV&rsquo;s &ldquo;keep high-residual vectors at higher precision&rdquo; trick to TurboQuant-style scalar quantization. Verdict: FILE. Residual distribution is near-flat under Haar rotation + Lloyd-Max (top 10% of vectors carry only 10.8% of error mass), and cross-tier score merging is miscalibrated on anisotropic embeddings (e.g. SPECTER2). `search_twostage()` remains the right memory/recall trade-off.
+
 ## Memory Profiles (100k vectors, d=384, 8-bit)
 
 | Strategy | Resident RAM | ms/query |

--- a/bench/hybrid_precision_eval.py
+++ b/bench/hybrid_precision_eval.py
@@ -1,0 +1,533 @@
+"""
+Hybrid-precision quantization investigation (issue #34).
+
+Hypothesis (ported from OjaKV arXiv:2509.21623): the per-vector
+reconstruction error under 2-bit TurboQuant is heavy-tailed. If so, a
+small fraction of high-residual vectors carries most of the error mass
+and keeping them at higher precision should yield outsized recall at
+near-flat memory cost.
+
+This script runs the three-step investigation from the issue:
+
+  Step 1: characterize the residual-error distribution on a real
+          embedding corpus (SPECTER2-encoded abstracts) and a synthetic
+          Gaussian baseline. Prints tail-mass statistics and KS / skew
+          / kurtosis diagnostics; optionally saves histograms.
+
+  Gate:   if the top-10% of vectors carry <40% of total squared error
+          mass, the hypothesis is dead and Step 2 is skipped.
+
+  Step 2: construct a hybrid-precision index — top-k% highest-residual
+          vectors stored at higher precision, rest at 2-bit — and
+          compare recall@{10,100} vs uniform 2/3/4-bit baselines at
+          matched bits/vector.
+
+  Step 3: decision is printed based on whether hybrid beats
+          uniform-at-same-bits-per-vector by >2 recall@10 points.
+
+The hybrid search implementation is a bench-only helper that splits
+the corpus into two precision tiers, calls remex.Quantizer.search_adc
+on each, and merges the top-k. No production code changes.
+
+Usage:
+
+    # Full run, synthetic baseline only (always works, fast)
+    python bench/hybrid_precision_eval.py --synthetic-only
+
+    # With cached SPECTER2 corpus (run specter2_eval.py first to cache)
+    python bench/hybrid_precision_eval.py --specter2 --plots
+
+    # Custom scenario
+    python bench/hybrid_precision_eval.py \
+        --specter2 --k-pct 10 --high-bits 4 --low-bits 2
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+from typing import Optional
+
+import numpy as np
+from scipy import stats
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from remex import Quantizer
+from remex.codebook import lloyd_max_codebook
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+CACHE_DIR = os.path.join(SCRIPT_DIR, ".specter2_cache")
+RESULTS_DIR = os.path.join(SCRIPT_DIR, "hybrid_results")
+PLOTS_DIR = os.path.join(SCRIPT_DIR, "plots")
+
+
+# ---------------------------------------------------------------------------
+# Step 1 — residual-error characterization
+# ---------------------------------------------------------------------------
+
+
+def residual_errors(
+    corpus: np.ndarray, bits: int, seed: int = 42
+) -> tuple[np.ndarray, Quantizer]:
+    """Encode + decode at `bits` precision and return relative L2 residuals.
+
+    err[i] = ||x[i] - dequantize(quantize(x[i]))||_2 / ||x[i]||_2
+    """
+    d = corpus.shape[1]
+    q = Quantizer(d=d, bits=bits, seed=seed)
+    compressed = q.encode(corpus)
+    x_hat = q.decode(compressed)
+
+    diff = corpus.astype(np.float32) - x_hat
+    abs_err = np.linalg.norm(diff, axis=1)
+    norms = np.linalg.norm(corpus, axis=1)
+    rel_err = abs_err / np.maximum(norms, 1e-12)
+    return rel_err, q
+
+
+def tail_mass_stats(rel_err: np.ndarray) -> dict:
+    """How much of total squared-error mass sits in the top p% of vectors."""
+    n = len(rel_err)
+    sq = rel_err.astype(np.float64) ** 2
+    total = float(sq.sum())
+    order = np.argsort(-rel_err)  # worst-first
+    sorted_sq = sq[order]
+    cum = np.cumsum(sorted_sq)
+
+    pcts = [1, 5, 10, 20, 30, 50]
+    masses = {}
+    for p in pcts:
+        k = max(1, int(np.ceil(n * p / 100)))
+        masses[p] = float(cum[k - 1] / total) if total > 0 else 0.0
+
+    return {
+        "total_sq_error": total,
+        "rel_err_mean": float(rel_err.mean()),
+        "rel_err_median": float(np.median(rel_err)),
+        "rel_err_std": float(rel_err.std()),
+        "rel_err_min": float(rel_err.min()),
+        "rel_err_max": float(rel_err.max()),
+        "rel_err_p95": float(np.percentile(rel_err, 95)),
+        "rel_err_p99": float(np.percentile(rel_err, 99)),
+        "skewness": float(stats.skew(rel_err)),
+        "excess_kurtosis": float(stats.kurtosis(rel_err, fisher=True)),
+        "mass_top_1pct": masses[1],
+        "mass_top_5pct": masses[5],
+        "mass_top_10pct": masses[10],
+        "mass_top_20pct": masses[20],
+        "mass_top_30pct": masses[30],
+        "mass_top_50pct": masses[50],
+        "n": n,
+    }
+
+
+def print_step1(label: str, bits: int, d: int, rel_err: np.ndarray) -> dict:
+    stats_ = tail_mass_stats(rel_err)
+    print(f"\n{'='*60}")
+    print(f"  Step 1 — residual-error distribution")
+    print(f"  Corpus: {label}  (n={rel_err.shape[0]}, d={d})")
+    print(f"  Quantization: {bits}-bit TurboQuant (Lloyd-Max + Haar rotation)")
+    print(f"{'='*60}")
+    print(f"  Relative L2 error  (||x - x̂|| / ||x||):")
+    print(f"    min / median / mean / max : "
+          f"{stats_['rel_err_min']:.4f} / {stats_['rel_err_median']:.4f} / "
+          f"{stats_['rel_err_mean']:.4f} / {stats_['rel_err_max']:.4f}")
+    print(f"    std                       : {stats_['rel_err_std']:.4f}")
+    print(f"    p95 / p99                 : "
+          f"{stats_['rel_err_p95']:.4f} / {stats_['rel_err_p99']:.4f}")
+    print(f"    skewness / excess kurt.   : "
+          f"{stats_['skewness']:.3f} / {stats_['excess_kurtosis']:.3f}")
+    print()
+    print(f"  Squared-error tail mass (fraction of total ||err||² carried "
+          f"by top-p% worst vectors):")
+    for p in (1, 5, 10, 20, 30, 50):
+        uniform = p / 100
+        concentration = stats_[f"mass_top_{p}pct"] / uniform
+        print(f"    top {p:>2d}%  →  {stats_[f'mass_top_{p}pct']:.3f}   "
+              f"({concentration:.2f}x uniform)")
+    print()
+    # Gate
+    heavy = stats_["mass_top_10pct"] > 0.40
+    print(f"  Hypothesis gate (>40% mass in top 10%): "
+          f"{'HOLDS — proceed to Step 2' if heavy else 'FAILS — tail too flat'}")
+
+    return {"label": label, "bits": bits, "d": d, **stats_, "gate_holds": heavy}
+
+
+def save_residual_plot(label: str, rel_err: np.ndarray, bits: int):
+    try:
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+    except ImportError:
+        print("  (matplotlib not installed, skipping plot)")
+        return None
+
+    os.makedirs(PLOTS_DIR, exist_ok=True)
+    safe = label.lower().replace(" ", "_").replace("/", "_")
+
+    fig, axes = plt.subplots(1, 2, figsize=(12, 4.5))
+    axes[0].hist(rel_err, bins=80, alpha=0.75, color="steelblue", edgecolor="white")
+    axes[0].axvline(np.median(rel_err), color="k", ls="--", lw=1, label=f"median={np.median(rel_err):.3f}")
+    axes[0].axvline(np.percentile(rel_err, 95), color="red", ls="--", lw=1, label=f"p95={np.percentile(rel_err, 95):.3f}")
+    axes[0].set_xlabel("relative L2 error  ||x - x̂|| / ||x||")
+    axes[0].set_ylabel("count")
+    axes[0].set_title(f"{label} — residual histogram ({bits}-bit)")
+    axes[0].legend()
+
+    # Lorenz-style tail mass curve
+    n = len(rel_err)
+    sq = (rel_err.astype(np.float64) ** 2)
+    order = np.argsort(-rel_err)
+    cum = np.cumsum(sq[order]) / sq.sum()
+    frac_vectors = np.arange(1, n + 1) / n
+    axes[1].plot(frac_vectors * 100, cum, color="darkorange", lw=2, label="cumulative error mass")
+    axes[1].plot([0, 100], [0, 1], color="gray", ls=":", lw=1, label="uniform")
+    for p in (10, 20):
+        k = max(1, int(np.ceil(n * p / 100)))
+        axes[1].axvline(p, color="k", ls="--", lw=0.6, alpha=0.5)
+        axes[1].annotate(f"{cum[k-1]*100:.0f}% of error",
+                         xy=(p, cum[k-1]), xytext=(p + 2, cum[k-1] - 0.08),
+                         fontsize=9)
+    axes[1].set_xlabel("top-p% worst vectors")
+    axes[1].set_ylabel("fraction of total squared error")
+    axes[1].set_title(f"{label} — tail-mass curve")
+    axes[1].set_xlim(0, 100)
+    axes[1].set_ylim(0, 1.02)
+    axes[1].legend(loc="lower right")
+    fig.tight_layout()
+
+    path = os.path.join(PLOTS_DIR, f"{safe}_{bits}bit_residuals.png")
+    fig.savefig(path, dpi=140, bbox_inches="tight")
+    plt.close(fig)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Step 2 — hybrid-precision benchmark
+# ---------------------------------------------------------------------------
+
+
+def exact_knn(corpus: np.ndarray, queries: np.ndarray, k: int) -> np.ndarray:
+    scores = queries @ corpus.T
+    return np.argsort(-scores, axis=1)[:, :k]
+
+
+def recall_at_k(pred: np.ndarray, truth: np.ndarray, k: int) -> float:
+    hits = 0
+    for p, t in zip(pred, truth):
+        hits += len(set(p[:k]) & set(t[:k]))
+    return hits / (len(pred) * k)
+
+
+def hybrid_scores(
+    corpus: np.ndarray,
+    queries: np.ndarray,
+    high_bits: int,
+    low_bits: int,
+    k_pct: float,
+    seed: int = 42,
+) -> tuple[np.ndarray, float]:
+    """Score queries against a hybrid-precision index.
+
+    Protocol:
+      1. Compute per-vector residual under ``low_bits`` TurboQuant.
+      2. Top ``k_pct`` of vectors by residual → quantize at ``high_bits``.
+      3. Remaining (1 - k_pct) → quantize at ``low_bits``.
+      4. ADC-score both tiers with the *same* Haar rotation (seed).
+      5. Concatenate scores in original corpus order.
+
+    Returns (scores: (n_queries, n), avg_bits_per_vector).
+    """
+    assert 0 < k_pct < 1
+    d = corpus.shape[1]
+    n = corpus.shape[0]
+
+    # Tier selection by low-bit residual
+    rel_err_low, _ = residual_errors(corpus, low_bits, seed=seed)
+    n_high = max(1, int(np.ceil(n * k_pct)))
+    high_idx = np.argpartition(-rel_err_low, n_high)[:n_high]
+    high_mask = np.zeros(n, dtype=bool)
+    high_mask[high_idx] = True
+    low_idx = np.where(~high_mask)[0]
+
+    q_high = Quantizer(d=d, bits=high_bits, seed=seed)
+    q_low = Quantizer(d=d, bits=low_bits, seed=seed)
+    comp_high = q_high.encode(corpus[high_idx])
+    comp_low = q_low.encode(corpus[low_idx])
+
+    all_scores = np.empty((queries.shape[0], n), dtype=np.float32)
+    for qi, query in enumerate(queries):
+        # search_adc returns top-k; we need all scores for merge, so call the
+        # scoring helper directly via a full-corpus k.
+        idx_h, sc_h = q_high.search_adc(comp_high, query, k=len(high_idx))
+        idx_l, sc_l = q_low.search_adc(comp_low, query, k=len(low_idx))
+        scores_row = np.empty(n, dtype=np.float32)
+        scores_row[high_idx[idx_h]] = sc_h
+        scores_row[low_idx[idx_l]] = sc_l
+        all_scores[qi] = scores_row
+
+    avg_bits = (n_high * high_bits + (n - n_high) * low_bits) / n
+    return all_scores, avg_bits
+
+
+def uniform_scores(
+    corpus: np.ndarray, queries: np.ndarray, bits: int, seed: int = 42
+) -> np.ndarray:
+    d = corpus.shape[1]
+    q = Quantizer(d=d, bits=bits, seed=seed)
+    comp = q.encode(corpus)
+    n = corpus.shape[0]
+    all_scores = np.empty((queries.shape[0], n), dtype=np.float32)
+    for qi, query in enumerate(queries):
+        idx, sc = q.search_adc(comp, query, k=n)
+        row = np.empty(n, dtype=np.float32)
+        row[idx] = sc
+        all_scores[qi] = row
+    return all_scores
+
+
+def top_k_from_scores(scores: np.ndarray, k: int) -> np.ndarray:
+    out = np.empty((scores.shape[0], k), dtype=np.int64)
+    for i in range(scores.shape[0]):
+        row = scores[i]
+        if k >= len(row):
+            out[i] = np.argsort(-row)[:k]
+        else:
+            part = np.argpartition(-row, k)[:k]
+            out[i] = part[np.argsort(-row[part])]
+    return out
+
+
+def run_step2(
+    corpus: np.ndarray,
+    label: str,
+    k_pct: float,
+    high_bits: int,
+    low_bits: int,
+    n_queries: int = 200,
+    max_k: int = 100,
+    seed: int = 99,
+) -> dict:
+    rng = np.random.default_rng(seed)
+    n = corpus.shape[0]
+    perm = rng.permutation(n)
+    n_queries = min(n_queries, n // 5)
+    query_idx = perm[:n_queries]
+    corpus_idx = perm[n_queries:]
+    queries = corpus[query_idx]
+    search_corpus = corpus[corpus_idx]
+
+    print(f"\n{'='*60}")
+    print(f"  Step 2 — recall benchmark: {label}")
+    print(f"  corpus {search_corpus.shape[0]}  queries {queries.shape[0]}  "
+          f"d={corpus.shape[1]}")
+    print(f"  hybrid: top {k_pct*100:.0f}% at {high_bits}-bit, "
+          f"rest at {low_bits}-bit")
+    print(f"{'='*60}")
+
+    truth = exact_knn(search_corpus, queries, max_k)
+
+    results = []
+
+    # Uniform baselines at 2, 3, 4 bits (skip if > high_bits)
+    for bits in sorted({low_bits, max(low_bits, low_bits + 1), high_bits}):
+        if bits in (5, 6, 7):  # remex restriction
+            continue
+        t0 = time.time()
+        scores = uniform_scores(search_corpus, queries, bits)
+        pred = top_k_from_scores(scores, max_k)
+        r10 = recall_at_k(pred[:, :10], truth[:, :10], 10)
+        r100 = recall_at_k(pred[:, :100], truth[:, :100], 100)
+        dt = time.time() - t0
+        results.append({
+            "method": f"uniform-{bits}bit",
+            "avg_bits": float(bits),
+            "recall_10": r10,
+            "recall_100": r100,
+            "time_s": dt,
+        })
+        print(f"  uniform-{bits}bit               avg_bits={bits:4.2f}  "
+              f"R@10={r10:.3f}  R@100={r100:.3f}  ({dt:.1f}s)")
+
+    # Hybrid
+    t0 = time.time()
+    h_scores, avg_bits = hybrid_scores(
+        search_corpus, queries, high_bits, low_bits, k_pct
+    )
+    pred = top_k_from_scores(h_scores, max_k)
+    r10 = recall_at_k(pred[:, :10], truth[:, :10], 10)
+    r100 = recall_at_k(pred[:, :100], truth[:, :100], 100)
+    dt = time.time() - t0
+    results.append({
+        "method": f"hybrid-{high_bits}/{low_bits}bit-top{int(k_pct*100)}%",
+        "avg_bits": avg_bits,
+        "recall_10": r10,
+        "recall_100": r100,
+        "time_s": dt,
+    })
+    print(f"  hybrid {high_bits}/{low_bits}bit  top{int(k_pct*100):>2d}%   "
+          f"avg_bits={avg_bits:4.2f}  R@10={r10:.3f}  R@100={r100:.3f}  "
+          f"({dt:.1f}s)")
+
+    # Verdict — interpolate uniform curve at the hybrid's avg_bits and
+    # compare. This is the "same bits/vector" comparison from the issue.
+    uniform_pts = sorted(
+        [r for r in results if r["method"].startswith("uniform")],
+        key=lambda r: r["avg_bits"],
+    )
+    hybrid = results[-1]
+    print()
+    if len(uniform_pts) < 2:
+        print("  → Not enough uniform baselines to interpolate.")
+    else:
+        # Find bracket containing hybrid's avg_bits
+        lo = hi = None
+        for i in range(len(uniform_pts) - 1):
+            if uniform_pts[i]["avg_bits"] <= avg_bits <= uniform_pts[i + 1]["avg_bits"]:
+                lo, hi = uniform_pts[i], uniform_pts[i + 1]
+                break
+        if lo is None:  # hybrid above or below the bracket — use nearest
+            ref = min(uniform_pts, key=lambda r: abs(r["avg_bits"] - avg_bits))
+            ref_r10 = ref["recall_10"]
+            print(f"  Uniform curve does not bracket avg_bits={avg_bits:.2f}; "
+                  f"using nearest ({ref['method']}) = {ref_r10:.3f}")
+        else:
+            t = (avg_bits - lo["avg_bits"]) / (hi["avg_bits"] - lo["avg_bits"])
+            ref_r10 = lo["recall_10"] + t * (hi["recall_10"] - lo["recall_10"])
+            print(f"  Uniform R@10 interpolated at {avg_bits:.2f} bits "
+                  f"(between {lo['method']}={lo['recall_10']:.3f} and "
+                  f"{hi['method']}={hi['recall_10']:.3f}) = {ref_r10:.3f}")
+
+        gap = hybrid["recall_10"] - ref_r10
+        print(f"    ΔR@10 (hybrid vs uniform-at-matched-bits) = {gap*100:+.1f} pts")
+        if gap > 0.02:
+            verdict = "SHIP"
+            reason = f"hybrid beats uniform curve by {gap*100:.1f} pts at matched bits"
+        elif gap > 0:
+            verdict = "FILE"
+            reason = f"hybrid ties uniform curve ({gap*100:+.1f} pts)"
+        else:
+            verdict = "FILE"
+            reason = f"hybrid loses vs uniform curve ({gap*100:+.1f} pts)"
+        print(f"    verdict: {verdict} — {reason}")
+
+    return {"label": label, "k_pct": k_pct, "high_bits": high_bits,
+            "low_bits": low_bits, "results": results}
+
+
+# ---------------------------------------------------------------------------
+# Corpus helpers
+# ---------------------------------------------------------------------------
+
+
+def synthetic_gaussian(n: int, d: int, seed: int = 0) -> np.ndarray:
+    """Unit-norm Gaussian vectors. The ideal TurboQuant input distribution."""
+    rng = np.random.default_rng(seed)
+    X = rng.standard_normal((n, d)).astype(np.float32)
+    X /= np.linalg.norm(X, axis=1, keepdims=True)
+    return X
+
+
+def load_specter2_cached(label: str) -> Optional[np.ndarray]:
+    path = os.path.join(CACHE_DIR, f"{label}.npy")
+    if not os.path.exists(path):
+        return None
+    return np.load(path)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--specter2", action="store_true",
+                        help="Run on cached SPECTER2 corpus (see specter2_eval.py)")
+    parser.add_argument("--synthetic-only", action="store_true",
+                        help="Skip real-data run; use synthetic Gaussian only")
+    parser.add_argument("--n-synthetic", type=int, default=10_000)
+    parser.add_argument("--d-synthetic", type=int, default=768)
+    parser.add_argument("--low-bits", type=int, default=2,
+                        help="Aggressive quantization tier (default 2)")
+    parser.add_argument("--high-bits", type=int, default=4,
+                        help="High-fidelity tier for the tail (default 4)")
+    parser.add_argument("--k-pct", type=float, default=10.0,
+                        help="Percent of vectors kept at high precision (default 10)")
+    parser.add_argument("--sweep", action="store_true",
+                        help="Sweep k_pct in {5,10,20} and high_bits in {4,8} "
+                             "for the matrix in the issue")
+    parser.add_argument("--plots", action="store_true",
+                        help="Save histogram + tail-mass plots")
+    parser.add_argument("--step1-only", action="store_true",
+                        help="Stop after residual characterization")
+    parser.add_argument("--force-step2", action="store_true",
+                        help="Run Step 2 even if gate fails")
+    parser.add_argument("--seed", type=int, default=42)
+    args = parser.parse_args()
+
+    os.makedirs(RESULTS_DIR, exist_ok=True)
+
+    corpora = []
+    if not args.specter2 or args.synthetic_only:
+        corpora.append(("synthetic Gaussian d=768",
+                        synthetic_gaussian(args.n_synthetic, args.d_synthetic, seed=0)))
+
+    if args.specter2 and not args.synthetic_only:
+        loaded = load_specter2_cached("specter2_nlp_broad")
+        if loaded is None:
+            print("SPECTER2 cache missing. Run:  python bench/specter2_eval.py --cached")
+            sys.exit(1)
+        corpora.append((f"SPECTER2 NLP-broad (n={loaded.shape[0]})", loaded))
+        narrow = load_specter2_cached("specter2_transformer_narrow")
+        if narrow is not None:
+            corpora.append((f"SPECTER2 Transformer-narrow (n={narrow.shape[0]})",
+                            narrow))
+
+    all_step1 = []
+    all_step2 = []
+
+    for label, corpus in corpora:
+        rel_err, _ = residual_errors(corpus, args.low_bits, seed=args.seed)
+        step1 = print_step1(label, args.low_bits, corpus.shape[1], rel_err)
+        all_step1.append(step1)
+        if args.plots:
+            path = save_residual_plot(label, rel_err, args.low_bits)
+            if path:
+                print(f"  plot: {path}")
+
+        if args.step1_only:
+            continue
+        if not step1["gate_holds"] and not args.force_step2:
+            print("  (gate failed — skipping Step 2; pass --force-step2 to run anyway)")
+            continue
+
+        if args.sweep:
+            sweep_configs = [(kp, hb) for kp in (5, 10, 20) for hb in (4, 8)]
+        else:
+            sweep_configs = [(args.k_pct, args.high_bits)]
+        for kp, hb in sweep_configs:
+            step2 = run_step2(
+                corpus, label,
+                k_pct=kp / 100,
+                high_bits=hb,
+                low_bits=args.low_bits,
+            )
+            all_step2.append(step2)
+
+    # Persist structured results
+    out_path = os.path.join(RESULTS_DIR, f"results_{int(time.time())}.json")
+    with open(out_path, "w") as f:
+        json.dump({
+            "config": vars(args),
+            "step1": all_step1,
+            "step2": all_step2,
+        }, f, indent=2)
+    print(f"\n  Results saved to {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/hybrid_precision_eval.py
+++ b/bench/hybrid_precision_eval.py
@@ -232,12 +232,25 @@ def hybrid_scores(
 ) -> tuple[np.ndarray, float]:
     """Score queries against a hybrid-precision index.
 
+    Uses a **single Matryoshka-nested Quantizer** at ``high_bits`` so the
+    codebooks across tiers are probability-consistent. Scoring the two
+    tiers with independently-fit Lloyd-Max codebooks at different bit
+    widths would produce score shifts (on SPECTER2, 2-bit means ~10%
+    smaller than exact, while 8-bit means match exactly) — merging such
+    scores without calibration pushes low-tier vectors below the full
+    high-tier regardless of relevance.
+
     Protocol:
-      1. Compute per-vector residual under ``low_bits`` TurboQuant.
-      2. Top ``k_pct`` of vectors by residual → quantize at ``high_bits``.
-      3. Remaining (1 - k_pct) → quantize at ``low_bits``.
-      4. ADC-score both tiers with the *same* Haar rotation (seed).
-      5. Concatenate scores in original corpus order.
+      1. Compute per-vector residual under ``low_bits`` to pick the tail.
+      2. Top ``k_pct`` of vectors by residual → score at ``high_bits``.
+      3. Remaining vectors → score at ``low_bits`` (same Quantizer, via
+         Matryoshka right-shift; same Haar rotation; centroids from the
+         same nested table).
+      4. Concatenate scores into corpus order.
+
+    Memory accounting: high tier stored at ``high_bits``, low tier
+    right-shifted to ``low_bits`` for bit-packed storage. Average
+    bits/vector = k * high_bits + (1 - k) * low_bits.
 
     Returns (scores: (n_queries, n), avg_bits_per_vector).
     """
@@ -245,7 +258,7 @@ def hybrid_scores(
     d = corpus.shape[1]
     n = corpus.shape[0]
 
-    # Tier selection by low-bit residual
+    # Tier selection — quick 2-bit reconstruction error picks the tail.
     rel_err_low, _ = residual_errors(corpus, low_bits, seed=seed)
     n_high = max(1, int(np.ceil(n * k_pct)))
     high_idx = np.argpartition(-rel_err_low, n_high)[:n_high]
@@ -253,17 +266,21 @@ def hybrid_scores(
     high_mask[high_idx] = True
     low_idx = np.where(~high_mask)[0]
 
-    q_high = Quantizer(d=d, bits=high_bits, seed=seed)
-    q_low = Quantizer(d=d, bits=low_bits, seed=seed)
-    comp_high = q_high.encode(corpus[high_idx])
-    comp_low = q_low.encode(corpus[low_idx])
+    # Single Quantizer at high_bits; Matryoshka handles low_bits via
+    # right-shift of the same indices with nested centroids.
+    q = Quantizer(d=d, bits=high_bits, seed=seed)
+    compressed = q.encode(corpus)
+    comp_high = compressed.subset(high_idx)
+    comp_low = compressed.subset(low_idx)
 
     all_scores = np.empty((queries.shape[0], n), dtype=np.float32)
     for qi, query in enumerate(queries):
-        # search_adc returns top-k; we need all scores for merge, so call the
-        # scoring helper directly via a full-corpus k.
-        idx_h, sc_h = q_high.search_adc(comp_high, query, k=len(high_idx))
-        idx_l, sc_l = q_low.search_adc(comp_low, query, k=len(low_idx))
+        idx_h, sc_h = q.search_adc(
+            comp_high, query, k=len(high_idx), precision=None
+        )
+        idx_l, sc_l = q.search_adc(
+            comp_low, query, k=len(low_idx), precision=low_bits
+        )
         scores_row = np.empty(n, dtype=np.float32)
         scores_row[high_idx[idx_h]] = sc_h
         scores_row[low_idx[idx_l]] = sc_l

--- a/bench/hybrid_results/.gitignore
+++ b/bench/hybrid_results/.gitignore
@@ -1,0 +1,1 @@
+results_*.json

--- a/docs/research/hybrid-precision-quantization.md
+++ b/docs/research/hybrid-precision-quantization.md
@@ -1,10 +1,38 @@
 # Investigation: mixed-precision quantization via residual-error tail selection
 
-**Status:** complete &middot; **Issue:** [#34](https://github.com/oaustegard/remex/issues/34) &middot; **Verdict:** _(pending &mdash; fill after Step 2)_
+**Status:** complete &middot; **Issue:** [#34](https://github.com/oaustegard/remex/issues/34) &middot; **Verdict:** **FILE** &mdash; hypothesis dead at Step&nbsp;1 on both corpora; Step&nbsp;2 confirms no ship-worthy hybrid at matched bits/vector.
 
 ## TL;DR
 
-_(to be written after Step 2)_
+The OjaKV hybrid-fidelity trick does not port to TurboQuant-style scalar
+quantization. Two independent reasons, each sufficient on its own:
+
+1. **The residual-error tail is flat.** On both synthetic Gaussian
+   (the ideal TurboQuant input) and SPECTER2 embeddings, the top-10% of
+   vectors by 2-bit residual carry only 10.8&ndash;11.0% of total
+   squared-error mass &mdash; only ~1.08&times; what a uniform distribution
+   would produce. There is no heavy tail to exploit.
+
+2. **Cross-tier score merging is miscalibrated on real embeddings.**
+   When Lloyd-Max is misspecified (SPECTER2: post-rotation &sigma; is 38%
+   of the N(0, 1/d) assumption), 2-bit reconstruction produces a
+   systematic downward bias in dot-product scores (&minus;10% absolute
+   on SPECTER2) while 4-bit and 8-bit are nearly unbiased. Merging scores
+   across precisions ranks *all* low-tier vectors below *all* high-tier
+   vectors by raw score, regardless of semantic relevance &mdash; hybrid
+   R@10 collapses to approximately the fraction of corpus promoted to the
+   high tier (5% &rarr; R@10&asymp;0.059, 10% &rarr; R@10&asymp;0.100,
+   20% &rarr; R@10&asymp;0.180).
+
+On synthetic data where Lloyd-Max *is* correctly specified, merging works
+but hybrid still loses to uniform interpolation by 2&ndash;21 R@10 points,
+because the Matryoshka nesting penalty at 2-bit swamps the tiny advantage
+from promoting a near-random 5&ndash;20% of vectors.
+
+**Recommendation:** keep `search_twostage()` as the standard way to
+trade memory for recall. It scores all vectors at low precision, then
+reranks only the top candidates at full precision &mdash; structurally
+avoids both failure modes above.
 
 ## Background
 
@@ -70,23 +98,167 @@ The residual distribution is **essentially uniform** over vectors. Top 10% carri
 
 ### SPECTER2 NLP-broad (d=768, n=4 017)
 
-_(to be filled after encoding completes)_
+```
+Relative L2 error  (||x - x̂|| / ||x||):
+  min / median / mean / max : 0.3071 / 0.3308 / 0.3309 / 0.3546
+  std                       : 0.0070
+  p95 / p99                 : 0.3426 / 0.3480
+  skewness / excess kurt.   : 0.127 / 0.131
+
+Squared-error tail mass:
+  top  1%  →  0.011   (1.15x uniform)
+  top  5%  →  0.055   (1.09x uniform)
+  top 10%  →  0.108   (1.08x uniform)
+  top 20%  →  0.212   (1.06x uniform)
+  top 30%  →  0.315   (1.05x uniform)
+  top 50%  →  0.517   (1.03x uniform)
+```
+
+Real scientific-paper embeddings produce a residual distribution almost
+indistinguishable from synthetic Gaussian. The absolute error level is
+slightly lower (mean 0.331 vs 0.342 &mdash; SPECTER2 sits at &sigma;
+&asymp; 0.014 per coord after rotation vs 0.036 for the synthetic
+baseline, so Lloyd-Max boundaries are too wide for SPECTER2 but the
+relative error-spread across vectors is similar). Top 10% carries 10.8%
+of total error mass, only 1.08&times; uniform &mdash; flatter than the
+synthetic baseline, which is the opposite of what the OjaKV hypothesis
+predicts.
+
+**Gate on SPECTER2: FAILS.** Also flat.
 
 ## Gate decision
 
-_(to be filled)_
+Both corpora fail the &ge;40% mass-in-top-10% gate by a wide margin.
+The hypothesis that 2-bit TurboQuant produces a heavy-tailed
+per-vector residual distribution is dead. Step 2 was run with
+`--force-step2` only to characterize what happens when you ignore the
+gate and build a hybrid index anyway &mdash; the numbers below show why
+the gate exists.
 
 ## Step 2 results
 
-_(to be filled)_
+Each config: 200 held-out queries, top-k vs exact inner-product ground
+truth, remaining vectors as the search corpus.
+
+### Synthetic Gaussian (n=9 800 after query split, d=768)
+
+| Config | avg bits | R@10 | R@100 | uniform R@10 at matched bits | ΔR@10 |
+|---|---:|---:|---:|---:|---:|
+| uniform-2bit | 2.00 | 0.549 | 0.638 | &mdash; | &mdash; |
+| uniform-3bit | 3.00 | 0.730 | 0.802 | &mdash; | &mdash; |
+| uniform-4bit | 4.00 | 0.855 | 0.895 | &mdash; | &mdash; |
+| uniform-8bit | 8.00 | 0.987 | 0.991 | &mdash; | &mdash; |
+| hybrid 4/2, top 5% | 2.10 | 0.548 | 0.646 | 0.568 | **&minus;1.9** |
+| hybrid 4/2, top 10% | 2.20 | 0.567 | 0.658 | 0.586 | **&minus;1.9** |
+| hybrid 4/2, top 20% | 2.40 | 0.600 | 0.684 | 0.622 | **&minus;2.2** |
+| hybrid 8/2, top 5% | 2.30 | 0.475 | 0.591 | 0.604 | **&minus;12.9** |
+| hybrid 8/2, top 10% | 2.60 | 0.491 | 0.605 | 0.658 | **&minus;16.6** |
+| hybrid 8/2, top 20% | 3.20 | 0.530 | 0.633 | 0.740 | **&minus;21.0** |
+
+Hybrid 4/2 at 5% and 10% both lose 1.9 pts vs the uniform curve &mdash;
+the 4&rarr;2 Matryoshka nesting penalty outweighs the tail-selection
+advantage on a flat tail. Hybrid 8/2 is dramatically worse: Matryoshka
+8&rarr;2 has a bigger nesting penalty than 4&rarr;2, so the 2-bit tier
+on an 8-bit parent encoding is considerably less accurate than a
+stand-alone 2-bit Lloyd-Max, and there is nothing in the residual
+distribution that recovers that loss.
+
+### SPECTER2 NLP-broad (n=3 817 after query split, d=768)
+
+| Config | avg bits | R@10 | R@100 | uniform R@10 at matched bits | ΔR@10 |
+|---|---:|---:|---:|---:|---:|
+| uniform-2bit | 2.00 | 0.532 | 0.658 | &mdash; | &mdash; |
+| uniform-3bit | 3.00 | 0.650 | 0.751 | &mdash; | &mdash; |
+| uniform-4bit | 4.00 | 0.784 | 0.852 | &mdash; | &mdash; |
+| uniform-8bit | 8.00 | 0.982 | 0.990 | &mdash; | &mdash; |
+| hybrid 4/2, top 5% | 2.10 | **0.059** | 0.176 | 0.543 | **&minus;48.5** |
+| hybrid 4/2, top 10% | 2.20 | **0.100** | 0.242 | 0.555 | **&minus;45.6** |
+| hybrid 4/2, top 20% | 2.40 | **0.179** | 0.395 | 0.579 | **&minus;40.1** |
+| hybrid 8/2, top 5% | 2.30 | **0.052** | 0.180 | 0.567 | **&minus;51.6** |
+| hybrid 8/2, top 10% | 2.60 | **0.099** | 0.261 | 0.603 | **&minus;50.4** |
+| hybrid 8/2, top 20% | 3.20 | **0.180** | 0.446 | 0.674 | **&minus;49.4** |
+
+Hybrid R@10 closely tracks `k_pct`: top 5% &rarr; 5.9%, top 10% &rarr;
+10.0%, top 20% &rarr; 17.9%. That is *exactly* the behaviour you get
+when the tier merge is dominated by a per-tier score offset rather than
+per-vector relevance &mdash; recall collapses to &ldquo;the fraction of
+true top-k that happened to be promoted to the high tier&rdquo;, which
+for residual-based promotion on a flat tail is just `k_pct`.
+
+### Diagnosing the SPECTER2 collapse
+
+Per-query score means on SPECTER2 (single query, k_pct=5%, n=3 817):
+
+| | high tier (4-bit, n=191) | low tier (2-bit Matryoshka, n=3 626) |
+|---|---:|---:|
+| approximate mean | 393.0 | 364.4 |
+| exact mean | 396.4 | 406.1 |
+| **bias** | **&minus;3.4** | **&minus;41.7** |
+| approximate range | [347.4, 434.1] | [310.4, 408.8] |
+| exact range | [345.1, 438.0] | [348.4, 450.8] |
+
+The low tier&rsquo;s approximate-score range maxes out at 408.8, below
+the high tier&rsquo;s mean of 393.0, so the merge sorts virtually every
+high-tier vector above virtually every low-tier vector regardless of
+true rank. On synthetic Gaussian the equivalent per-tier bias is
+&minus;0.0002 (high) / &minus;0.0000 (low) &mdash; effectively zero,
+which is why that merge at least produces sane numbers (just not good
+ones).
+
+**Root cause.** SPECTER2 is anisotropic &mdash; the [SPECTER2 case
+study](../specter2-case-study.md) documents that its post-rotation
+&sigma; is 38% of the N(0, 1/d) assumption. Lloyd-Max boundaries
+calibrated for the theoretical variance are too wide, so 2-bit
+reconstruction systematically under-uses the outer levels and shrinks
+dot-product magnitudes by ~10%. 4-bit and 8-bit are far less sensitive
+(more levels &rarr; less clipping to the mismatched distribution), so
+the bias only shows up at the low tier. This is not a bug in the
+hybrid construction; it is a structural reason why the construction
+cannot work on real anisotropic embeddings.
 
 ## Verdict
 
-_(to be filled)_
+**FILE.** The OjaKV hybrid-storage policy does not port to TurboQuant
+scalar quantization. Both gating criteria fail independently:
+
+- Step 1 gate fails: the residual distribution is near-uniform across
+  vectors on both synthetic and SPECTER2 corpora. No tail to exploit.
+- Step 2 ship criterion fails: no config beats the uniform curve at
+  matched bits/vector. On synthetic, hybrid 4/2 loses ~2 pts (Matryoshka
+  penalty); on SPECTER2, hybrid loses 40&ndash;52 pts (score-scale bias).
 
 ## What to take away
 
-_(to be filled)_
+1. **TurboQuant is doing its job.** The Haar rotation plus Lloyd-Max
+   codebook is explicitly designed to isotropize the error so that no
+   vector suffers disproportionately. The flat residual distribution is
+   a success of that design, not a failure &mdash; and it is precisely
+   what makes OjaKV-style &ldquo;promote the outliers&rdquo; heuristics
+   useless here.
+
+2. **OjaKV&rsquo;s hybrid trick is basis-specific.** It works because
+   OjaKV compresses by projecting onto a low-rank basis, and some tokens
+   are genuinely far outside the basis. With scalar quantization every
+   coordinate gets its own (small) error budget; there is no
+   low-rank outlier phenomenon.
+
+3. **Don&rsquo;t merge scores across precisions on anisotropic data.**
+   Even with Matryoshka-nested codebooks (which guarantee
+   probability-consistent centroids across bit widths), the
+   *reconstruction accuracy* depends on the codebook being well-matched
+   to the distribution. When it isn&rsquo;t, the bias is bit-width-dependent
+   and tier merges by raw score fail catastrophically. The existing
+   [`Quantizer.search_twostage()`](../../remex/core.py#L635) pattern
+   avoids this entirely by scoring everything at one precision for the
+   coarse pass and reranking only candidates at full precision.
+
+4. **Score-scale bias is worth its own investigation.** The finding
+   that 2-bit SPECTER2 scores are biased &minus;10% absolute while
+   4/8-bit are unbiased hints at a calibration opportunity: a
+   distribution-aware Lloyd-Max (fitted to SPECTER2&rsquo;s &sigma;
+   &asymp; 0.014 rather than the theoretical 0.036) might both improve
+   recall directly and make cross-precision merges feasible. That is
+   a separate line of work.
 
 ## Reproducing
 

--- a/docs/research/hybrid-precision-quantization.md
+++ b/docs/research/hybrid-precision-quantization.md
@@ -1,0 +1,110 @@
+# Investigation: mixed-precision quantization via residual-error tail selection
+
+**Status:** complete &middot; **Issue:** [#34](https://github.com/oaustegard/remex/issues/34) &middot; **Verdict:** _(pending &mdash; fill after Step 2)_
+
+## TL;DR
+
+_(to be written after Step 2)_
+
+## Background
+
+OjaKV (arXiv:[2509.21623](https://arxiv.org/abs/2509.21623), Zhu/Yang et al. 2025) reports that the dominant gain in their KV-cache scheme comes not from the online Oja updates they brand the paper around, but from a simple "hybrid storage" policy: keep tokens with high reconstruction error under the current basis at full fidelity, compress the rest. On RULER 0.6&times; their ablation shows this hybrid policy contributes **+18 points** while the Oja updates contribute only **+3**.
+
+OjaKV's core technique is dimension reduction, not bit quantization, so most of the paper doesn't port to remex. But the hybrid-fidelity pattern is axis-agnostic: if a small fraction of vectors carry most of the quantization error, paying a little more memory to keep them at higher precision should trade cheaply for recall.
+
+This investigation tests whether the pattern holds for TurboQuant-style scalar quantization as used in remex.
+
+## Hypothesis
+
+Under 2-bit remex (random orthogonal rotation + Lloyd-Max N(0, 1/d) codebook), the per-vector relative reconstruction error is **heavy-tailed**. Specifically, the top 10% of vectors by residual carry >40% of the total squared-error mass. If this holds, promoting those vectors to higher precision (4-bit or 8-bit) should yield a favorable recall/memory trade-off versus uniform quantization at matched bits/vector.
+
+## Method
+
+Implemented in `bench/hybrid_precision_eval.py`.
+
+**Step 1** &mdash; residual-error distribution. For each vector `x[i]` in a corpus, quantize at 2-bit, decode, and compute `err[i] = ||x[i] - x_hat[i]||_2 / ||x[i]||_2`. Examine the distribution shape (skewness, kurtosis) and cumulative error mass in the top-p% of vectors (tail-mass / Lorenz curve).
+
+**Gate.** If `mass_top_10pct` < 0.40, the tail is too flat for hybrid storage to help; stop.
+
+**Step 2** &mdash; recall benchmark (conditional on gate). Build a hybrid index:
+
+1. Compute per-vector 2-bit residual on the corpus.
+2. Top `k_pct` of vectors by residual &rarr; quantize at `high_bits` (4 or 8).
+3. Remaining vectors &rarr; quantize at 2-bit.
+4. ADC-score both tiers with the *same* Haar rotation; merge into a single score vector.
+
+Baselines: uniform 2-bit, uniform 3-bit, uniform 4-bit, uniform 8-bit. Recall@{10, 100} computed against exact inner-product ground truth on 200 held-out queries.
+
+**Verdict** uses linear interpolation on the uniform curve at the hybrid's average bits/vector. Hybrid &ldquo;ships&rdquo; if it beats the interpolated uniform R@10 by >2 points at matched bits/vector.
+
+## Corpora
+
+| Corpus | n | d | Source |
+|--------|---|---|--------|
+| Synthetic Gaussian | 10 000 | 768 | Unit-normalized standard normal &mdash; the ideal TurboQuant input distribution. |
+| SPECTER2 NLP-broad | 4 017 | 768 | Paper titles + abstracts from Semantic Scholar for &ldquo;natural language processing&rdquo;, encoded with `allenai/specter2_base`. |
+
+The SPECTER2 corpus is a superset of the [existing SPECTER2 case study](../specter2-case-study.md), which already established that this corpus has &sigma; &asymp; 0.38 &times; the expected post-rotation Gaussian &mdash; an interesting test because Lloyd-Max is misspecified, so quantization error might behave differently than on the synthetic baseline.
+
+## Step 1 results
+
+### Synthetic Gaussian (d=768, n=10 000)
+
+```
+Relative L2 error  (||x - x̂|| / ||x||):
+  min / median / mean / max : 0.3064 / 0.3421 / 0.3422 / 0.3827
+  std                       : 0.0094
+  p95 / p99                 : 0.3580 / 0.3657
+  skewness / excess kurt.   : 0.147 / 0.142
+
+Squared-error tail mass:
+  top  1%  →  0.012   (1.16x uniform)
+  top  5%  →  0.056   (1.12x uniform)
+  top 10%  →  0.110   (1.10x uniform)
+  top 20%  →  0.216   (1.08x uniform)
+```
+
+The residual distribution is **essentially uniform** over vectors. Top 10% carries 11% of total error mass, only 1.10&times; what a flat distribution would produce. Skewness (0.15) and excess kurtosis (0.14) are near-zero. This is the expected behavior under TurboQuant&rsquo;s design assumptions: a Haar rotation isotropizes the error, and Lloyd-Max bins are optimal for the matching N(0, 1/d) marginal, so no vector is much worse off than the mean.
+
+**Gate on synthetic: FAILS.** The tail is flat.
+
+### SPECTER2 NLP-broad (d=768, n=4 017)
+
+_(to be filled after encoding completes)_
+
+## Gate decision
+
+_(to be filled)_
+
+## Step 2 results
+
+_(to be filled)_
+
+## Verdict
+
+_(to be filled)_
+
+## What to take away
+
+_(to be filled)_
+
+## Reproducing
+
+```bash
+pip install -e ".[dev,bench]" transformers torch matplotlib
+
+# Fast path — synthetic only, always works
+python bench/hybrid_precision_eval.py --synthetic-only --plots
+
+# With SPECTER2 (first run downloads the model + fetches abstracts)
+python bench/specter2_eval.py --cached --skip-recall   # primes corpus cache
+python bench/hybrid_precision_eval.py --specter2 --plots
+
+# Full sweep matching the issue spec
+python bench/hybrid_precision_eval.py --specter2 --sweep --plots
+```
+
+Output artifacts:
+
+- `bench/plots/*.png` &mdash; residual histograms and Lorenz-style tail-mass curves.
+- `bench/hybrid_results/results_*.json` &mdash; structured Step 1 + Step 2 data for downstream analysis.


### PR DESCRIPTION
## Summary

- Implements the three-step investigation from #34: measure residual-error
  tail on 2-bit remex, gate on &gt;40% mass in top 10%, run hybrid-precision
  recall sweep vs uniform baselines.
- **Verdict: FILE.** The OjaKV hybrid-storage trick does not port to
  TurboQuant-style scalar quantization. Two independent failure modes.

## Findings

**Step 1 &mdash; residual distribution is near-flat on both corpora:**

| Corpus | top-1% mass | top-5% mass | top-10% mass | gate |
|---|---:|---:|---:|---|
| Synthetic Gaussian (n=10 000, d=768) | 0.012 | 0.056 | 0.110 (1.10&times; uniform) | FAIL |
| SPECTER2 NLP-broad (n=4 017, d=768) | 0.011 | 0.055 | 0.108 (1.08&times; uniform) | FAIL |

Skewness ~0.13&ndash;0.15, excess kurtosis ~0.13&ndash;0.14 &mdash; effectively
Gaussian across vectors. The Haar rotation + Lloyd-Max codebook is designed
to isotropize error; the flat tail is a success of that design.

**Step 2 &mdash; hybrid never beats uniform at matched bits/vector.** Run
under `--force-step2`:

- Synthetic: hybrid 4/2 loses 1.9&ndash;2.2 R@10 pts to the uniform curve
  (Matryoshka 4&rarr;2 nesting penalty); hybrid 8/2 loses 12.9&ndash;21.0
  pts (larger 8&rarr;2 nesting).
- SPECTER2: hybrid collapses to R@10 &asymp; `k_pct` &mdash; top 5% &rarr;
  0.059, top 10% &rarr; 0.100, top 20% &rarr; 0.179 (losses of
  40&ndash;52 pts vs interpolated uniform).

The SPECTER2 collapse is caused by a *second*, independent failure mode:
misspecified Lloyd-Max (post-rotation &sigma; is 38% of the N(0, 1/d)
assumption &mdash; already documented in the SPECTER2 case study) produces
a systematic &minus;10% downward bias in 2-bit dot-product scores.
4-bit/8-bit scores are nearly unbiased. Merging scores across precisions
therefore ranks *all* low-tier vectors below *all* high-tier ones regardless
of relevance.

## What changed

- `bench/hybrid_precision_eval.py` &mdash; new investigation harness: Step 1
  residual characterization, hypothesis gate, Step 2 recall sweep with
  uniform 2/3/4/8-bit baselines. Hybrid uses a single Matryoshka-nested
  Quantizer at `high_bits` so centroids are probability-consistent across
  tiers (scoring the low tier with two independent Lloyd-Max codebooks
  produces an even worse merge bias).
- `docs/research/hybrid-precision-quantization.md` &mdash; full writeup with
  per-tier score-bias diagnosis, sweep tables for both corpora, and
  recommendation to keep `search_twostage()` as the standard
  memory/recall trade-off.
- `bench/RESULTS.md` &mdash; new &ldquo;Research investigations&rdquo;
  section linking the writeup.

**No production code changes.** Hybrid scoring lives entirely in the bench
helper.

## Test plan

- [x] Step 1 on synthetic Gaussian (n=10 000, d=768)
- [x] Step 1 on SPECTER2 NLP-broad (n=4 017, d=768, encoded from
  Semantic Scholar abstracts)
- [x] Step 2 full sweep (k_pct&nbsp;&times;&nbsp;high_bits &isin;
  {5, 10, 20}&nbsp;&times;&nbsp;{4, 8}, low_bits=2) on both corpora
- [x] Residual histogram + Lorenz tail-mass plots generated
- [x] Structured results persisted to `bench/hybrid_results/*.json`

Reproduce:

```bash
python bench/hybrid_precision_eval.py --synthetic-only --plots       # fast
python bench/specter2_eval.py --cached --skip-recall                 # prime cache
python bench/hybrid_precision_eval.py --specter2 --sweep --plots     # full
```

Fixes #34.