### PR TITLE
Mojo port of Quantizer (encode + ADC search) — closes #5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@ build/
 *.npz
 bench/.specter2_cache/
 bench/plots/
+
+# Mojo build artifacts
+remex/mojo/polarquant
+remex/mojo/bench/bench_encode
+remex/mojo/bench/bench_search

--- a/README.md
+++ b/README.md
@@ -280,6 +280,27 @@ pytest tests/test_adc_gpu.py -v         # ADC and GPU searcher tests
 pytest tests/test_packed_vectors.py -v  # PackedVectors tests
 ```
 
+## Mojo port (`polarquant`)
+
+A standalone Mojo CLI binary lives in [`remex/mojo/`](remex/mojo/). It
+mirrors the encode + ADC search path with no Python runtime
+dependency, reading `.npy` corpus files directly and writing a small
+binary `.pq` container that the Python library can load via
+`remex.load_pq()` (and vice versa via `remex.save_pq()`).
+
+```bash
+cd remex/mojo
+mojo build -I . polarquant.mojo -o polarquant
+./polarquant encode corpus.npy --bits 4 --seed 42 -o corpus.pq
+./polarquant search corpus.pq query.npy --k 10 --seed 42
+```
+
+For bit-identical encoding to Python (matching rotations and
+codebook), use `--params P.bin` after dumping with
+`remex.save_params(quantizer, P)`. See
+[`remex/mojo/README.md`](remex/mojo/README.md) for build, test, and
+benchmark instructions.
+
 ## References
 
 - Zandieh et al. (2025). *TurboQuant: Online Vector Quantization with Near-optimal Distortion Rate.* ICLR 2026. [arXiv:2504.19874](https://arxiv.org/abs/2504.19874)

--- a/bench/RESULTS.md
+++ b/bench/RESULTS.md
@@ -130,6 +130,42 @@ See [docs/specter2-case-study.md](../docs/specter2-case-study.md) for full analy
 
 Float32 baseline: 1,536 bytes/vector, 15.36 MB per 10k vectors.
 
+## Mojo port (`polarquant`) vs NumPy
+
+Standalone Mojo binary built from `remex/mojo/` (see issue #5 / the
+Mojo port PR). The Python and Mojo paths use **different** rotations
+(NumPy `default_rng` PCG64 + Ziggurat vs Mojo xoshiro256++ +
+Marsaglia polar) — both are valid Haar samples; the encoding is
+algorithmically identical given matching parameters. With `--params`
+mode (Python dumps R + codebook, Mojo loads them), `polarquant
+encode` produces a `.pq` byte-identical to Python's
+`save_pq(quantizer.encode(X))`.
+
+Wall-clock (n=10k, d=384, bits=4, queries=50, k=10, container CPU):
+
+| Stage           | NumPy    | Mojo (this PR) | Mojo / NumPy |
+|-----------------|---------:|---------------:|-------------:|
+| encode (µs/vec) |    52.3  |          222.5 |        4.3x slower |
+| ADC search (ms/q) |  21.1  |            3.8 |        5.5x faster |
+
+Mojo ADC search wins because the gather-heavy inner loop is
+straight-line scalar code that LLVM optimizes well, while the
+equivalent NumPy is bottlenecked on `np.outer` and chunk-wise
+gathers. Mojo encode loses to NumPy because NumPy's `X @ R.T` calls
+into BLAS (vendor SIMD), while the Mojo port currently uses a
+naive scalar matvec — vectorizing it via `std.algorithm.vectorize`
+is the obvious follow-up.
+
+Reproduce:
+
+```bash
+cd remex/mojo
+mojo build -I . polarquant.mojo            -o polarquant
+mojo build -I . bench/bench_encode.mojo    -o bench/bench_encode
+mojo build -I . bench/bench_search.mojo    -o bench/bench_search
+python bench/compare.py --n 10000 --d 384 --bits 4 --queries 50 --k 10
+```
+
 ## Reproducibility
 
 All benchmarks can be reproduced with:

--- a/remex/__init__.py
+++ b/remex/__init__.py
@@ -17,6 +17,7 @@ import warnings
 from remex.core import Quantizer, CompressedVectors, PackedVectors
 from remex.codebook import lloyd_max_codebook, nested_codebooks
 from remex.packing import pack, unpack, packed_nbytes
+from remex.pq_format import save_pq, load_pq, save_params
 
 __version__ = "0.5.0"
 __all__ = [
@@ -24,6 +25,7 @@ __all__ = [
     "PolarQuantizer",  # deprecated alias
     "lloyd_max_codebook", "nested_codebooks",
     "pack", "unpack", "packed_nbytes",
+    "save_pq", "load_pq", "save_params",
 ]
 
 

--- a/remex/mojo/README.md
+++ b/remex/mojo/README.md
@@ -1,0 +1,137 @@
+# remex Mojo port (`polarquant`)
+
+A pure-Mojo port of the remex Quantizer's encode + ADC search path,
+shipped as a standalone CLI binary.
+
+Closes [issue #5](https://github.com/oaustegard/remex/issues/5).
+
+## What's here
+
+```
+remex/mojo/
+├── README.md                # This file
+├── polarquant.mojo          # CLI entrypoint (encode + search)
+├── src/
+│   ├── mathx.mojo           # erf-based normal CDF / PDF
+│   ├── rng.mojo             # xoshiro256++ + Marsaglia polar normal
+│   ├── matrix.mojo          # Owning Float32 / Float64 matrices
+│   ├── rotation.mojo        # Householder QR → Haar orthogonal matrix
+│   ├── codebook.mojo        # Lloyd-Max iteration on N(0, 1/d)
+│   ├── packing.mojo         # 1/2/3/4/8-bit pack and unpack
+│   ├── npy.mojo             # .npy reader (float32, 2D, C-contiguous)
+│   ├── pq_format.mojo       # .pq binary format read/write
+│   ├── params_format.mojo   # .params dump (R + boundaries + centroids)
+│   └── quantizer.mojo       # Quantizer struct: encode + ADC search
+├── tests/
+│   ├── test_rng.mojo
+│   ├── test_rotation.mojo
+│   ├── test_codebook.mojo
+│   ├── test_packing.mojo
+│   └── test_encode.mojo     # bit-identical encode parity vs Python
+└── bench/
+    ├── bench_encode.mojo
+    ├── bench_search.mojo
+    └── compare.py           # Mojo vs NumPy comparison driver
+```
+
+## Build
+
+The container needs the Mojo compiler (~500MB):
+
+```bash
+uv pip install --system --break-system-packages modular --no-deps
+uv pip install --system --break-system-packages mojo max
+```
+
+Build the CLI and the bench binaries:
+
+```bash
+cd remex/mojo
+mojo build -I . polarquant.mojo            -o polarquant
+mojo build -I . bench/bench_encode.mojo    -o bench/bench_encode
+mojo build -I . bench/bench_search.mojo    -o bench/bench_search
+```
+
+## CLI usage
+
+```bash
+# Encode an .npy of float32 vectors → .pq
+./polarquant encode corpus.npy --bits 4 --seed 42 -o corpus.pq
+
+# Search a single (1, d) query against a .pq, top-k
+./polarquant search corpus.pq query.npy --k 10 --seed 42 --top 10
+```
+
+The same `corpus.pq` round-trips through the Python library:
+
+```python
+from remex import load_pq, save_pq, Quantizer
+cv = load_pq("corpus.pq")            # works either way
+print(cv.n, cv.d, cv.bits, cv.compression_ratio)
+```
+
+## Two parameter modes — `--seed` vs `--params`
+
+The encode/search path needs (R, boundaries, centroids). The CLI
+provides those two ways:
+
+| Flag | Source of (R, codebook) | Bit-identical to a Python `Quantizer(seed=S)`? |
+|---|---|---|
+| `--seed S` | Computed in Mojo from S via xoshiro256++ + Householder QR + Lloyd-Max | **No.** Mojo uses xoshiro256++; Python uses NumPy's PCG64 + `default_rng`. The rotations are different but both are valid Haar samples. |
+| `--params P.bin` | Loaded from a file written by `remex.save_params(quantizer, P)` | **Yes.** Mojo's encoded `.pq` is byte-identical to Python's. |
+
+`--params` is what the parity test (`tests/test_encode.mojo`) uses. Use
+it when you want a Mojo-encoded index that the Python library can search
+into and recover the same neighbors as if Python had encoded the corpus
+itself. Use `--seed` for a fully self-contained Mojo workflow.
+
+## Tests
+
+```bash
+cd remex/mojo
+mojo run -I . tests/test_rng.mojo
+mojo run -I . tests/test_rotation.mojo
+mojo run -I . tests/test_codebook.mojo
+mojo run -I . tests/test_packing.mojo
+
+# Encode parity (requires Python remex installed and fixtures generated):
+python -c "
+import numpy as np
+from remex import Quantizer, save_pq, save_params
+np.random.seed(0)
+X = np.random.randn(50, 16).astype(np.float32)
+np.save('/tmp/_parity_X.npy', X)
+q = Quantizer(d=16, bits=4, seed=42)
+save_params('/tmp/_parity.params', q)
+save_pq('/tmp/_parity_ref.pq', q.encode(X))
+"
+mojo run -I . tests/test_encode.mojo
+```
+
+## Benchmarks
+
+```bash
+cd remex/mojo
+python bench/compare.py --n 10000 --d 384 --bits 4 --queries 100 --k 10
+```
+
+See `bench/RESULTS.md` (in this PR) for current numbers.
+
+## Notes / known gaps
+
+- **Encode is currently scalar.** The hot loop is a straightforward
+  per-row matvec + searchsorted; SIMD vectorization (via Mojo's
+  `vectorize`) is the obvious next step.
+- **No Matryoshka / no `search_twostage`.** Out of scope for issue #5.
+- **No GPU.** The `coding-mojo` skill notes Claude.ai containers are
+  CPU-only; GPU work needs to be tested on a different host.
+- **Seed parity** with NumPy's `default_rng` is not bit-identical (see
+  the table above). Implementing PCG64 + SeedSequence + Ziggurat in
+  Mojo to match NumPy exactly is a separate, substantial effort. The
+  `--params` file path is the practical bridge.
+- **UnsafePointer field aliasing.** Several spots copy struct-owned
+  buffers into a fresh local allocation before passing the pointer to
+  another function. Direct `struct.field[i]` reads through an
+  `UnsafePointer` field can return stale/garbage values for the first
+  one or two indices on Mojo 0.26.2 in this container. The copies are
+  flagged in comments where they happen.

--- a/remex/mojo/bench/bench_encode.mojo
+++ b/remex/mojo/bench/bench_encode.mojo
@@ -1,0 +1,69 @@
+"""Time encode_batch on a synthetic (n, d) corpus.
+
+Usage: bench_encode --n N --d D --bits B [--seed S]
+"""
+
+from std.sys import argv
+from std.time import perf_counter_ns
+from std.memory import alloc
+from src.codebook import lloyd_max_codebook
+from src.matrix import Matrix
+from src.quantizer import Quantizer, encode_batch
+from src.rotation import haar_rotation
+from src.rng import Xoshiro256pp
+
+
+def _arg_idx(args: List[String], flag: String) -> Int:
+    for i in range(len(args)):
+        if args[i] == flag:
+            return i
+    return -1
+
+
+def _flag_int(args: List[String], flag: String, default: Int) raises -> Int:
+    var i = _arg_idx(args, flag)
+    if i < 0:
+        return default
+    return Int(args[i + 1])
+
+
+def main() raises:
+    var args = argv()
+    var sub = List[String]()
+    for i in range(1, len(args)):
+        sub.append(String(args[i]))
+
+    var n = _flag_int(sub, String("--n"), 10000)
+    var d = _flag_int(sub, String("--d"), 384)
+    var bits = _flag_int(sub, String("--bits"), 4)
+    var seed = UInt64(_flag_int(sub, String("--seed"), 42))
+
+    print("bench_encode: n =", n, "d =", d, "bits =", bits)
+
+    # Synthesize standard-normal X
+    var rng = Xoshiro256pp(seed)
+    var X = alloc[Float32](n * d)
+    for i in range(n * d):
+        X[i] = Float32(rng.next_normal())
+
+    # Build quantizer (one-time setup, not timed)
+    var R = haar_rotation(d, seed)
+    var cb = lloyd_max_codebook(d, bits)
+    var q = Quantizer(R^, cb^, d, bits, seed)
+
+    var indices = alloc[UInt8](n * d)
+    var norms = alloc[Float32](n)
+
+    # Warmup
+    encode_batch(q, X, n, indices, norms)
+
+    var t0 = perf_counter_ns()
+    encode_batch(q, X, n, indices, norms)
+    var t1 = perf_counter_ns()
+    var dt_ns = Int(t1 - t0)
+    var us_per_vec = Float64(dt_ns) / Float64(n) / 1000.0
+    print("  encode time:", dt_ns / 1000000, "ms total,", us_per_vec, "us / vector")
+
+    X.free()
+    indices.free()
+    norms.free()

--- a/remex/mojo/bench/bench_search.mojo
+++ b/remex/mojo/bench/bench_search.mojo
@@ -1,0 +1,93 @@
+"""Time adc_search on a synthetic compressed corpus.
+
+Usage: bench_search --n N --d D --bits B --queries Q --k K [--seed S]
+"""
+
+from std.sys import argv
+from std.time import perf_counter_ns
+from std.memory import alloc
+from src.codebook import lloyd_max_codebook
+from src.matrix import Matrix
+from src.quantizer import Quantizer, encode_batch, adc_search
+from src.rotation import haar_rotation
+from src.rng import Xoshiro256pp
+
+
+def _arg_idx(args: List[String], flag: String) -> Int:
+    for i in range(len(args)):
+        if args[i] == flag:
+            return i
+    return -1
+
+
+def _flag_int(args: List[String], flag: String, default: Int) raises -> Int:
+    var i = _arg_idx(args, flag)
+    if i < 0:
+        return default
+    return Int(args[i + 1])
+
+
+def main() raises:
+    var args = argv()
+    var sub = List[String]()
+    for i in range(1, len(args)):
+        sub.append(String(args[i]))
+
+    var n = _flag_int(sub, String("--n"), 10000)
+    var d = _flag_int(sub, String("--d"), 384)
+    var bits = _flag_int(sub, String("--bits"), 4)
+    var queries = _flag_int(sub, String("--queries"), 100)
+    var k = _flag_int(sub, String("--k"), 10)
+    var seed = UInt64(_flag_int(sub, String("--seed"), 42))
+
+    print("bench_search: n =", n, "d =", d, "bits =", bits,
+          "queries =", queries, "k =", k)
+
+    # Build corpus
+    var rng = Xoshiro256pp(seed)
+    var X = alloc[Float32](n * d)
+    for i in range(n * d):
+        X[i] = Float32(rng.next_normal())
+
+    var R = haar_rotation(d, seed)
+    var cb = lloyd_max_codebook(d, bits)
+    var q = Quantizer(R^, cb^, d, bits, seed)
+
+    var indices = alloc[UInt8](n * d)
+    var norms = alloc[Float32](n)
+    encode_batch(q, X, n, indices, norms)
+    X.free()
+
+    # Build random queries
+    var Q_buf = alloc[Float32](queries * d)
+    for i in range(queries * d):
+        Q_buf[i] = Float32(rng.next_normal())
+
+    var top_idx = alloc[Int](k)
+    var top_scores = alloc[Float32](k)
+
+    # Warmup
+    var qbuf0 = alloc[Float32](d)
+    for j in range(d):
+        qbuf0[j] = Q_buf[j]
+    adc_search(q, indices, norms, n, qbuf0, k, top_idx, top_scores)
+    qbuf0.free()
+
+    var t0 = perf_counter_ns()
+    for qi in range(queries):
+        # Copy out the qi-th query
+        var qbuf = alloc[Float32](d)
+        for j in range(d):
+            qbuf[j] = Q_buf[qi * d + j]
+        adc_search(q, indices, norms, n, qbuf, k, top_idx, top_scores)
+        qbuf.free()
+    var t1 = perf_counter_ns()
+    var dt_ns = Int(t1 - t0)
+    var ms_per_q = Float64(dt_ns) / Float64(queries) / 1000000.0
+    print("  search time:", dt_ns / 1000000, "ms total,", ms_per_q, "ms / query")
+
+    indices.free()
+    norms.free()
+    Q_buf.free()
+    top_idx.free()
+    top_scores.free()

--- a/remex/mojo/bench/compare.py
+++ b/remex/mojo/bench/compare.py
@@ -1,0 +1,127 @@
+"""Mojo vs NumPy benchmark for remex encode + ADC search.
+
+Generates a synthetic standard-normal corpus, runs the same workload
+through (a) the Python `remex.Quantizer` and (b) the Mojo binary built
+from `polarquant.mojo`. Prints a comparison table.
+
+Usage:
+    python bench/compare.py [--n 10000] [--d 384] [--bits 4]
+                            [--queries 100] [--k 10]
+
+The Mojo binaries are expected at `bench/bench_encode` and
+`bench/bench_search` (build them with `mojo build`).
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+import numpy as np
+
+THIS_DIR = Path(__file__).resolve().parent
+MOJO_DIR = THIS_DIR.parent
+REPO_ROOT = MOJO_DIR.parents[1]
+
+
+def _run_mojo(binary: str, args: list[str]) -> str:
+    path = MOJO_DIR / "bench" / binary
+    if not path.exists():
+        raise FileNotFoundError(
+            f"{path} not found — build with `mojo build -I {MOJO_DIR} "
+            f"bench/{binary}.mojo -o bench/{binary}`"
+        )
+    out = subprocess.check_output([str(path), *args], cwd=MOJO_DIR, text=True)
+    return out
+
+
+def _parse_us_per_vec(out: str) -> float:
+    m = re.search(r"([0-9.]+)\s+us / vector", out)
+    if not m:
+        raise RuntimeError(f"could not parse encode timing from: {out!r}")
+    return float(m.group(1))
+
+
+def _parse_ms_per_query(out: str) -> float:
+    m = re.search(r"([0-9.]+)\s+ms / query", out)
+    if not m:
+        raise RuntimeError(f"could not parse search timing from: {out!r}")
+    return float(m.group(1))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--n", type=int, default=10000)
+    ap.add_argument("--d", type=int, default=384)
+    ap.add_argument("--bits", type=int, default=4)
+    ap.add_argument("--queries", type=int, default=100)
+    ap.add_argument("--k", type=int, default=10)
+    ap.add_argument("--seed", type=int, default=42)
+    args = ap.parse_args()
+
+    sys.path.insert(0, str(REPO_ROOT))
+    from remex import Quantizer
+
+    rng = np.random.default_rng(args.seed)
+    X = rng.standard_normal((args.n, args.d), dtype=np.float32)
+    Qs = rng.standard_normal((args.queries, args.d), dtype=np.float32)
+
+    # --- Python encode ---
+    pq = Quantizer(d=args.d, bits=args.bits, seed=args.seed)
+    # warmup
+    pq.encode(X[:16])
+    t0 = time.perf_counter()
+    cv = pq.encode(X)
+    py_encode_us_per_vec = (time.perf_counter() - t0) / args.n * 1e6
+
+    # --- Python ADC search ---
+    pq.search_adc(cv, Qs[0], k=args.k)  # warmup
+    t0 = time.perf_counter()
+    for q in Qs:
+        pq.search_adc(cv, q, k=args.k)
+    py_search_ms_per_q = (time.perf_counter() - t0) / args.queries * 1e3
+
+    # --- Mojo encode ---
+    out = _run_mojo("bench_encode", [
+        "--n", str(args.n), "--d", str(args.d),
+        "--bits", str(args.bits), "--seed", str(args.seed),
+    ])
+    mojo_encode_us_per_vec = _parse_us_per_vec(out)
+
+    # --- Mojo search ---
+    out = _run_mojo("bench_search", [
+        "--n", str(args.n), "--d", str(args.d),
+        "--bits", str(args.bits), "--queries", str(args.queries),
+        "--k", str(args.k), "--seed", str(args.seed),
+    ])
+    mojo_search_ms_per_q = _parse_ms_per_query(out)
+
+    print()
+    print(f"=== n={args.n}, d={args.d}, bits={args.bits} ===")
+    print(f"{'Stage':<12} {'NumPy':>14} {'Mojo':>14} {'Speedup':>10}")
+    print("-" * 54)
+    print(
+        f"{'encode (us)':<12} "
+        f"{py_encode_us_per_vec:>14.2f} {mojo_encode_us_per_vec:>14.2f} "
+        f"{py_encode_us_per_vec/mojo_encode_us_per_vec:>9.2f}x"
+    )
+    print(
+        f"{'search (ms)':<12} "
+        f"{py_search_ms_per_q:>14.3f} {mojo_search_ms_per_q:>14.3f} "
+        f"{py_search_ms_per_q/mojo_search_ms_per_q:>9.2f}x"
+    )
+    print()
+    print(
+        "Note: the Mojo and NumPy paths use *different* random rotations "
+        "(different RNGs from the same seed). The encoding is correct in "
+        "both cases; recall is the property to compare, not exact indices."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/remex/mojo/polarquant.mojo
+++ b/remex/mojo/polarquant.mojo
@@ -1,0 +1,204 @@
+"""polarquant CLI — Mojo port of the remex compress/search workflow.
+
+Usage:
+    polarquant encode <input.npy> --bits N [--seed S | --params P.bin] -o <out.pq>
+    polarquant search <index.pq> <query.npy> --k K [--seed S | --params P.bin]
+                       [--top <int>]
+
+`--seed S`   computes (R, codebook) from seed S in Mojo (not bit-identical to
+             a Python Quantizer with the same seed; see README).
+`--params P` loads (R, codebook) from a `.params` file written by
+             `remex.save_params(quantizer, path)` — bit-identical encoding.
+
+Outputs `index.pq`, the binary container readable by `remex.load_pq()`.
+"""
+
+from std.sys import argv
+from std.memory import alloc, UnsafePointer
+from src.codebook import Codebook, lloyd_max_codebook
+from src.matrix import Matrix
+from src.npy import load_npy_2d_f32
+from src.params_format import load_params
+from src.pq_format import save_pq, load_pq
+from src.quantizer import Quantizer, encode_batch, adc_search
+from src.packing import pack, packed_nbytes
+from src.rotation import haar_rotation
+
+
+def _arg_str(args: List[String], idx: Int) raises -> String:
+    if idx >= len(args):
+        raise Error("missing argument")
+    return args[idx]
+
+
+def _arg_idx(args: List[String], flag: String) -> Int:
+    for i in range(len(args)):
+        if args[i] == flag:
+            return i
+    return -1
+
+
+def _build_quantizer(d: Int, bits: Int, seed: UInt64,
+                     params_path: String) raises -> Quantizer:
+    if len(params_path) > 0:
+        var R = Matrix(d, d)
+        var cb = Codebook(bits)
+        load_params(params_path, R, cb)
+        return Quantizer(R^, cb^, d, bits, seed)
+    var R = haar_rotation(d, seed)
+    var cb = lloyd_max_codebook(d, bits)
+    return Quantizer(R^, cb^, d, bits, seed)
+
+
+def _print_usage():
+    print("usage:")
+    print("  polarquant encode <input.npy> --bits N (--seed S | --params P) -o <out.pq>")
+    print("  polarquant search <index.pq> <query.npy> --k K (--seed S | --params P) [--top T]")
+
+
+def cmd_encode(args: List[String]) raises:
+    """Encode subcommand: read .npy, encode, write .pq."""
+    if len(args) < 2:
+        _print_usage()
+        raise Error("encode: missing input.npy")
+    var input_path = args[1]
+
+    var bits_idx = _arg_idx(args, String("--bits"))
+    if bits_idx < 0:
+        raise Error("encode: --bits required")
+    var bits = Int(_arg_str(args, bits_idx + 1))
+
+    var seed_idx = _arg_idx(args, String("--seed"))
+    var params_idx = _arg_idx(args, String("--params"))
+    if seed_idx < 0 and params_idx < 0:
+        raise Error("encode: provide --seed or --params")
+    var seed: UInt64 = UInt64(42)
+    if seed_idx >= 0:
+        seed = UInt64(Int(_arg_str(args, seed_idx + 1)))
+    var params_path = String("")
+    if params_idx >= 0:
+        params_path = _arg_str(args, params_idx + 1)
+
+    var out_idx = _arg_idx(args, String("-o"))
+    if out_idx < 0:
+        raise Error("encode: -o <out.pq> required")
+    var out_path = _arg_str(args, out_idx + 1)
+
+    print("encode:", input_path, "→", out_path, "(bits =", bits, ")")
+    var X = load_npy_2d_f32(input_path)
+    var n = X.rows
+    var d = X.cols
+    print("  loaded", n, "vectors of dimension", d)
+
+    var q = _build_quantizer(d, bits, seed, params_path)
+
+    # Copy X into a fresh buffer (works around an UnsafePointer borrow oddity
+    # observed when passing struct fields across function boundaries).
+    var X_buf = alloc[Float32](n * d)
+    for i in range(n):
+        for j in range(d):
+            X_buf[i * d + j] = X.get(i, j)
+
+    var indices = alloc[UInt8](n * d)
+    var norms = alloc[Float32](n)
+    encode_batch(q, X_buf, n, indices, norms)
+    X_buf.free()
+
+    var nb = packed_nbytes(n * d, bits)
+    var packed = alloc[UInt8](nb)
+    pack(indices, n * d, bits, packed)
+    save_pq(out_path, packed, nb, norms, n, d, bits)
+    var total_bytes = nb + n * 4 + 32
+    var ratio = Float64(n * d * 4) / Float64(nb + n * 4)
+    print("  wrote", total_bytes, "bytes (compression ratio:", ratio, "x)")
+
+    indices.free()
+    norms.free()
+    packed.free()
+
+
+def cmd_search(args: List[String]) raises:
+    """Search subcommand: load .pq, score query, print top-k."""
+    if len(args) < 3:
+        _print_usage()
+        raise Error("search: missing index.pq or query.npy")
+    var index_path = args[1]
+    var query_path = args[2]
+
+    var k_idx = _arg_idx(args, String("--k"))
+    if k_idx < 0:
+        raise Error("search: --k required")
+    var k = Int(_arg_str(args, k_idx + 1))
+
+    var seed_idx = _arg_idx(args, String("--seed"))
+    var params_idx = _arg_idx(args, String("--params"))
+    if seed_idx < 0 and params_idx < 0:
+        raise Error("search: provide --seed or --params")
+    var seed: UInt64 = UInt64(42)
+    if seed_idx >= 0:
+        seed = UInt64(Int(_arg_str(args, seed_idx + 1)))
+    var params_path = String("")
+    if params_idx >= 0:
+        params_path = _arg_str(args, params_idx + 1)
+
+    var top_idx = _arg_idx(args, String("--top"))
+    var print_top = k
+    if top_idx >= 0:
+        print_top = Int(_arg_str(args, top_idx + 1))
+
+    var pq = load_pq(index_path)
+    var Q = load_npy_2d_f32(query_path)
+    if Q.rows != 1:
+        raise Error("search: query.npy must be a single (1, d) vector")
+    if Q.cols != pq.d:
+        raise Error("search: query d mismatch")
+
+    var q_quant = _build_quantizer(pq.d, pq.bits, seed, params_path)
+
+    # Unpack indices into uint8 (n*d). Copy norms into a fresh buffer too —
+    # see test_encode.mojo for the same workaround.
+    from src.packing import unpack
+    var indices = alloc[UInt8](pq.n * pq.d)
+    unpack(pq.packed_indices, pq.n * pq.d, pq.bits, indices)
+    var norms_local = alloc[Float32](pq.n)
+    for i in range(pq.n):
+        norms_local[i] = pq.norms[i]
+
+    # Copy query
+    var qbuf = alloc[Float32](pq.d)
+    for j in range(pq.d):
+        qbuf[j] = Q.get(0, j)
+
+    var top_idx_buf = alloc[Int](k)
+    var top_scores = alloc[Float32](k)
+    adc_search(q_quant, indices, norms_local, pq.n, qbuf, k, top_idx_buf, top_scores)
+
+    print("top", print_top, "results:")
+    var to_print = print_top if print_top <= k else k
+    for i in range(to_print):
+        print("  rank", i, ": idx =", top_idx_buf[i], " score =", top_scores[i])
+
+    qbuf.free()
+    indices.free()
+    norms_local.free()
+    top_idx_buf.free()
+    top_scores.free()
+
+
+def main() raises:
+    var args = argv()
+    if len(args) < 2:
+        _print_usage()
+        return
+    var cmd = String(args[1])
+    # Slice argv from position 1 forward as the subcommand's own argv.
+    var sub_args = List[String]()
+    for i in range(1, len(args)):
+        sub_args.append(String(args[i]))
+    if cmd == "encode":
+        cmd_encode(sub_args)
+    elif cmd == "search":
+        cmd_search(sub_args)
+    else:
+        _print_usage()
+        raise Error(String("unknown subcommand: ") + cmd)

--- a/remex/mojo/src/codebook.mojo
+++ b/remex/mojo/src/codebook.mojo
@@ -1,0 +1,98 @@
+"""Lloyd-Max scalar quantizer codebook for N(0, 1/d).
+
+Mirrors `remex.codebook.lloyd_max_codebook`. The Mojo version uses
+`+/-INF_SENTINEL = ±50` for the outer interval edges — far enough into
+the tails that cdf(±50*sigma) is 1.0/0.0 in float64.
+"""
+
+from std.math import sqrt
+from std.memory import alloc, UnsafePointer
+from src.mathx import normal_cdf, normal_pdf
+
+
+comptime N_ITER_DEFAULT = 300
+comptime INF_SENTINEL = 50.0  # any value where cdf(x*sigma) saturates
+
+
+struct Codebook(Movable):
+    """Holds a Lloyd-Max codebook for a fixed (d, bits)."""
+    var boundaries: UnsafePointer[Float32, MutExternalOrigin]   # length n_levels - 1
+    var centroids: UnsafePointer[Float32, MutExternalOrigin]    # length n_levels
+    var n_levels: Int
+    var bits: Int
+
+    def __init__(out self, bits: Int):
+        self.bits = bits
+        self.n_levels = 1 << bits
+        # Allocate centroids first; boundaries gets at least one slot.
+        self.centroids = alloc[Float32](self.n_levels)
+        var n_b = self.n_levels - 1
+        if n_b < 1:
+            n_b = 1
+        self.boundaries = alloc[Float32](n_b)
+
+    def get_centroid(self, j: Int) -> Float32:
+        return self.centroids[j]
+
+    def get_boundary(self, j: Int) -> Float32:
+        return self.boundaries[j]
+
+    def __del__(deinit self):
+        self.boundaries.free()
+        self.centroids.free()
+
+
+def lloyd_max_codebook(d: Int, bits: Int, n_iter: Int = N_ITER_DEFAULT) -> Codebook:
+    """Build a Lloyd-Max codebook for N(0, 1/d) coordinates."""
+    var n_levels = 1 << bits
+    var sigma = 1.0 / sqrt(Float64(d))
+    var sigma2 = sigma * sigma
+
+    # Float64 working buffers for numerical stability
+    var c = alloc[Float64](n_levels)
+    var b_lo = alloc[Float64](n_levels)
+    var b_hi = alloc[Float64](n_levels)
+
+    # Initialize centroids: linspace(-3*sigma, 3*sigma, n_levels)
+    if n_levels == 1:
+        c[0] = 0.0
+    else:
+        var lo = -3.0 * sigma
+        var hi = 3.0 * sigma
+        var step = (hi - lo) / Float64(n_levels - 1)
+        for i in range(n_levels):
+            c[i] = lo + Float64(i) * step
+
+    for _ in range(n_iter):
+        # Compute bounds
+        b_lo[0] = -INF_SENTINEL
+        b_hi[n_levels - 1] = INF_SENTINEL
+        for k in range(n_levels - 1):
+            var mid = Float64(0.5) * (c[k] + c[k + 1])
+            b_hi[k] = mid
+            b_lo[k + 1] = mid
+
+        # Update centroids: conditional mean on each interval
+        for j in range(n_levels):
+            var lo_ = b_lo[j]
+            var hi_ = b_hi[j]
+            var ca = normal_cdf(lo_, sigma)
+            var cdfb = normal_cdf(hi_, sigma)
+            var prob = cdfb - ca
+            if prob > Float64(1e-15):
+                var pa = normal_pdf(lo_, sigma)
+                var pb = normal_pdf(hi_, sigma)
+                var newc = sigma2 * (pa - pb) / prob
+                c[j] = newc
+
+    var cb = Codebook(bits)
+    for j in range(n_levels):
+        cb.centroids[j] = Float32(c[j])
+    for j in range(n_levels - 1):
+        var mid = Float64(0.5) * (c[j] + c[j + 1])
+        cb.boundaries[j] = Float32(mid)
+
+    c.free()
+    b_lo.free()
+    b_hi.free()
+    return cb^

--- a/remex/mojo/src/mathx.mojo
+++ b/remex/mojo/src/mathx.mojo
@@ -1,0 +1,39 @@
+"""Math helpers: standard normal CDF / PDF on N(0, sigma^2).
+
+The Lloyd-Max codebook iteration over N(0, 1/d) uses these. We implement
+them with the stdlib `erf` and `exp` so the Mojo binary stays pure with no
+SciPy/Python interop at runtime.
+"""
+
+from std.math import erf, exp, sqrt, pi
+
+
+comptime SQRT_2 = 1.4142135623730951
+comptime INV_SQRT_2PI = 0.3989422804014327  # 1 / sqrt(2*pi)
+
+
+def normal_cdf(x: Float64, sigma: Float64) -> Float64:
+    """CDF of N(0, sigma^2) at x."""
+    return 0.5 * (1.0 + erf(x / (sigma * SQRT_2)))
+
+
+def normal_pdf(x: Float64, sigma: Float64) -> Float64:
+    """PDF of N(0, sigma^2) at x."""
+    var z = x / sigma
+    return INV_SQRT_2PI / sigma * exp(-0.5 * z * z)
+
+
+def normal_truncated_mean(a: Float64, b: Float64, sigma: Float64) -> Float64:
+    """E[X | a < X <= b] for X ~ N(0, sigma^2).
+
+    Equals -sigma^2 * (pdf(b) - pdf(a)) / (cdf(b) - cdf(a)).
+    Used inside Lloyd-Max to recompute centroids from boundaries.
+    """
+    var pa = normal_pdf(a, sigma)
+    var pb = normal_pdf(b, sigma)
+    var ca = normal_cdf(a, sigma)
+    var cb = normal_cdf(b, sigma)
+    var denom = cb - ca
+    if denom < 1e-300:
+        return 0.5 * (a + b)
+    return -(sigma * sigma) * (pb - pa) / denom

--- a/remex/mojo/src/matrix.mojo
+++ b/remex/mojo/src/matrix.mojo
@@ -1,0 +1,61 @@
+"""Tiny owning Float32 / Float64 matrices in row-major order.
+
+Just enough to support the encode hot path. Indexing is unchecked; this
+is internal scaffolding, not a public collection.
+
+Note on origin: `MutExternalOrigin` marks the heap data as externally
+owned from Mojo's borrow-checker perspective; the struct's own `__del__`
+is responsible for freeing.
+"""
+
+from std.memory import alloc, UnsafePointer
+
+
+struct Matrix(Movable):
+    var data: UnsafePointer[Float32, MutExternalOrigin]
+    var rows: Int
+    var cols: Int
+
+    def __init__(out self, rows: Int, cols: Int):
+        self.rows = rows
+        self.cols = cols
+        self.data = alloc[Float32](rows * cols)
+        for i in range(rows * cols):
+            self.data[i] = Float32(0.0)
+
+    def __del__(deinit self):
+        self.data.free()
+
+    def get(self, i: Int, j: Int) -> Float32:
+        return self.data[i * self.cols + j]
+
+    def set(mut self, i: Int, j: Int, v: Float32):
+        self.data[i * self.cols + j] = v
+
+
+struct MatrixF64(Movable):
+    var data: UnsafePointer[Float64, MutExternalOrigin]
+    var rows: Int
+    var cols: Int
+
+    def __init__(out self, rows: Int, cols: Int):
+        self.rows = rows
+        self.cols = cols
+        self.data = alloc[Float64](rows * cols)
+        for i in range(rows * cols):
+            self.data[i] = Float64(0.0)
+
+    def __del__(deinit self):
+        self.data.free()
+
+    def get(self, i: Int, j: Int) -> Float64:
+        return self.data[i * self.cols + j]
+
+    def set(mut self, i: Int, j: Int, v: Float64):
+        self.data[i * self.cols + j] = v
+
+    def to_float32(self) -> Matrix:
+        var out = Matrix(self.rows, self.cols)
+        for i in range(self.rows * self.cols):
+            out.data[i] = Float32(self.data[i])
+        return out^

--- a/remex/mojo/src/npy.mojo
+++ b/remex/mojo/src/npy.mojo
@@ -1,0 +1,188 @@
+"""Minimal .npy reader for 2D float32, C-contiguous arrays.
+
+Spec: https://numpy.org/doc/stable/reference/generated/numpy.lib.format.html
+
+We support v1.0 and v2.0 magic headers, dtype='<f4' (little-endian
+float32), fortran_order=False, ndim=2. Anything else raises an error.
+"""
+
+from std.pathlib import Path
+from std.memory import alloc, UnsafePointer
+
+
+struct Npy2D(Movable):
+    """Owning buffer of a (rows, cols) float32 array loaded from .npy."""
+    var data: UnsafePointer[Float32, MutExternalOrigin]
+    var rows: Int
+    var cols: Int
+
+    def __init__(out self, rows: Int, cols: Int):
+        self.rows = rows
+        self.cols = cols
+        self.data = alloc[Float32](rows * cols)
+
+    def __del__(deinit self):
+        self.data.free()
+
+    def get(self, i: Int, j: Int) -> Float32:
+        return self.data[i * self.cols + j]
+
+
+def _byte_str(s: String, p: Int) raises -> String:
+    """Return s[p] as a 1-char ASCII String."""
+    return chr(Int(s.as_bytes()[p]))
+
+
+def _parse_int(s: String, mut pos: Int) raises -> Int:
+    """Parse a non-negative integer starting at `pos` in `s`. Advances pos."""
+    var v: Int = 0
+    var found: Bool = False
+    while pos < len(s):
+        var ch = _byte_str(s, pos)
+        if ch >= "0" and ch <= "9":
+            v = v * 10 + (Int(ord(ch)) - Int(ord("0")))
+            pos += 1
+            found = True
+        else:
+            break
+    if not found:
+        raise Error("expected integer in .npy header")
+    return v
+
+
+def _find_quoted(s: String, key: String) raises -> String:
+    """Find a single-quoted string value associated with `'key'`."""
+    var marker = String("'") + key + String("'")
+    var idx = s.find(marker)
+    if idx < 0:
+        raise Error(String("missing '") + key + String("' in .npy header"))
+    # Skip ahead to ':' then to opening quote
+    var p = idx + len(marker)
+    while p < len(s) and _byte_str(s, p) != ":":
+        p += 1
+    p += 1
+    while p < len(s) and _byte_str(s, p) != "'":
+        p += 1
+    if p >= len(s):
+        raise Error("malformed .npy header (no opening quote for value)")
+    p += 1
+    var start = p
+    while p < len(s) and _byte_str(s, p) != "'":
+        p += 1
+    if p >= len(s):
+        raise Error("malformed .npy header (no closing quote for value)")
+    var out = String("")
+    for k in range(start, p):
+        out += _byte_str(s, k)
+    return out
+
+
+def _find_bool(s: String, key: String) raises -> Bool:
+    var marker = String("'") + key + String("':")
+    var idx = s.find(marker)
+    if idx < 0:
+        raise Error(String("missing '") + key + String("' in .npy header"))
+    var p = idx + len(marker)
+    while p < len(s) and _byte_str(s, p) == " ":
+        p += 1
+    # Look for True/False
+    if p + 4 <= len(s):
+        var four = String("")
+        for k in range(p, p + 4):
+            four += _byte_str(s, k)
+        if four == "True":
+            return True
+    if p + 5 <= len(s):
+        var five = String("")
+        for k in range(p, p + 5):
+            five += _byte_str(s, k)
+        if five == "False":
+            return False
+    raise Error(String("could not parse '") + key + String("' value"))
+
+
+def _parse_shape(s: String, mut rows: Int, mut cols: Int) raises:
+    """Parse the shape tuple, store rows/cols. Requires 2D."""
+    var marker = String("'shape':")
+    var idx = s.find(marker)
+    if idx < 0:
+        raise Error("missing 'shape' in .npy header")
+    var p = idx + len(marker)
+    while p < len(s) and _byte_str(s, p) != "(":
+        p += 1
+    if p >= len(s):
+        raise Error("malformed shape (no '(')")
+    p += 1
+    while p < len(s) and _byte_str(s, p) == " ":
+        p += 1
+    rows = _parse_int(s, p)
+    while p < len(s) and _byte_str(s, p) != ",":
+        p += 1
+    if p >= len(s):
+        raise Error("expected 2D array (got 1D shape)")
+    p += 1
+    while p < len(s) and _byte_str(s, p) == " ":
+        p += 1
+    if _byte_str(s, p) == ")":
+        raise Error("expected 2D array, got 1D")
+    cols = _parse_int(s, p)
+
+
+def load_npy_2d_f32(path: String) raises -> Npy2D:
+    """Load a 2D float32 C-contiguous .npy file."""
+    var raw = Path(path).read_bytes()
+    if len(raw) < 10:
+        raise Error("file too small to be .npy")
+    # Magic: \x93 N U M P Y
+    if (Int(raw[0]) != 0x93 or Int(raw[1]) != Int(ord("N")) or
+            Int(raw[2]) != Int(ord("U")) or Int(raw[3]) != Int(ord("M")) or
+            Int(raw[4]) != Int(ord("P")) or Int(raw[5]) != Int(ord("Y"))):
+        raise Error("bad .npy magic")
+    var major = Int(raw[6])
+    var header_len: Int
+    var data_offset: Int
+    if major == 1:
+        header_len = Int(raw[8]) | (Int(raw[9]) << 8)
+        data_offset = 10 + header_len
+    elif major == 2 or major == 3:
+        if len(raw) < 12:
+            raise Error("file too small for v2.0/3.0 header")
+        header_len = (
+            Int(raw[8])
+            | (Int(raw[9]) << 8)
+            | (Int(raw[10]) << 16)
+            | (Int(raw[11]) << 24)
+        )
+        data_offset = 12 + header_len
+    else:
+        raise Error("unsupported .npy version (need 1.x, 2.x, or 3.x)")
+
+    # Decode header (ASCII)
+    var header_offset = data_offset - header_len
+    var header = String("")
+    for i in range(header_offset, header_offset + header_len):
+        header += chr(Int(raw[i]))
+
+    var dtype = _find_quoted(header, "descr")
+    if dtype != "<f4" and dtype != "|f4" and dtype != "=f4":
+        raise Error(String("only float32 (<f4) supported, got dtype=") + dtype)
+
+    var fortran = _find_bool(header, "fortran_order")
+    if fortran:
+        raise Error(".npy must be C-contiguous (fortran_order=False)")
+
+    var rows: Int = 0
+    var cols: Int = 0
+    _parse_shape(header, rows, cols)
+    var n = rows * cols
+    var expected_bytes = data_offset + n * 4
+    if len(raw) < expected_bytes:
+        raise Error("truncated .npy data section")
+
+    var out = Npy2D(rows, cols)
+    # Copy float32 data little-endian (assume host is little-endian, which
+    # is true on x86/ARM64). Reinterpret bytes 4 at a time.
+    var bp = out.data.bitcast[UInt8]()
+    for i in range(n * 4):
+        bp[i] = raw[data_offset + i]
+    return out^

--- a/remex/mojo/src/packing.mojo
+++ b/remex/mojo/src/packing.mojo
@@ -1,0 +1,144 @@
+"""Bit-packing for sub-byte indices. Mirrors `remex/packing.py` exactly.
+
+Supported widths: 1, 2, 3, 4, 8 bits. 5-7 are rejected.
+
+For 1-bit, MSB-first ordering matches `np.packbits` default.
+"""
+
+from std.memory import alloc, UnsafePointer
+
+
+def packed_nbytes(n_values: Int, bits: Int) raises -> Int:
+    """Bytes required to pack `n_values` indices at the given width."""
+    if bits == 8:
+        return n_values
+    if bits == 4:
+        return (n_values + 1) // 2
+    if bits == 2:
+        return (n_values + 3) // 4
+    if bits == 1:
+        return (n_values + 7) // 8
+    if bits == 3:
+        return ((n_values + 7) // 8) * 3
+    raise Error("bits must be 1, 2, 3, 4, or 8 (5-7 unsupported)")
+
+
+def pack(values: UnsafePointer[UInt8, MutExternalOrigin], n: Int, bits: Int,
+         mut out: UnsafePointer[UInt8, MutExternalOrigin]) raises:
+    """Pack `n` uint8 indices from `values` into `out` (size = packed_nbytes(n, bits))."""
+    if bits == 8:
+        for i in range(n):
+            out[i] = values[i]
+        return
+
+    if bits == 4:
+        var nb = (n + 1) // 2
+        for i in range(nb):
+            var hi = values[2 * i]
+            var lo: UInt8 = UInt8(0)
+            if 2 * i + 1 < n:
+                lo = values[2 * i + 1]
+            out[i] = (hi << 4) | lo
+        return
+
+    if bits == 2:
+        var nb = (n + 3) // 4
+        for i in range(nb):
+            var v0 = values[4 * i] if 4 * i < n else UInt8(0)
+            var v1 = values[4 * i + 1] if 4 * i + 1 < n else UInt8(0)
+            var v2 = values[4 * i + 2] if 4 * i + 2 < n else UInt8(0)
+            var v3 = values[4 * i + 3] if 4 * i + 3 < n else UInt8(0)
+            out[i] = (v0 << 6) | (v1 << 4) | (v2 << 2) | v3
+        return
+
+    if bits == 1:
+        var nb = (n + 7) // 8
+        for i in range(nb):
+            var b: UInt8 = UInt8(0)
+            for k in range(8):
+                var idx = 8 * i + k
+                if idx < n:
+                    b |= (values[idx] & UInt8(1)) << UInt8(7 - k)
+            out[i] = b
+        return
+
+    if bits == 3:
+        var ng = (n + 7) // 8     # number of 8-value groups
+        for g in range(ng):
+            var v = InlineArray[UInt8, 8](fill=UInt8(0))
+            for k in range(8):
+                var idx = 8 * g + k
+                if idx < n:
+                    v[k] = values[idx]
+            # Byte 0: [v0:3][v1:3][v2:2hi]
+            out[3 * g] = (v[0] << 5) | (v[1] << 2) | (v[2] >> 1)
+            # Byte 1: [v2:1lo][v3:3][v4:3][v5:1hi]
+            out[3 * g + 1] = ((v[2] & UInt8(1)) << 7) | (v[3] << 4) | (v[4] << 1) | (v[5] >> 2)
+            # Byte 2: [v5:2lo][v6:3][v7:3]
+            out[3 * g + 2] = ((v[5] & UInt8(3)) << 6) | (v[6] << 3) | v[7]
+        return
+
+    raise Error("bits must be 1, 2, 3, 4, or 8 (5-7 unsupported)")
+
+
+def unpack(packed: UnsafePointer[UInt8, MutExternalOrigin],
+           n_values: Int, bits: Int,
+           mut out: UnsafePointer[UInt8, MutExternalOrigin]) raises:
+    """Unpack `n_values` indices from `packed` into `out`."""
+    if bits == 8:
+        for i in range(n_values):
+            out[i] = packed[i]
+        return
+
+    if bits == 4:
+        for i in range(n_values):
+            var byte = packed[i // 2]
+            if i % 2 == 0:
+                out[i] = (byte >> 4) & UInt8(0x0F)
+            else:
+                out[i] = byte & UInt8(0x0F)
+        return
+
+    if bits == 2:
+        for i in range(n_values):
+            var byte = packed[i // 4]
+            var slot = i % 4
+            if slot == 0:
+                out[i] = (byte >> 6) & UInt8(0x03)
+            elif slot == 1:
+                out[i] = (byte >> 4) & UInt8(0x03)
+            elif slot == 2:
+                out[i] = (byte >> 2) & UInt8(0x03)
+            else:
+                out[i] = byte & UInt8(0x03)
+        return
+
+    if bits == 1:
+        for i in range(n_values):
+            var byte = packed[i // 8]
+            var bit = 7 - (i % 8)
+            out[i] = (byte >> UInt8(bit)) & UInt8(1)
+        return
+
+    if bits == 3:
+        var ng = (n_values + 7) // 8
+        for g in range(ng):
+            var b0 = packed[3 * g]
+            var b1 = packed[3 * g + 1]
+            var b2 = packed[3 * g + 2]
+            var v = InlineArray[UInt8, 8](fill=UInt8(0))
+            v[0] = (b0 >> 5) & UInt8(0x07)
+            v[1] = (b0 >> 2) & UInt8(0x07)
+            v[2] = ((b0 & UInt8(0x03)) << 1) | ((b1 >> 7) & UInt8(0x01))
+            v[3] = (b1 >> 4) & UInt8(0x07)
+            v[4] = (b1 >> 1) & UInt8(0x07)
+            v[5] = ((b1 & UInt8(0x01)) << 2) | ((b2 >> 6) & UInt8(0x03))
+            v[6] = (b2 >> 3) & UInt8(0x07)
+            v[7] = b2 & UInt8(0x07)
+            for k in range(8):
+                var idx = 8 * g + k
+                if idx < n_values:
+                    out[idx] = v[k]
+        return
+
+    raise Error("bits must be 1, 2, 3, 4, or 8 (5-7 unsupported)")

--- a/remex/mojo/src/params_format.mojo
+++ b/remex/mojo/src/params_format.mojo
@@ -1,0 +1,125 @@
+"""`.params` file: dump of (R, boundaries, centroids) so a Mojo binary can
+encode / search using the *exact* parameters a Python `remex.Quantizer`
+would use. Lets us write tests that assert bit-identical encode output.
+
+Layout (little-endian):
+  bytes 0-3   : magic 'PR\x00\x01'
+  bytes 4-7   : d (u32)
+  byte 8      : bits (u8)
+  bytes 9-15  : reserved (zero)
+  bytes 16+   : R              (d * d float32 row-major)
+  then        : boundaries     ((n_levels - 1) float32)
+  then        : centroids      (n_levels float32)
+"""
+
+from std.pathlib import Path
+from std.memory import alloc, UnsafePointer
+from src.codebook import Codebook
+from src.matrix import Matrix
+
+
+comptime PARAMS_HEADER_BYTES = 16
+comptime PARAMS_VERSION: UInt8 = 1
+
+
+def _u32_le(buf: UnsafePointer[UInt8, MutExternalOrigin], off: Int) -> Int:
+    return (
+        Int(buf[off])
+        | (Int(buf[off + 1]) << 8)
+        | (Int(buf[off + 2]) << 16)
+        | (Int(buf[off + 3]) << 24)
+    )
+
+
+def load_params(path: String, mut R_out: Matrix, mut cb_out: Codebook) raises:
+    """Read R, boundaries, centroids from a .params file into the given outputs.
+
+    `R_out` must be (d, d) and `cb_out` must have matching `bits` already.
+    """
+    var raw = Path(path).read_bytes()
+    if len(raw) < PARAMS_HEADER_BYTES:
+        raise Error(".params file too small")
+
+    var owned = alloc[UInt8](len(raw))
+    for i in range(len(raw)):
+        owned[i] = raw[i]
+
+    if Int(owned[0]) != Int(ord("P")) or Int(owned[1]) != Int(ord("R")):
+        owned.free()
+        raise Error("bad .params magic")
+    if Int(owned[3]) != Int(PARAMS_VERSION):
+        owned.free()
+        raise Error("unsupported .params version")
+
+    var d = _u32_le(owned, 4)
+    var bits = Int(owned[8])
+    if d != R_out.rows or d != R_out.cols:
+        owned.free()
+        raise Error("R shape mismatch")
+    if bits != cb_out.bits:
+        owned.free()
+        raise Error("bits mismatch")
+
+    var n_levels = 1 << bits
+    var R_bytes = d * d * 4
+    var b_bytes = (n_levels - 1) * 4
+    var c_bytes = n_levels * 4
+    var expected = PARAMS_HEADER_BYTES + R_bytes + b_bytes + c_bytes
+    if len(raw) < expected:
+        owned.free()
+        raise Error("truncated .params data")
+
+    # Copy R
+    var R_dst = R_out.data.bitcast[UInt8]()
+    var R_off = PARAMS_HEADER_BYTES
+    for i in range(R_bytes):
+        R_dst[i] = owned[R_off + i]
+
+    var b_dst = cb_out.boundaries.bitcast[UInt8]()
+    var b_off = R_off + R_bytes
+    for i in range(b_bytes):
+        b_dst[i] = owned[b_off + i]
+
+    var c_dst = cb_out.centroids.bitcast[UInt8]()
+    var c_off = b_off + b_bytes
+    for i in range(c_bytes):
+        c_dst[i] = owned[c_off + i]
+
+    owned.free()
+
+
+def save_params(path: String, R: Matrix, cb: Codebook) raises:
+    """Write (R, boundaries, centroids) to a .params file."""
+    var d = R.rows
+    var bits = cb.bits
+    var n_levels = cb.n_levels
+    var R_bytes = d * d * 4
+    var b_bytes = (n_levels - 1) * 4
+    var c_bytes = n_levels * 4
+    var total = PARAMS_HEADER_BYTES + R_bytes + b_bytes + c_bytes
+
+    var buf = alloc[UInt8](total)
+    for i in range(PARAMS_HEADER_BYTES):
+        buf[i] = UInt8(0)
+    buf[0] = UInt8(0x50)  # 'P'
+    buf[1] = UInt8(0x52)  # 'R'
+    buf[3] = PARAMS_VERSION
+    buf[4] = UInt8(d & 0xFF)
+    buf[5] = UInt8((d >> 8) & 0xFF)
+    buf[6] = UInt8((d >> 16) & 0xFF)
+    buf[7] = UInt8((d >> 24) & 0xFF)
+    buf[8] = UInt8(bits)
+
+    var R_src = R.data.bitcast[UInt8]()
+    for i in range(R_bytes):
+        buf[PARAMS_HEADER_BYTES + i] = R_src[i]
+    var b_src = cb.boundaries.bitcast[UInt8]()
+    for i in range(b_bytes):
+        buf[PARAMS_HEADER_BYTES + R_bytes + i] = b_src[i]
+    var c_src = cb.centroids.bitcast[UInt8]()
+    for i in range(c_bytes):
+        buf[PARAMS_HEADER_BYTES + R_bytes + b_bytes + i] = c_src[i]
+
+    var span = Span[UInt8, MutExternalOrigin](ptr=buf, length=total)
+    Path(path).write_bytes(span)
+    buf.free()

--- a/remex/mojo/src/pq_format.mojo
+++ b/remex/mojo/src/pq_format.mojo
@@ -1,0 +1,138 @@
+"""`.pq` file format: simple binary container for compressed vectors.
+
+Layout (all little-endian):
+  bytes 0-1   : magic 'PQ' (0x50, 0x51)
+  byte 2      : reserved (0)
+  byte 3      : version (=1)
+  bytes 4-7   : d (u32)
+  bytes 8-15  : n (u64)
+  byte 16     : bits (u8)
+  bytes 17-31 : reserved (15 zero bytes) — header padded to 32 bytes
+  bytes 32+   : packed_indices (length = packed_nbytes(n*d, bits))
+  then        : norms (n × float32)
+
+The Python side mirrors this in `remex.pq_format.{save_pq, load_pq}`.
+"""
+
+from std.pathlib import Path
+from std.memory import alloc, UnsafePointer
+from src.packing import packed_nbytes
+
+
+comptime PQ_HEADER_BYTES = 32
+comptime PQ_VERSION: UInt8 = 1
+
+
+struct PqVectors(Movable):
+    """In-memory container for a loaded .pq file."""
+    var packed_indices: UnsafePointer[UInt8, MutExternalOrigin]
+    var norms: UnsafePointer[Float32, MutExternalOrigin]
+    var n: Int
+    var d: Int
+    var bits: Int
+    var packed_bytes: Int
+
+    def __init__(out self, n: Int, d: Int, bits: Int) raises:
+        self.n = n
+        self.d = d
+        self.bits = bits
+        self.packed_bytes = packed_nbytes(n * d, bits)
+        self.packed_indices = alloc[UInt8](self.packed_bytes)
+        self.norms = alloc[Float32](n)
+
+    def __del__(deinit self):
+        self.packed_indices.free()
+        self.norms.free()
+
+
+def _u32_le(buf: UnsafePointer[UInt8, MutExternalOrigin], off: Int) -> Int:
+    return (
+        Int(buf[off])
+        | (Int(buf[off + 1]) << 8)
+        | (Int(buf[off + 2]) << 16)
+        | (Int(buf[off + 3]) << 24)
+    )
+
+
+def _u64_le(buf: UnsafePointer[UInt8, MutExternalOrigin], off: Int) -> Int:
+    var v: Int = 0
+    for k in range(8):
+        v |= Int(buf[off + k]) << (8 * k)
+    return v
+
+
+def save_pq(path: String,
+            packed_indices: UnsafePointer[UInt8, MutExternalOrigin], packed_bytes: Int,
+            norms: UnsafePointer[Float32, MutExternalOrigin], n: Int,
+            d: Int, bits: Int) raises:
+    """Write a .pq file."""
+    var total = PQ_HEADER_BYTES + packed_bytes + n * 4
+    var buf = alloc[UInt8](total)
+    # Zero header
+    for i in range(PQ_HEADER_BYTES):
+        buf[i] = UInt8(0)
+    buf[0] = UInt8(0x50)  # 'P'
+    buf[1] = UInt8(0x51)  # 'Q'
+    buf[2] = UInt8(0)
+    buf[3] = PQ_VERSION
+    # d (u32 LE) at offset 4
+    buf[4] = UInt8(d & 0xFF)
+    buf[5] = UInt8((d >> 8) & 0xFF)
+    buf[6] = UInt8((d >> 16) & 0xFF)
+    buf[7] = UInt8((d >> 24) & 0xFF)
+    # n (u64 LE) at offset 8
+    for k in range(8):
+        buf[8 + k] = UInt8((n >> (8 * k)) & 0xFF)
+    # bits at offset 16
+    buf[16] = UInt8(bits)
+
+    # packed indices
+    for i in range(packed_bytes):
+        buf[PQ_HEADER_BYTES + i] = packed_indices[i]
+
+    # norms (float32 LE)
+    var norms_bytes = norms.bitcast[UInt8]()
+    var norm_off = PQ_HEADER_BYTES + packed_bytes
+    for i in range(n * 4):
+        buf[norm_off + i] = norms_bytes[i]
+
+    # Convert to List[UInt8] and write via Path.write_bytes
+    var span = Span[UInt8, MutExternalOrigin](ptr=buf, length=total)
+    Path(path).write_bytes(span)
+    buf.free()
+
+
+def load_pq(path: String) raises -> PqVectors:
+    """Read a .pq file."""
+    var raw = Path(path).read_bytes()
+    if len(raw) < PQ_HEADER_BYTES:
+        raise Error(".pq file too small")
+    if Int(raw[0]) != 0x50 or Int(raw[1]) != 0x51:
+        raise Error("bad .pq magic")
+    if Int(raw[3]) != Int(PQ_VERSION):
+        raise Error("unsupported .pq version")
+
+    # Copy the raw bytes into an owned buffer for pointer arithmetic.
+    var owned = alloc[UInt8](len(raw))
+    for i in range(len(raw)):
+        owned[i] = raw[i]
+
+    var d = _u32_le(owned, 4)
+    var n = _u64_le(owned, 8)
+    var bits = Int(owned[16])
+
+    var pq = PqVectors(n, d, bits)
+    var expected = PQ_HEADER_BYTES + pq.packed_bytes + n * 4
+    if len(raw) < expected:
+        owned.free()
+        raise Error("truncated .pq data")
+
+    for i in range(pq.packed_bytes):
+        pq.packed_indices[i] = owned[PQ_HEADER_BYTES + i]
+    var norms_bytes = pq.norms.bitcast[UInt8]()
+    var norm_off = PQ_HEADER_BYTES + pq.packed_bytes
+    for i in range(n * 4):
+        norms_bytes[i] = owned[norm_off + i]
+
+    owned.free()
+    return pq^

--- a/remex/mojo/src/quantizer.mojo
+++ b/remex/mojo/src/quantizer.mojo
@@ -1,0 +1,159 @@
+"""Quantizer: encode + ADC search.
+
+Mirrors `remex.core.Quantizer` for the data-oblivious encode/search path.
+The encode kernel fuses rotation and per-coordinate quantization in a
+single pass per row. The search uses an ADC-style score table keyed by
+the rotated query and the codebook centroids.
+"""
+
+from std.math import sqrt
+from std.memory import alloc, UnsafePointer
+from src.codebook import Codebook, lloyd_max_codebook
+from src.matrix import Matrix
+from src.rotation import haar_rotation
+from src.packing import pack, packed_nbytes
+
+
+def _searchsorted(boundaries: UnsafePointer[Float32, MutExternalOrigin],
+                  n_b: Int, x: Float32) -> Int:
+    """numpy-default 'left' binary search: smallest i such that x < boundaries[i],
+    or n_b if x >= boundaries[n_b-1]. Result is in [0, n_b]."""
+    var lo = 0
+    var hi = n_b
+    while lo < hi:
+        var mid = (lo + hi) >> 1
+        if x < boundaries[mid]:
+            hi = mid
+        else:
+            lo = mid + 1
+    return lo
+
+
+struct Quantizer(Movable):
+    var R: Matrix
+    var cb: Codebook
+    var d: Int
+    var bits: Int
+    var seed: UInt64
+
+    def __init__(out self, d: Int, bits: Int, seed: UInt64):
+        self.d = d
+        self.bits = bits
+        self.seed = seed
+        self.R = haar_rotation(d, seed)
+        self.cb = lloyd_max_codebook(d, bits)
+
+    def __init__(out self, var R: Matrix, var cb: Codebook,
+                 d: Int, bits: Int, seed: UInt64):
+        """Construct from already-built parameters (used when loading from disk)."""
+        self.R = R^
+        self.cb = cb^
+        self.d = d
+        self.bits = bits
+        self.seed = seed
+
+
+def encode_batch(q: Quantizer,
+                 X: UnsafePointer[Float32, MutExternalOrigin],
+                 n: Int,
+                 mut indices_out: UnsafePointer[UInt8, MutExternalOrigin],
+                 mut norms_out: UnsafePointer[Float32, MutExternalOrigin]) raises:
+    """Encode `n` rows of (n, d) float32 X into uint8 indices_out (n, d) and norms_out (n,).
+
+    Hot path: per row, compute norm, normalize, rotate, searchsorted into boundaries.
+    The rotated coordinates live in a stack/heap buffer per row — never
+    materialized as an (n, d) intermediate.
+    """
+    var d = q.d
+    var n_b = q.cb.n_levels - 1
+    var rotated = alloc[Float32](d)
+    for i in range(n):
+        var base = i * d
+        var nm: Float32 = Float32(0.0)
+        for j in range(d):
+            var v: Float32 = X[base + j]
+            nm += v * v
+        nm = sqrt(nm)
+        norms_out[i] = nm
+        var inv = Float32(1.0) / nm if nm > Float32(1e-8) else Float32(1.0 / 1e-8)
+
+        # Rotate: rotated[k] = sum_j R[k, j] * (X[i, j] / nm)
+        # Inlined to avoid an extra normalized buffer.
+        for k in range(d):
+            var s: Float32 = Float32(0.0)
+            var rrow = k * d
+            for j in range(d):
+                s += q.R.data[rrow + j] * X[base + j]
+            rotated[k] = s * inv
+
+        # Searchsorted per coordinate
+        for k in range(d):
+            indices_out[base + k] = UInt8(_searchsorted(q.cb.boundaries, n_b, rotated[k]))
+    rotated.free()
+
+
+def adc_search(q: Quantizer,
+               indices: UnsafePointer[UInt8, MutExternalOrigin],
+               norms: UnsafePointer[Float32, MutExternalOrigin],
+               n: Int,
+               query: UnsafePointer[Float32, MutExternalOrigin],
+               k: Int,
+               mut top_idx: UnsafePointer[Int, MutExternalOrigin],
+               mut top_scores: UnsafePointer[Float32, MutExternalOrigin]) raises:
+    """ADC top-k search.
+
+    Builds a (d, n_levels) lookup table = outer(R @ query, centroids), then
+    accumulates scores per row, then takes top-k by score (descending).
+    """
+    var d = q.d
+    var n_levels = q.cb.n_levels
+
+    # q_rot = R @ query
+    var q_rot = alloc[Float32](d)
+    for i in range(d):
+        var s: Float32 = Float32(0.0)
+        var rrow = i * d
+        for j in range(d):
+            s += q.R.data[rrow + j] * query[j]
+        q_rot[i] = s
+
+    # table[j, c] = q_rot[j] * centroid[c]
+    var table = alloc[Float32](d * n_levels)
+    for j in range(d):
+        var qj = q_rot[j]
+        var trow = j * n_levels
+        for c in range(n_levels):
+            table[trow + c] = qj * q.cb.centroids[c]
+
+    # Score each row: s_i = sum_j table[j, idx[i, j]] * norms[i].
+    var scores = alloc[Float32](n)
+    for i in range(n):
+        var s: Float32 = Float32(0.0)
+        var base = i * d
+        for j in range(d):
+            var c = Int(indices[base + j])
+            s += table[j * n_levels + c]
+        scores[i] = s * norms[i]
+
+    # Top-k: simple O(n*k) selection (k is small typically). For each output
+    # slot, scan remaining for max and mark used.
+    var used = alloc[UInt8](n)
+    for i in range(n):
+        used[i] = UInt8(0)
+    var kk = k if k <= n else n
+    for outer in range(kk):
+        var best_i: Int = -1
+        var best_s: Float32 = Float32(0.0)
+        for i in range(n):
+            if used[i] == UInt8(0):
+                if best_i < 0 or scores[i] > best_s:
+                    best_i = i
+                    best_s = scores[i]
+        top_idx[outer] = best_i
+        top_scores[outer] = best_s
+        used[best_i] = UInt8(1)
+
+    used.free()
+    scores.free()
+    table.free()
+    q_rot.free()

--- a/remex/mojo/src/rng.mojo
+++ b/remex/mojo/src/rng.mojo
@@ -1,0 +1,81 @@
+"""Deterministic PRNG and standard-normal sampling.
+
+Uses splitmix64 to seed xoshiro256++ for uniforms, and the Marsaglia
+polar method for standard normals. The same seed yields the same stream
+across runs and platforms.
+
+Seed semantics are NOT bit-identical to NumPy's `default_rng(seed)`. To
+get an encoding bit-identical to Python remex, dump (R, boundaries) from
+Python with `remex.dump_quantizer_params()` and load them in Mojo via
+`pq_format.load_params()`. The Mojo CLI exposes both paths.
+"""
+
+from std.math import sqrt, log
+
+
+@fieldwise_init
+struct SplitMix64(Copyable, Movable):
+    var state: UInt64
+
+    def next(mut self) -> UInt64:
+        self.state = self.state + 0x9E3779B97F4A7C15
+        var z = self.state
+        z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9
+        z = (z ^ (z >> 27)) * 0x94D049BB133111EB
+        return z ^ (z >> 31)
+
+
+struct Xoshiro256pp(Copyable, Movable):
+    var s0: UInt64
+    var s1: UInt64
+    var s2: UInt64
+    var s3: UInt64
+    var _has_spare: Bool
+    var _spare: Float64
+
+    def __init__(out self, seed: UInt64):
+        var sm = SplitMix64(seed)
+        self.s0 = sm.next()
+        self.s1 = sm.next()
+        self.s2 = sm.next()
+        self.s3 = sm.next()
+        self._has_spare = False
+        self._spare = 0.0
+
+    def _rotl(self, x: UInt64, k: Int) -> UInt64:
+        var ku = UInt64(k)
+        return (x << ku) | (x >> (UInt64(64) - ku))
+
+    def next_u64(mut self) -> UInt64:
+        var result = self._rotl(self.s0 + self.s3, 23) + self.s0
+        var t = self.s1 << 17
+        self.s2 ^= self.s0
+        self.s3 ^= self.s1
+        self.s1 ^= self.s2
+        self.s0 ^= self.s3
+        self.s2 ^= t
+        self.s3 = self._rotl(self.s3, 45)
+        return result
+
+    def next_uniform(mut self) -> Float64:
+        # 53-bit mantissa uniform in [0, 1)
+        var bits = self.next_u64() >> 11
+        return Float64(bits) * (1.0 / Float64(1 << 53))
+
+    def next_normal(mut self) -> Float64:
+        """Marsaglia polar method — produces pairs; caches the spare."""
+        if self._has_spare:
+            self._has_spare = False
+            return self._spare
+
+        var u: Float64 = 0.0
+        var v: Float64 = 0.0
+        var s: Float64 = 2.0
+        while s >= 1.0 or s == 0.0:
+            u = 2.0 * self.next_uniform() - 1.0
+            v = 2.0 * self.next_uniform() - 1.0
+            s = u * u + v * v
+        var factor = sqrt(-2.0 * log(s) / s)
+        self._spare = v * factor
+        self._has_spare = True
+        return u * factor

--- a/remex/mojo/src/rotation.mojo
+++ b/remex/mojo/src/rotation.mojo
@@ -1,0 +1,122 @@
+"""Haar-distributed random orthogonal matrix via Householder QR.
+
+Mirrors `remex.rotation.haar_rotation`:
+  1. Sample A ~ N(0, 1) of shape (d, d)
+  2. QR decompose
+  3. Sign-correct: Q[:, j] *= sign(R[j, j])
+
+The resulting Q is uniformly distributed on O(d) (Mezzadri 2007).
+"""
+
+from std.math import sqrt
+from std.memory import alloc, UnsafePointer
+from src.rng import Xoshiro256pp
+from src.matrix import Matrix, MatrixF64
+
+
+def _norm2(p: UnsafePointer[Float64, MutExternalOrigin], n: Int) -> Float64:
+    var s: Float64 = 0.0
+    for i in range(n):
+        s += p[i] * p[i]
+    return sqrt(s)
+
+
+def _householder_qr(mut A: MatrixF64, mut Q: MatrixF64):
+    """In-place QR. After call: A holds R (upper triangular), Q holds Q."""
+    var n = A.rows
+    # Initialize Q = I
+    for i in range(n):
+        for j in range(n):
+            Q.set(i, j, Float64(1.0) if i == j else Float64(0.0))
+
+    for k in range(n - 1):
+        # Compute alpha = -sign(A[k,k]) * ||A[k:, k]||
+        var col_norm_sq: Float64 = 0.0
+        for i in range(k, n):
+            var v = A.get(i, k)
+            col_norm_sq += v * v
+        var col_norm = sqrt(col_norm_sq)
+        if col_norm == 0.0:
+            continue
+        var sign_akk: Float64 = -1.0 if A.get(k, k) < 0.0 else 1.0
+        var alpha = -sign_akk * col_norm
+
+        # v = A[k:, k] - alpha * e1
+        # store v in a temp column-vector
+        var v_len = n - k
+        var vp = alloc[Float64](v_len)
+        for i in range(v_len):
+            vp[i] = A.get(k + i, k)
+        vp[0] -= alpha
+
+        var v_norm = _norm2(vp, v_len)
+        if v_norm == 0.0:
+            vp.free()
+            continue
+        for i in range(v_len):
+            vp[i] /= v_norm
+
+        # Apply H = I - 2 v v^T to A[k:, k:] from the left:
+        # for each column j >= k: A[k:, j] -= 2 v (v^T A[k:, j])
+        for j in range(k, n):
+            var dot: Float64 = 0.0
+            for i in range(v_len):
+                dot += vp[i] * A.get(k + i, j)
+            var two_dot = 2.0 * dot
+            for i in range(v_len):
+                A.set(k + i, j, A.get(k + i, j) - two_dot * vp[i])
+
+        # Apply H to Q from the right: Q[:, k:] -= 2 (Q[:, k:] v) v^T
+        for i in range(n):
+            var dot: Float64 = 0.0
+            for j in range(v_len):
+                dot += Q.get(i, k + j) * vp[j]
+            var two_dot = 2.0 * dot
+            for j in range(v_len):
+                Q.set(i, k + j, Q.get(i, k + j) - two_dot * vp[j])
+
+        vp.free()
+
+
+def haar_rotation(d: Int, seed: UInt64) -> Matrix:
+    """Haar-distributed (d, d) orthogonal matrix as float32."""
+    var rng = Xoshiro256pp(seed)
+    var A = MatrixF64(d, d)
+    for i in range(d):
+        for j in range(d):
+            A.set(i, j, rng.next_normal())
+
+    var Q = MatrixF64(d, d)
+    _householder_qr(A, Q)
+
+    # Sign-correct: Q[:, j] *= sign(R[j, j])
+    for j in range(d):
+        var diag = A.get(j, j)
+        if diag < 0.0:
+            for i in range(d):
+                Q.set(i, j, -Q.get(i, j))
+
+    return Q.to_float32()
+
+
+def matvec(M: Matrix, x: UnsafePointer[Float32, MutExternalOrigin],
+           mut out_buf: UnsafePointer[Float32, MutExternalOrigin]):
+    """y = M @ x, where M is (rows, cols) and x is length cols."""
+    for i in range(M.rows):
+        var s: Float32 = Float32(0.0)
+        var base = i * M.cols
+        for j in range(M.cols):
+            s += M.data[base + j] * x[j]
+        out_buf[i] = s
+
+
+def matvec_T(M: Matrix, x: UnsafePointer[Float32, MutExternalOrigin],
+             mut out_buf: UnsafePointer[Float32, MutExternalOrigin]):
+    """y = M.T @ x. (i.e. dot product of x with each column of M.)"""
+    for j in range(M.cols):
+        out_buf[j] = Float32(0.0)
+    for i in range(M.rows):
+        var base = i * M.cols
+        var xi = x[i]
+        for j in range(M.cols):
+            out_buf[j] += M.data[base + j] * xi

--- a/remex/mojo/tests/test_codebook.mojo
+++ b/remex/mojo/tests/test_codebook.mojo
@@ -1,0 +1,71 @@
+"""Test Lloyd-Max codebook against expected properties + Python parity."""
+
+from std.testing import assert_true
+from std.math import sqrt
+from src.codebook import lloyd_max_codebook
+
+
+def _abs(x: Float32) -> Float32:
+    return -x if x < Float32(0.0) else x
+
+
+def test_symmetric_4bit() raises:
+    """Centroids of an even Lloyd-Max codebook are symmetric around 0."""
+    var cb = lloyd_max_codebook(384, 4)
+    for i in range(8):
+        var left = cb.get_centroid(i)
+        var right = cb.get_centroid(15 - i)
+        var sym_err = _abs(left + right)
+        assert_true(sym_err < Float32(1e-5))
+    print("test_symmetric_4bit: ok")
+
+
+def test_monotone_4bit() raises:
+    """Centroids must be strictly increasing."""
+    var cb = lloyd_max_codebook(384, 4)
+    for i in range(15):
+        assert_true(cb.get_centroid(i) < cb.get_centroid(i + 1))
+    print("test_monotone_4bit: ok")
+
+
+def test_boundaries_are_midpoints() raises:
+    var cb = lloyd_max_codebook(384, 3)
+    for i in range(7):
+        var mid = Float32(0.5) * (cb.get_centroid(i) + cb.get_centroid(i + 1))
+        assert_true(_abs(cb.get_boundary(i) - mid) < Float32(1e-7))
+    print("test_boundaries_are_midpoints: ok")
+
+
+def test_shape() raises:
+    """1, 2, 4, 8 bits → 2, 4, 16, 256 levels."""
+    var cb1 = lloyd_max_codebook(384, 1)
+    assert_true(cb1.n_levels == 2)
+    var cb4 = lloyd_max_codebook(384, 4)
+    assert_true(cb4.n_levels == 16)
+    var cb8 = lloyd_max_codebook(384, 8)
+    assert_true(cb8.n_levels == 256)
+    print("test_shape: ok")
+
+
+def test_known_values() raises:
+    """Spot-check 1-bit codebook: ±E[|N(0,sigma)|] = ±sigma*sqrt(2/pi)."""
+    var d = 384
+    var sigma = Float32(1.0) / Float32(sqrt(Float64(d)))
+    var expected_mag = sigma * Float32(sqrt(Float64(2.0) / Float64(3.141592653589793)))
+    var cb = lloyd_max_codebook(d, 1)
+    var c0: Float32 = cb.get_centroid(0)
+    var c1: Float32 = cb.get_centroid(1)
+    var lhs1 = _abs(c0 + expected_mag)
+    var lhs2 = _abs(c1 - expected_mag)
+    assert_true(lhs1 < Float32(1e-5))
+    assert_true(lhs2 < Float32(1e-5))
+    print("test_known_values: ok")
+
+
+def main() raises:
+    test_shape()
+    test_symmetric_4bit()
+    test_monotone_4bit()
+    test_boundaries_are_midpoints()
+    test_known_values()
+    print("[test_codebook] all passed")

--- a/remex/mojo/tests/test_encode.mojo
+++ b/remex/mojo/tests/test_encode.mojo
@@ -1,0 +1,74 @@
+"""Encode parity test.
+
+The Python test runner generates a Quantizer's R + codebook (via Python)
+and dumps them to /tmp/_parity.params, plus an X.npy of test vectors and
+the Python-encoded indices and norms (as a .pq file). This test loads
+those, encodes X with the same R + codebook in Mojo, and asserts the
+packed output is byte-identical.
+"""
+
+from std.testing import assert_equal, assert_true
+from std.memory import alloc
+from src.codebook import Codebook
+from src.matrix import Matrix
+from src.npy import load_npy_2d_f32
+from src.params_format import load_params
+from src.pq_format import load_pq, save_pq
+from src.quantizer import Quantizer, encode_batch
+from src.packing import pack, packed_nbytes
+
+
+def main() raises:
+    # Load matching Python-generated params + X + expectederence .pq
+    var X = load_npy_2d_f32(String("/tmp/_parity_X.npy"))
+    var expected = load_pq(String("/tmp/_parity_ref.pq"))
+    var d = X.cols
+    var n = X.rows
+    var bits = expected.bits
+
+    var R = Matrix(d, d)
+    var cb = Codebook(bits)
+    load_params(String("/tmp/_parity.params"), R, cb)
+
+    var q = Quantizer(R^, cb^, d, bits, UInt64(0))
+
+    # Encode in Mojo. Copy X into a fresh buffer to dodge any borrow weirdness
+    # on Npy2D.data crossing the function boundary.
+    var X_buf = alloc[Float32](n * d)
+    for i in range(n):
+        for j in range(d):
+            X_buf[i * d + j] = X.get(i, j)
+
+    var indices = alloc[UInt8](n * d)
+    var norms = alloc[Float32](n)
+    encode_batch(q, X_buf, n, indices, norms)
+    X_buf.free()
+
+    # Compare unpacked indices first (easier to debug than packed)
+    # Build a temp packed of mojo indices, then compare to expected.packed_indices
+    var packed = alloc[UInt8](expected.packed_bytes)
+    pack(indices, n * d, bits, packed)
+
+    var max_norm_diff: Float32 = Float32(0.0)
+    for i in range(n):
+        var a: Float32 = norms[i]
+        var b: Float32 = expected.norms[i]
+        var diff = a - b
+        if diff < Float32(0.0):
+            diff = -diff
+        if diff > max_norm_diff:
+            max_norm_diff = diff
+    print("max norm diff (Mojo vs Python):", max_norm_diff)
+    assert_true(max_norm_diff < Float32(1e-5))
+
+    var n_diff: Int = 0
+    for i in range(expected.packed_bytes):
+        if packed[i] != expected.packed_indices[i]:
+            n_diff += 1
+    print("packed-byte differences:", n_diff, "out of", expected.packed_bytes)
+    assert_equal(n_diff, 0)
+
+    indices.free()
+    norms.free()
+    packed.free()
+    print("[test_encode] parity ok — Mojo encode is bit-identical to Python")

--- a/remex/mojo/tests/test_packing.mojo
+++ b/remex/mojo/tests/test_packing.mojo
@@ -1,0 +1,56 @@
+"""Roundtrip tests for pack/unpack at all supported widths."""
+
+from std.testing import assert_equal, assert_true
+from std.memory import alloc
+from src.packing import pack, unpack, packed_nbytes
+from src.rng import Xoshiro256pp
+
+
+def _roundtrip(n: Int, bits: Int, seed: UInt64) raises:
+    var rng = Xoshiro256pp(seed)
+    var mask = UInt64((1 << bits) - 1) if bits < 8 else UInt64(0xFF)
+
+    var inp = alloc[UInt8](n)
+    for i in range(n):
+        inp[i] = UInt8(rng.next_u64() & mask)
+
+    var nb = packed_nbytes(n, bits)
+    var packed = alloc[UInt8](nb)
+    pack(inp, n, bits, packed)
+
+    var out = alloc[UInt8](n)
+    unpack(packed, n, bits, out)
+
+    for i in range(n):
+        assert_equal(Int(out[i]), Int(inp[i]))
+
+    inp.free()
+    packed.free()
+    out.free()
+
+
+def test_roundtrips() raises:
+    var widths = [1, 2, 3, 4, 8]
+    var sizes = [1, 7, 8, 9, 16, 17, 100, 1000]
+    for bw in widths:
+        for n in sizes:
+            _roundtrip(n, bw, 42)
+        print("  bits =", bw, " roundtrip ok")
+
+
+def test_packed_nbytes() raises:
+    assert_equal(packed_nbytes(8, 8), 8)
+    assert_equal(packed_nbytes(8, 4), 4)
+    assert_equal(packed_nbytes(8, 2), 2)
+    assert_equal(packed_nbytes(8, 1), 1)
+    assert_equal(packed_nbytes(8, 3), 3)
+    assert_equal(packed_nbytes(7, 4), 4)   # ceil(7/2)=4
+    assert_equal(packed_nbytes(7, 1), 1)   # ceil(7/8)=1
+    assert_equal(packed_nbytes(9, 3), 6)   # ceil(9/8)*3 = 2*3 = 6
+    print("test_packed_nbytes: ok")
+
+
+def main() raises:
+    test_packed_nbytes()
+    test_roundtrips()
+    print("[test_packing] all passed")

--- a/remex/mojo/tests/test_rng.mojo
+++ b/remex/mojo/tests/test_rng.mojo
@@ -1,0 +1,47 @@
+"""Test rng.mojo: determinism + basic statistical sanity."""
+
+from src.rng import Xoshiro256pp
+from std.math import sqrt
+from std.testing import assert_equal, assert_true
+
+
+def test_determinism() raises:
+    var r1 = Xoshiro256pp(42)
+    var r2 = Xoshiro256pp(42)
+    for _ in range(1000):
+        assert_equal(r1.next_u64(), r2.next_u64())
+    print("test_determinism: ok")
+
+
+def test_uniform_range() raises:
+    var r = Xoshiro256pp(7)
+    for _ in range(10000):
+        var u = r.next_uniform()
+        assert_true(u >= 0.0 and u < 1.0)
+    print("test_uniform_range: ok")
+
+
+def test_normal_moments() raises:
+    var r = Xoshiro256pp(123)
+    var n = 200000
+    var s: Float64 = 0.0
+    var s2: Float64 = 0.0
+    for _ in range(n):
+        var x = r.next_normal()
+        s += x
+        s2 += x * x
+    var mean = s / Float64(n)
+    var var_ = s2 / Float64(n) - mean * mean
+    var sd = sqrt(var_)
+    print("normal: n =", n, "mean =", mean, "sd =", sd)
+    # ~3 sigma bounds for n=200k:
+    assert_true(mean > -0.02 and mean < 0.02)
+    assert_true(sd > 0.99 and sd < 1.01)
+    print("test_normal_moments: ok")
+
+
+def main() raises:
+    test_determinism()
+    test_uniform_range()
+    test_normal_moments()
+    print("[test_rng] all passed")

--- a/remex/mojo/tests/test_rotation.mojo
+++ b/remex/mojo/tests/test_rotation.mojo
@@ -1,0 +1,75 @@
+"""Test rotation: orthogonality + determinism."""
+
+from std.math import sqrt
+from std.testing import assert_true
+from std.memory import alloc
+from src.rotation import haar_rotation, matvec, matvec_T
+from src.matrix import Matrix
+
+
+def _abs(x: Float32) -> Float32:
+    return -x if x < Float32(0.0) else x
+
+
+def _orthogonality_error(M: Matrix) -> Float32:
+    """max |M.T @ M - I|."""
+    var d = M.rows
+    var max_err: Float32 = Float32(0.0)
+    for i in range(d):
+        for j in range(d):
+            var s: Float32 = Float32(0.0)
+            for k in range(d):
+                s += M.get(k, i) * M.get(k, j)
+            var target: Float32 = Float32(1.0) if i == j else Float32(0.0)
+            var err = _abs(s - target)
+            if err > max_err:
+                max_err = err
+    return max_err
+
+
+def test_orthogonal() raises:
+    var R = haar_rotation(8, 42)
+    var err = _orthogonality_error(R)
+    print("orthogonality err (d=8) =", err)
+    assert_true(err < 1e-5)
+    print("test_orthogonal: ok")
+
+
+def test_determinism() raises:
+    var R1 = haar_rotation(16, 7)
+    var R2 = haar_rotation(16, 7)
+    var max_diff: Float32 = Float32(0.0)
+    for i in range(16 * 16):
+        var d = _abs(R1.data[i] - R2.data[i])
+        if d > max_diff:
+            max_diff = d
+    print("determinism max_diff =", max_diff)
+    assert_true(max_diff == Float32(0.0))
+    print("test_determinism: ok")
+
+
+def test_norm_preserving() raises:
+    var d = 32
+    var R = haar_rotation(d, 1)
+    var x = alloc[Float32](d)
+    var y = alloc[Float32](d)
+    for i in range(d):
+        x[i] = Float32(i + 1) * Float32(0.1) - Float32(1.0)
+    matvec(R, x, y)
+    var nx: Float32 = Float32(0.0)
+    var ny: Float32 = Float32(0.0)
+    for i in range(d):
+        nx += x[i] * x[i]
+        ny += y[i] * y[i]
+    print("||x||^2 =", nx, "||Rx||^2 =", ny)
+    assert_true(_abs(nx - ny) < Float32(1e-3))
+    x.free()
+    y.free()
+    print("test_norm_preserving: ok")
+
+
+def main() raises:
+    test_orthogonal()
+    test_determinism()
+    test_norm_preserving()
+    print("[test_rotation] all passed")

--- a/remex/pq_format.py
+++ b/remex/pq_format.py
@@ -1,0 +1,131 @@
+"""`.pq` binary file format used by the Mojo CLI port.
+
+Layout (little-endian):
+    bytes 0-1   : magic 'PQ' (0x50, 0x51)
+    byte 2      : reserved (0)
+    byte 3      : version (=1)
+    bytes 4-7   : d (u32)
+    bytes 8-15  : n (u64)
+    byte 16     : bits (u8)
+    bytes 17-31 : reserved (15 zero bytes)
+    bytes 32+   : packed_indices (length = packed_nbytes(n*d, bits))
+    then        : norms (n × float32, little-endian)
+
+This is a minimal alternative to the Python `.npz` format that is trivially
+parseable from Mojo without unzip/numpy-header machinery. See
+`remex/mojo/src/pq_format.mojo`.
+"""
+
+from __future__ import annotations
+
+import struct
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from remex.packing import pack, unpack, packed_nbytes
+
+if TYPE_CHECKING:
+    from remex.core import CompressedVectors, Quantizer
+
+PQ_HEADER_BYTES = 32
+PQ_VERSION = 1
+PQ_MAGIC = b"PQ\x00\x01"
+
+PARAMS_HEADER_BYTES = 16
+PARAMS_VERSION = 1
+PARAMS_MAGIC = b"PR\x00\x01"
+
+
+def save_params(path: str | Path, quantizer: "Quantizer") -> None:
+    """Dump (R, boundaries, centroids) so a Mojo binary can mirror this Quantizer.
+
+    Used to verify bit-identical encode output between Python and Mojo.
+    """
+    d = int(quantizer.d)
+    bits = int(quantizer.bits)
+    R = np.ascontiguousarray(quantizer.R, dtype=np.float32)
+    boundaries = np.ascontiguousarray(quantizer.boundaries, dtype=np.float32)
+    centroids = np.ascontiguousarray(quantizer.centroids, dtype=np.float32)
+    if R.shape != (d, d):
+        raise ValueError(f"R shape {R.shape} != (d, d) = ({d}, {d})")
+    if boundaries.size != (1 << bits) - 1:
+        raise ValueError("boundaries size mismatch")
+    if centroids.size != (1 << bits):
+        raise ValueError("centroids size mismatch")
+
+    header = bytearray(PARAMS_HEADER_BYTES)
+    header[0:4] = PARAMS_MAGIC
+    header[4:8] = struct.pack("<I", d)
+    header[8] = bits & 0xFF
+    with open(path, "wb") as f:
+        f.write(bytes(header))
+        f.write(R.tobytes())
+        f.write(boundaries.tobytes())
+        f.write(centroids.tobytes())
+
+
+def save_pq(path: str | Path, compressed: "CompressedVectors") -> None:
+    """Serialize a CompressedVectors to the .pq binary format."""
+    n, d, bits = int(compressed.n), int(compressed.d), int(compressed.bits)
+    packed = pack(compressed.indices.ravel(), bits)
+    expected_packed = packed_nbytes(n, d, bits)
+    if packed.nbytes != expected_packed:
+        raise ValueError(
+            f"packed indices size mismatch: got {packed.nbytes}, "
+            f"expected {expected_packed}"
+        )
+
+    header = bytearray(PQ_HEADER_BYTES)
+    header[0:4] = PQ_MAGIC
+    header[4:8] = struct.pack("<I", d)
+    header[8:16] = struct.pack("<Q", n)
+    header[16] = bits & 0xFF
+
+    norms = np.ascontiguousarray(compressed.norms, dtype=np.float32)
+
+    with open(path, "wb") as f:
+        f.write(bytes(header))
+        f.write(packed.tobytes())
+        f.write(norms.tobytes())
+
+
+def load_pq(path: str | Path) -> "CompressedVectors":
+    """Read a .pq file and return a CompressedVectors."""
+    from remex.core import CompressedVectors
+
+    raw = Path(path).read_bytes()
+    if len(raw) < PQ_HEADER_BYTES:
+        raise ValueError(".pq file too small")
+    if raw[0:2] != b"PQ":
+        raise ValueError("bad .pq magic")
+    if raw[3] != PQ_VERSION:
+        raise ValueError(f"unsupported .pq version: {raw[3]}")
+
+    (d,) = struct.unpack("<I", raw[4:8])
+    (n,) = struct.unpack("<Q", raw[8:16])
+    bits = raw[16]
+    if bits in (5, 6, 7):
+        raise ValueError(
+            f"bits={bits} is not supported. Use 1-4 or 8 bits."
+        )
+
+    expected_packed = packed_nbytes(n, d, bits)
+    expected_total = PQ_HEADER_BYTES + expected_packed + n * 4
+    if len(raw) < expected_total:
+        raise ValueError("truncated .pq data")
+
+    packed = np.frombuffer(
+        raw, dtype=np.uint8,
+        count=expected_packed,
+        offset=PQ_HEADER_BYTES,
+    )
+    norms = np.frombuffer(
+        raw, dtype=np.float32,
+        count=n,
+        offset=PQ_HEADER_BYTES + expected_packed,
+    )
+
+    indices = unpack(packed, bits, n * d).reshape(n, d)
+    return CompressedVectors(indices.copy(), norms.copy(), d, bits)


### PR DESCRIPTION
## Summary

Pure-Mojo port of the remex Quantizer's encode and ADC search path under `remex/mojo/`, plus a `polarquant` CLI binary. Closes #5.

- **`remex/mojo/src/`** — Mojo modules: rotation (Householder QR), Lloyd-Max codebook, bit-packing (1/2/3/4/8-bit), `.npy` reader, `.pq` + `.params` binary formats, PRNG (xoshiro256++ + Marsaglia polar), and the encode + ADC search hot path.
- **`remex/mojo/polarquant.mojo`** — CLI:
  ```
  polarquant encode in.npy --bits N (--seed S | --params P) -o out.pq
  polarquant search index.pq query.npy --k K (--seed S | --params P)
  ```
- **`remex/mojo/tests/`** — Per-module tests; `test_encode.mojo` asserts **bit-identical** encoded `.pq` vs Python given the same `(R, codebook)`.
- **`remex/mojo/bench/`** — Mojo timing harnesses + Python `compare.py` driver.
- **`remex/pq_format.py`** — Python `save_pq` / `load_pq` / `save_params`. The `.pq` container round-trips between Python and Mojo (md5-identical bytes verified).

### Bench (n=10k, d=384, bits=4, container CPU)

| Stage | NumPy | Mojo | Mojo vs NumPy |
|---|---:|---:|---:|
| encode (µs/vec) | 52.3 | 222.5 | 4.3x slower |
| ADC search (ms/q) | 21.1 | 3.8 | **5.5x faster** |

Mojo ADC search wins because the gather inner loop is straight-line scalar code that LLVM optimizes well; Mojo encode loses to NumPy because NumPy's `X @ R.T` calls into BLAS while the Mojo port currently uses a naive scalar matvec — vectorizing it via `std.algorithm.vectorize` is the obvious follow-up.

## Out of scope (deferred)

- Matryoshka nested codebooks / `search_twostage`
- `decode()` reconstruction
- `PackedVectors` (in-memory packed representation)
- GPU / MAX integration
- 5/6/7-bit support (Python rejects them too)
- NumPy-PCG64 seed parity — Mojo's xoshiro256++ produces different (still valid Haar) rotations from the same seed integer. Use `--params P.bin` (Python dumps R + codebook, Mojo loads them) when bit-identical encoding to Python is required.

## Test plan

- [x] All 5 Mojo unit-test files pass: `mojo run -I . tests/test_*.mojo`
- [x] `test_encode.mojo` confirms bit-identical packed indices vs Python `Quantizer.encode` given matching `(R, codebook)` (loaded from `.params`)
- [x] CLI `encode` round-trips through `remex.load_pq()` (md5-identical to Python's `save_pq(quantizer.encode(X))`)
- [x] CLI `search` returns the same top-k order and scores as Python `Quantizer.search_adc` when both use the same `(R, codebook)`
- [x] Existing Python test suite still green: `pytest tests/` → 126 passed, 11 skipped
- [x] Pack/unpack round-trip across all supported widths (1, 2, 3, 4, 8 bits)
- [x] `bench/compare.py` runs end-to-end and prints Mojo vs NumPy timings

CI is unchanged in this PR — Mojo install is ~500MB and slow. Document the manual build in `remex/mojo/README.md`.

https://claude.ai/code/session_01AwBJcxc1CF2xZ3C12XxQqv