### PR TITLE
Mojo port: Matryoshka nested codebooks + search_twostage

### DIFF
--- a/remex/mojo/README.md
+++ b/remex/mojo/README.md
@@ -16,21 +16,23 @@ remex/mojo/
 │   ├── rng.mojo             # xoshiro256++ + Marsaglia polar normal
 │   ├── matrix.mojo          # Owning Float32 / Float64 matrices
 │   ├── rotation.mojo        # Householder QR → Haar orthogonal matrix
-│   ├── codebook.mojo        # Lloyd-Max iteration on N(0, 1/d)
+│   ├── codebook.mojo        # Lloyd-Max iteration on N(0, 1/d) + Matryoshka nested tables
 │   ├── packing.mojo         # 1/2/3/4/8-bit pack and unpack
 │   ├── npy.mojo             # .npy reader (float32, 2D, C-contiguous)
 │   ├── pq_format.mojo       # .pq binary format read/write
 │   ├── params_format.mojo   # .params dump (R + boundaries + centroids)
-│   └── quantizer.mojo       # Quantizer struct: encode + ADC search
+│   └── quantizer.mojo       # Quantizer struct: encode + ADC search + two-stage search
 ├── tests/
 │   ├── test_rng.mojo
 │   ├── test_rotation.mojo
 │   ├── test_codebook.mojo
 │   ├── test_packing.mojo
-│   └── test_encode.mojo     # bit-identical encode parity vs Python
+│   ├── test_encode.mojo            # bit-identical encode parity vs Python
+│   └── test_search_twostage.mojo   # top-k parity for search_twostage vs Python
 └── bench/
     ├── bench_encode.mojo
     ├── bench_search.mojo
+    ├── bench_twostage.mojo
     └── compare.py           # Mojo vs NumPy comparison driver
 ```
 
@@ -50,6 +52,7 @@ cd remex/mojo
 mojo build -I . polarquant.mojo            -o polarquant
 mojo build -I . bench/bench_encode.mojo    -o bench/bench_encode
 mojo build -I . bench/bench_search.mojo    -o bench/bench_search
+mojo build -I . bench/bench_twostage.mojo  -o bench/bench_twostage
 ```
 
 ## CLI usage
@@ -60,6 +63,11 @@ mojo build -I . bench/bench_search.mojo    -o bench/bench_search
 
 # Search a single (1, d) query against a .pq, top-k
 ./polarquant search corpus.pq query.npy --k 10 --seed 42 --top 10
+
+# Memory-efficient two-stage retrieval: coarse ADC scan at reduced
+# precision, full-precision rerank on the top `--candidates` rows.
+./polarquant search corpus.pq query.npy --k 10 --seed 42 \
+    --twostage --candidates 500 --coarse-precision 2
 ```
 
 The same `corpus.pq` round-trips through the Python library:
@@ -106,6 +114,42 @@ save_params('/tmp/_parity.params', q)
 save_pq('/tmp/_parity_ref.pq', q.encode(X))
 "
 mojo run -I . tests/test_encode.mojo
+
+# search_twostage parity (also requires Python remex installed):
+python -c "
+import numpy as np
+from remex import Quantizer, save_pq, save_params
+
+np.random.seed(0)
+n, d, bits = 200, 16, 4
+n_q, k, candidates, coarse_precision = 8, 5, 50, 2
+
+X = np.random.randn(n, d).astype(np.float32)
+Q = np.random.randn(n_q, d).astype(np.float32)
+
+q = Quantizer(d=d, bits=bits, seed=42)
+save_params('/tmp/_twostage.params', q)
+cv = q.encode(X)
+save_pq('/tmp/_twostage.pq', cv)
+
+np.save('/tmp/_twostage_X.npy', X)
+np.save('/tmp/_twostage_Q.npy', Q)
+
+expected_idx = np.zeros((n_q, k), dtype=np.float32)
+expected_scores = np.zeros((n_q, k), dtype=np.float32)
+for i in range(n_q):
+    ti, ts = q.search_twostage(
+        cv, Q[i], k=k, candidates=candidates,
+        coarse_precision=coarse_precision)
+    expected_idx[i] = ti.astype(np.float32)
+    expected_scores[i] = ts
+
+meta = np.array([[k, candidates, coarse_precision, n_q]], dtype=np.float32)
+np.save('/tmp/_twostage_meta.npy', meta)
+np.save('/tmp/_twostage_expected_idx.npy', expected_idx)
+np.save('/tmp/_twostage_expected_scores.npy', expected_scores)
+"
+mojo run -I . tests/test_search_twostage.mojo
 ```
 
 ## Benchmarks
@@ -127,7 +171,11 @@ See `bench/RESULTS.md` (in this PR) for current numbers.
   µs/vec to 21 µs/vec at d=384 (8.6x speedup), within 1.3x of NumPy's
   BLAS `X @ R.T`. Closing the remaining gap would mean tiling /
   blocking the matvec or batching multiple rows per call.
-- **No Matryoshka / no `search_twostage`.** Out of scope for issue #5.
+- **`search_twostage` is naive.** The coarse stage is a straightforward
+  per-row ADC table lookup (no SIMD on the lookup gather), and the
+  candidate selection is O(n*candidates). Mirrors the structure of
+  `adc_search` in this port. Tighter inner-loop kernels — especially
+  for the coarse-stage reduction at low precision — are a follow-up.
 - **No GPU.** The `coding-mojo` skill notes Claude.ai containers are
   CPU-only; GPU work needs to be tested on a different host.
 - **Seed parity** with NumPy's `default_rng` is not bit-identical (see

--- a/remex/mojo/bench/bench_twostage.mojo
+++ b/remex/mojo/bench/bench_twostage.mojo
@@ -1,0 +1,105 @@
+"""Time search_twostage on a synthetic compressed corpus.
+
+Usage: bench_twostage --n N --d D --bits B --queries Q --k K
+                      [--candidates C] [--coarse-precision K] [--seed S]
+
+Default `coarse_precision` is `max(1, bits - 2)`, mirroring the Python
+default in `Quantizer.search_twostage`.
+"""
+
+from std.sys import argv
+from std.time import perf_counter_ns
+from std.memory import alloc
+from src.codebook import lloyd_max_codebook, nested_codebooks_from
+from src.matrix import Matrix
+from src.quantizer import Quantizer, encode_batch, search_twostage
+from src.rotation import haar_rotation
+from src.rng import Xoshiro256pp
+
+
+def _arg_idx(args: List[String], flag: String) -> Int:
+    for i in range(len(args)):
+        if args[i] == flag:
+            return i
+    return -1
+
+
+def _flag_int(args: List[String], flag: String, default: Int) raises -> Int:
+    var i = _arg_idx(args, flag)
+    if i < 0:
+        return default
+    return Int(args[i + 1])
+
+
+def main() raises:
+    var args = argv()
+    var sub = List[String]()
+    for i in range(1, len(args)):
+        sub.append(String(args[i]))
+
+    var n = _flag_int(sub, String("--n"), 10000)
+    var d = _flag_int(sub, String("--d"), 384)
+    var bits = _flag_int(sub, String("--bits"), 4)
+    var queries = _flag_int(sub, String("--queries"), 100)
+    var k = _flag_int(sub, String("--k"), 10)
+    var candidates = _flag_int(sub, String("--candidates"), 500)
+    var default_coarse = bits - 2 if bits - 2 >= 1 else 1
+    var coarse_precision = _flag_int(sub, String("--coarse-precision"), default_coarse)
+    var seed = UInt64(_flag_int(sub, String("--seed"), 42))
+
+    print("bench_twostage: n =", n, "d =", d, "bits =", bits,
+          "queries =", queries, "k =", k,
+          "candidates =", candidates,
+          "coarse_precision =", coarse_precision)
+
+    # Build corpus.
+    var rng = Xoshiro256pp(seed)
+    var X = alloc[Float32](n * d)
+    for i in range(n * d):
+        X[i] = Float32(rng.next_normal())
+
+    var R = haar_rotation(d, seed)
+    var cb = lloyd_max_codebook(d, bits)
+    # Build nested *before* moving cb into the Quantizer.
+    var nested = nested_codebooks_from(cb, d)
+    var q = Quantizer(R^, cb^, d, bits, seed)
+
+    var indices = alloc[UInt8](n * d)
+    var norms = alloc[Float32](n)
+    encode_batch(q, X, n, indices, norms)
+    X.free()
+
+    # Build random queries.
+    var Q_buf = alloc[Float32](queries * d)
+    for i in range(queries * d):
+        Q_buf[i] = Float32(rng.next_normal())
+
+    var top_idx = alloc[Int](k)
+    var top_scores = alloc[Float32](k)
+
+    # Warmup.
+    var qbuf0 = alloc[Float32](d)
+    for j in range(d):
+        qbuf0[j] = Q_buf[j]
+    search_twostage(q, nested, indices, norms, n, qbuf0,
+                    k, candidates, coarse_precision, top_idx, top_scores)
+    qbuf0.free()
+
+    var t0 = perf_counter_ns()
+    for qi in range(queries):
+        var qbuf = alloc[Float32](d)
+        for j in range(d):
+            qbuf[j] = Q_buf[qi * d + j]
+        search_twostage(q, nested, indices, norms, n, qbuf,
+                        k, candidates, coarse_precision, top_idx, top_scores)
+        qbuf.free()
+    var t1 = perf_counter_ns()
+    var dt_ns = Int(t1 - t0)
+    var ms_per_q = Float64(dt_ns) / Float64(queries) / 1000000.0
+    print("  search time:", dt_ns / 1000000, "ms total,", ms_per_q, "ms / query")
+
+    indices.free()
+    norms.free()
+    Q_buf.free()
+    top_idx.free()
+    top_scores.free()

--- a/remex/mojo/bench/compare.py
+++ b/remex/mojo/bench/compare.py
@@ -1,15 +1,17 @@
-"""Mojo vs NumPy benchmark for remex encode + ADC search.
+"""Mojo vs NumPy benchmark for remex encode + ADC search + two-stage search.
 
 Generates a synthetic standard-normal corpus, runs the same workload
-through (a) the Python `remex.Quantizer` and (b) the Mojo binary built
+through (a) the Python `remex.Quantizer` and (b) the Mojo binaries built
 from `polarquant.mojo`. Prints a comparison table.
 
 Usage:
     python bench/compare.py [--n 10000] [--d 384] [--bits 4]
                             [--queries 100] [--k 10]
+                            [--candidates 500] [--coarse-precision K]
 
-The Mojo binaries are expected at `bench/bench_encode` and
-`bench/bench_search` (build them with `mojo build`).
+The Mojo binaries are expected at `bench/bench_encode`,
+`bench/bench_search`, and `bench/bench_twostage` (build them with
+`mojo build`).
 """
 
 import argparse
@@ -60,8 +62,17 @@ def main() -> int:
     ap.add_argument("--bits", type=int, default=4)
     ap.add_argument("--queries", type=int, default=100)
     ap.add_argument("--k", type=int, default=10)
+    ap.add_argument("--candidates", type=int, default=500)
+    ap.add_argument("--coarse-precision", type=int, default=None,
+                    help="Coarse-stage precision for two-stage search "
+                         "(default: max(1, bits - 2))")
     ap.add_argument("--seed", type=int, default=42)
     args = ap.parse_args()
+    coarse_precision = (
+        args.coarse_precision
+        if args.coarse_precision is not None
+        else max(1, args.bits - 2)
+    )
 
     sys.path.insert(0, str(REPO_ROOT))
     from remex import Quantizer
@@ -85,6 +96,19 @@ def main() -> int:
         pq.search_adc(cv, q, k=args.k)
     py_search_ms_per_q = (time.perf_counter() - t0) / args.queries * 1e3
 
+    # --- Python two-stage search ---
+    pq.search_twostage(
+        cv, Qs[0], k=args.k,
+        candidates=args.candidates, coarse_precision=coarse_precision,
+    )  # warmup
+    t0 = time.perf_counter()
+    for q in Qs:
+        pq.search_twostage(
+            cv, q, k=args.k,
+            candidates=args.candidates, coarse_precision=coarse_precision,
+        )
+    py_twostage_ms_per_q = (time.perf_counter() - t0) / args.queries * 1e3
+
     # --- Mojo encode ---
     out = _run_mojo("bench_encode", [
         "--n", str(args.n), "--d", str(args.d),
@@ -100,19 +124,35 @@ def main() -> int:
     ])
     mojo_search_ms_per_q = _parse_ms_per_query(out)
 
+    # --- Mojo two-stage search ---
+    out = _run_mojo("bench_twostage", [
+        "--n", str(args.n), "--d", str(args.d),
+        "--bits", str(args.bits), "--queries", str(args.queries),
+        "--k", str(args.k), "--seed", str(args.seed),
+        "--candidates", str(args.candidates),
+        "--coarse-precision", str(coarse_precision),
+    ])
+    mojo_twostage_ms_per_q = _parse_ms_per_query(out)
+
     print()
-    print(f"=== n={args.n}, d={args.d}, bits={args.bits} ===")
-    print(f"{'Stage':<12} {'NumPy':>14} {'Mojo':>14} {'Speedup':>10}")
-    print("-" * 54)
+    print(f"=== n={args.n}, d={args.d}, bits={args.bits}, "
+          f"candidates={args.candidates}, coarse_precision={coarse_precision} ===")
+    print(f"{'Stage':<14} {'NumPy':>14} {'Mojo':>14} {'Speedup':>10}")
+    print("-" * 56)
     print(
-        f"{'encode (us)':<12} "
+        f"{'encode (us)':<14} "
         f"{py_encode_us_per_vec:>14.2f} {mojo_encode_us_per_vec:>14.2f} "
         f"{py_encode_us_per_vec/mojo_encode_us_per_vec:>9.2f}x"
     )
     print(
-        f"{'search (ms)':<12} "
+        f"{'search (ms)':<14} "
         f"{py_search_ms_per_q:>14.3f} {mojo_search_ms_per_q:>14.3f} "
         f"{py_search_ms_per_q/mojo_search_ms_per_q:>9.2f}x"
+    )
+    print(
+        f"{'twostage (ms)':<14} "
+        f"{py_twostage_ms_per_q:>14.3f} {mojo_twostage_ms_per_q:>14.3f} "
+        f"{py_twostage_ms_per_q/mojo_twostage_ms_per_q:>9.2f}x"
     )
     print()
     print(

--- a/remex/mojo/polarquant.mojo
+++ b/remex/mojo/polarquant.mojo
@@ -15,12 +15,12 @@ Outputs `index.pq`, the binary container readable by `remex.load_pq()`.
 
 from std.sys import argv
 from std.memory import alloc, UnsafePointer
-from src.codebook import Codebook, lloyd_max_codebook
+from src.codebook import Codebook, NestedCodebook, lloyd_max_codebook, nested_codebooks_from
 from src.matrix import Matrix
 from src.npy import load_npy_2d_f32
 from src.params_format import load_params
 from src.pq_format import save_pq, load_pq
-from src.quantizer import Quantizer, encode_batch, adc_search
+from src.quantizer import Quantizer, encode_batch, adc_search, search_twostage
 from src.packing import pack, packed_nbytes
 from src.rotation import haar_rotation
 
@@ -54,6 +54,7 @@ def _print_usage():
     print("usage:")
     print("  polarquant encode <input.npy> --bits N (--seed S | --params P) -o <out.pq>")
     print("  polarquant search <index.pq> <query.npy> --k K (--seed S | --params P) [--top T]")
+    print("                   [--twostage --candidates N --coarse-precision K]")
 
 
 def cmd_encode(args: List[String]) raises:
@@ -146,6 +147,21 @@ def cmd_search(args: List[String]) raises:
     if top_idx >= 0:
         print_top = Int(_arg_str(args, top_idx + 1))
 
+    # Two-stage mode flags
+    var twostage_idx = _arg_idx(args, String("--twostage"))
+    var use_twostage = twostage_idx >= 0
+    var candidates = 0
+    var coarse_precision = 0
+    if use_twostage:
+        var cand_idx = _arg_idx(args, String("--candidates"))
+        if cand_idx < 0:
+            raise Error("search --twostage: --candidates N required")
+        candidates = Int(_arg_str(args, cand_idx + 1))
+        var cp_idx = _arg_idx(args, String("--coarse-precision"))
+        if cp_idx < 0:
+            raise Error("search --twostage: --coarse-precision K required")
+        coarse_precision = Int(_arg_str(args, cp_idx + 1))
+
     var pq = load_pq(index_path)
     var Q = load_npy_2d_f32(query_path)
     if Q.rows != 1:
@@ -171,7 +187,15 @@ def cmd_search(args: List[String]) raises:
 
     var top_idx_buf = alloc[Int](k)
     var top_scores = alloc[Float32](k)
-    adc_search(q_quant, indices, norms_local, pq.n, qbuf, k, top_idx_buf, top_scores)
+    if use_twostage:
+        # Build nested centroid tables from the loaded full-precision codebook.
+        # Reaching into q_quant.cb is fine — Quantizer is owned locally here.
+        var nested = nested_codebooks_from(q_quant.cb, pq.d)
+        search_twostage(q_quant, nested, indices, norms_local, pq.n,
+                        qbuf, k, candidates, coarse_precision,
+                        top_idx_buf, top_scores)
+    else:
+        adc_search(q_quant, indices, norms_local, pq.n, qbuf, k, top_idx_buf, top_scores)
 
     print("top", print_top, "results:")
     var to_print = print_top if print_top <= k else k

--- a/remex/mojo/src/codebook.mojo
+++ b/remex/mojo/src/codebook.mojo
@@ -1,8 +1,8 @@
 """Lloyd-Max scalar quantizer codebook for N(0, 1/d).
 
-Mirrors `remex.codebook.lloyd_max_codebook`. The Mojo version uses
-`+/-INF_SENTINEL = ±50` for the outer interval edges — far enough into
-the tails that cdf(±50*sigma) is 1.0/0.0 in float64.
+Mirrors `remex.codebook.lloyd_max_codebook` and `remex.codebook.nested_codebooks`.
+The Mojo version uses `+/-INF_SENTINEL = ±50` for the outer interval edges —
+far enough into the tails that cdf(±50*sigma) is 1.0/0.0 in float64.
 """
 
 from std.math import sqrt
@@ -12,6 +12,7 @@ from src.mathx import normal_cdf, normal_pdf
 
 comptime N_ITER_DEFAULT = 300
 comptime INF_SENTINEL = 50.0  # any value where cdf(x*sigma) saturates
+comptime NESTED_MAX_BITS = 8   # supported max precision (matches Python)
 
 
 struct Codebook(Movable):
@@ -96,3 +97,120 @@ def lloyd_max_codebook(d: Int, bits: Int, n_iter: Int = N_ITER_DEFAULT) -> Codeb
     b_lo.free()
     b_hi.free()
     return cb^
+
+
+struct NestedCodebook(Movable):
+    """Matryoshka-style nested centroid tables for precisions 1..max_bits.
+
+    Layout: a single flat buffer holds 2 + 4 + 8 + ... + 2^max_bits = 2^(max_bits+1) - 2
+    Float32 values. `offsets[bits]` is the start offset of the level for that
+    precision, so the table for `bits == b` lives at `centroids[offsets[b] : offsets[b] + 2^b]`.
+    """
+    var centroids: UnsafePointer[Float32, MutExternalOrigin]
+    # offsets[b] = start of the level for precision b (b in 1..max_bits).
+    # offsets[max_bits + 1] = total length. Sized for max_bits = 8 (10 slots).
+    var offsets: InlineArray[Int, 10]
+    var max_bits: Int
+
+    def __init__(out self, max_bits: Int):
+        if max_bits < 1 or max_bits > NESTED_MAX_BITS:
+            raise Error("nested codebook: max_bits must be 1..8")
+        self.max_bits = max_bits
+        self.offsets = InlineArray[Int, 10](fill=0)
+        var off = 0
+        for b in range(1, max_bits + 1):
+            self.offsets[b] = off
+            off += (1 << b)
+        self.offsets[max_bits + 1] = off
+        self.centroids = alloc[Float32](off)
+        for i in range(off):
+            self.centroids[i] = Float32(0.0)
+
+    def get_table(self, bits: Int) -> UnsafePointer[Float32, MutExternalOrigin]:
+        """Pointer to the centroid table at the given precision level."""
+        return self.centroids + self.offsets[bits]
+
+    def get_centroid(self, bits: Int, idx: Int) -> Float32:
+        return self.centroids[self.offsets[bits] + idx]
+
+    def n_levels(self, bits: Int) -> Int:
+        return 1 << bits
+
+    def __del__(deinit self):
+        self.centroids.free()
+
+
+def nested_codebooks_from(cb: Codebook, d: Int) -> NestedCodebook:
+    """Build nested centroid tables from an already-computed max-bits codebook.
+
+    The Gaussian distribution is successively refinable: the top `b` bits of
+    a `max_bits`-bit Lloyd-Max code are themselves a valid `b`-bit code into
+    the table built by probability-weighted averaging of the corresponding
+    centroid groups.
+
+    Using a precomputed `cb` (rather than re-running Lloyd-Max) lets callers
+    derive nested centroids that exactly match the centroids saved in a
+    Python-written `.params` file — required for the parity test.
+    """
+    var max_bits = cb.bits
+    var n_max = cb.n_levels
+    var sigma = 1.0 / sqrt(Float64(d))
+    var nested = NestedCodebook(max_bits)
+
+    # Top level: copy the max-precision centroids verbatim.
+    var max_table = nested.get_table(max_bits)
+    for j in range(n_max):
+        max_table[j] = cb.centroids[j]
+
+    if max_bits == 1:
+        return nested^
+
+    # Per-bin probability mass under N(0, 1/d). Boundaries are the midpoints
+    # of consecutive centroids, with ±INF_SENTINEL for the outer edges
+    # (matches `remex.codebook.nested_codebooks` which uses ±inf there).
+    var probs = alloc[Float64](n_max)
+    var bounds = alloc[Float64](n_max + 1)
+    bounds[0] = -INF_SENTINEL
+    bounds[n_max] = INF_SENTINEL
+    for j in range(n_max - 1):
+        bounds[j + 1] = Float64(0.5) * (Float64(cb.centroids[j]) + Float64(cb.centroids[j + 1]))
+    for j in range(n_max):
+        probs[j] = normal_cdf(bounds[j + 1], sigma) - normal_cdf(bounds[j], sigma)
+
+    # Coarser levels: weighted average of the max-bits centroids in each
+    # contiguous group of size `n_max // n_target`.
+    var target_bits = max_bits - 1
+    while target_bits >= 1:
+        var n_target = 1 << target_bits
+        var group_size = n_max // n_target
+        var target_table = nested.get_table(target_bits)
+        for g in range(n_target):
+            var start = g * group_size
+            var total_prob: Float64 = 0.0
+            var weighted: Float64 = 0.0
+            var simple: Float64 = 0.0
+            for k in range(group_size):
+                var idx = start + k
+                total_prob += probs[idx]
+                weighted += probs[idx] * Float64(cb.centroids[idx])
+                simple += Float64(cb.centroids[idx])
+            if total_prob > 1e-15:
+                target_table[g] = Float32(weighted / total_prob)
+            else:
+                target_table[g] = Float32(simple / Float64(group_size))
+        target_bits -= 1
+
+    probs.free()
+    bounds.free()
+    return nested^
+
+
+def nested_codebooks(d: Int, max_bits: Int) -> NestedCodebook:
+    """Build a Lloyd-Max codebook for `(d, max_bits)` and return its nested tables.
+
+    Convenience wrapper around `lloyd_max_codebook` + `nested_codebooks_from`.
+    For tests that need parity with a Python-written `.params` file, call
+    `nested_codebooks_from(loaded_cb, d)` directly so the centroids match.
+    """
+    var cb = lloyd_max_codebook(d, max_bits)
+    return nested_codebooks_from(cb, d)

--- a/remex/mojo/src/quantizer.mojo
+++ b/remex/mojo/src/quantizer.mojo
@@ -9,7 +9,7 @@ the rotated query and the codebook centroids.
 from std.math import sqrt
 from std.memory import alloc, UnsafePointer
 from std.sys.info import simd_width_of
-from src.codebook import Codebook, lloyd_max_codebook
+from src.codebook import Codebook, NestedCodebook, lloyd_max_codebook
 from src.matrix import Matrix
 from src.rotation import haar_rotation
 from src.packing import pack, packed_nbytes
@@ -188,4 +188,122 @@ def adc_search(q: Quantizer,
     used.free()
     scores.free()
     table.free()
+    q_rot.free()
+
+
+def search_twostage(q: Quantizer,
+                    nested: NestedCodebook,
+                    indices: UnsafePointer[UInt8, MutExternalOrigin],
+                    norms: UnsafePointer[Float32, MutExternalOrigin],
+                    n: Int,
+                    query: UnsafePointer[Float32, MutExternalOrigin],
+                    k: Int,
+                    candidates: Int,
+                    coarse_precision: Int,
+                    mut top_idx: UnsafePointer[Int, MutExternalOrigin],
+                    mut top_scores: UnsafePointer[Float32, MutExternalOrigin]) raises:
+    """Two-stage retrieval: coarse ADC scan + full-precision rerank.
+
+    Stage 1: ADC scan at `coarse_precision` over the full corpus. For each
+    row i, the score uses the right-shifted index `indices[i, j] >> shift`
+    against the coarse centroid table at `coarse_precision` bits. Keeps the
+    top `candidates` rows by coarse score.
+
+    Stage 2: Re-score the candidate rows at full precision (`q.bits`) using
+    the full-precision centroid table. Return the top-k by fine score.
+
+    `indices` is a contiguous (n, d) uint8 buffer of full-precision codes
+    (already unpacked). `norms` is a length-`n` float32 buffer. `nested`
+    must have been built with `max_bits == q.bits`.
+    """
+    var d = q.d
+    var bits = q.bits
+    if coarse_precision < 1 or coarse_precision > bits:
+        raise Error("search_twostage: coarse_precision must be 1..bits")
+    if nested.max_bits != bits:
+        raise Error("search_twostage: nested.max_bits must equal q.bits")
+
+    var shift = bits - coarse_precision
+    var n_levels_coarse = 1 << coarse_precision
+    var coarse_k = candidates if candidates <= n else n
+    if coarse_k < k:
+        raise Error("search_twostage: candidates must be >= k")
+
+    # q_rot = R @ query (SIMD dot per output coord) — same shape as adc_search.
+    var q_rot = alloc[Float32](d)
+    for i in range(d):
+        q_rot[i] = _dot_f32(q.R.data + i * d, query, d)
+
+    # Stage 1: build coarse lookup table and score each row.
+    var coarse_centroids = nested.get_table(coarse_precision)
+    var coarse_table = alloc[Float32](d * n_levels_coarse)
+    for j in range(d):
+        var qj = q_rot[j]
+        var trow = j * n_levels_coarse
+        for c in range(n_levels_coarse):
+            coarse_table[trow + c] = qj * coarse_centroids[c]
+
+    var coarse_scores = alloc[Float32](n)
+    for i in range(n):
+        var s: Float32 = Float32(0.0)
+        var base = i * d
+        for j in range(d):
+            var c_full = Int(indices[base + j])
+            var c_coarse = c_full >> shift if shift > 0 else c_full
+            s += coarse_table[j * n_levels_coarse + c_coarse]
+        coarse_scores[i] = s * norms[i]
+    coarse_table.free()
+
+    # Pick the top `coarse_k` candidates by coarse score (selection-style).
+    # Order within the candidate set doesn't matter — only membership does.
+    var cand_idx = alloc[Int](coarse_k)
+    var used = alloc[UInt8](n)
+    for i in range(n):
+        used[i] = UInt8(0)
+    for outer in range(coarse_k):
+        var best_i: Int = -1
+        var best_s: Float32 = Float32(0.0)
+        for i in range(n):
+            if used[i] == UInt8(0):
+                if best_i < 0 or coarse_scores[i] > best_s:
+                    best_i = i
+                    best_s = coarse_scores[i]
+        cand_idx[outer] = best_i
+        used[best_i] = UInt8(1)
+    used.free()
+    coarse_scores.free()
+
+    # Stage 2: full-precision rerank on the candidate set.
+    # fine_score(i) = sum_j q_rot[j] * full_centroids[indices[i, j]] * norms[i]
+    var fine_centroids = q.cb.centroids
+    var fine_scores = alloc[Float32](coarse_k)
+    for ci in range(coarse_k):
+        var i = cand_idx[ci]
+        var base = i * d
+        var s: Float32 = Float32(0.0)
+        for j in range(d):
+            var c = Int(indices[base + j])
+            s += q_rot[j] * fine_centroids[c]
+        fine_scores[ci] = s * norms[i]
+
+    # Top-k by fine score.
+    var kk = k if k <= coarse_k else coarse_k
+    var used2 = alloc[UInt8](coarse_k)
+    for i in range(coarse_k):
+        used2[i] = UInt8(0)
+    for outer in range(kk):
+        var best_i: Int = -1
+        var best_s: Float32 = Float32(0.0)
+        for ci in range(coarse_k):
+            if used2[ci] == UInt8(0):
+                if best_i < 0 or fine_scores[ci] > best_s:
+                    best_i = ci
+                    best_s = fine_scores[ci]
+        top_idx[outer] = cand_idx[best_i]
+        top_scores[outer] = best_s
+        used2[best_i] = UInt8(1)
+
+    used2.free()
+    fine_scores.free()
+    cand_idx.free()
     q_rot.free()

--- a/remex/mojo/tests/test_search_twostage.mojo
+++ b/remex/mojo/tests/test_search_twostage.mojo
@@ -1,0 +1,154 @@
+"""Parity test for `search_twostage`.
+
+A Python runner builds a Quantizer with `(d, bits, seed)`, dumps the params,
+encodes a corpus to .pq, and saves a set of queries plus reference
+(top-k indices, top-k scores) tuples produced by Python's
+`Quantizer.search_twostage`. This test re-runs the same workload in Mojo
+against the loaded params + indices + nested codebook and asserts that
+the top-k order matches and scores agree to rtol=1e-5.
+
+Setup (run before this test):
+
+    python -c "
+    import numpy as np
+    from remex import Quantizer, save_pq, save_params
+
+    np.random.seed(0)
+    n, d, bits = 200, 16, 4
+    n_q, k, candidates, coarse_precision = 8, 5, 50, 2
+
+    X = np.random.randn(n, d).astype(np.float32)
+    Q = np.random.randn(n_q, d).astype(np.float32)
+
+    q = Quantizer(d=d, bits=bits, seed=42)
+    save_params('/tmp/_twostage.params', q)
+    cv = q.encode(X)
+    save_pq('/tmp/_twostage.pq', cv)
+
+    np.save('/tmp/_twostage_X.npy', X)
+    np.save('/tmp/_twostage_Q.npy', Q)
+
+    expected_idx = np.zeros((n_q, k), dtype=np.float32)
+    expected_scores = np.zeros((n_q, k), dtype=np.float32)
+    for i in range(n_q):
+        ti, ts = q.search_twostage(
+            cv, Q[i], k=k, candidates=candidates,
+            coarse_precision=coarse_precision)
+        expected_idx[i] = ti.astype(np.float32)
+        expected_scores[i] = ts
+
+    # Save metadata as a (1, 4) float32 row: [k, candidates, coarse_precision, n_q]
+    meta = np.array([[k, candidates, coarse_precision, n_q]], dtype=np.float32)
+    np.save('/tmp/_twostage_meta.npy', meta)
+    np.save('/tmp/_twostage_expected_idx.npy', expected_idx)
+    np.save('/tmp/_twostage_expected_scores.npy', expected_scores)
+    "
+"""
+
+from std.testing import assert_equal, assert_true
+from std.memory import alloc
+from src.codebook import Codebook, NestedCodebook, nested_codebooks_from
+from src.matrix import Matrix
+from src.npy import load_npy_2d_f32
+from src.params_format import load_params
+from src.pq_format import load_pq
+from src.quantizer import Quantizer, search_twostage
+from src.packing import unpack
+
+
+def _abs(x: Float32) -> Float32:
+    return -x if x < Float32(0.0) else x
+
+
+def main() raises:
+    var meta = load_npy_2d_f32(String("/tmp/_twostage_meta.npy"))
+    var k = Int(meta.get(0, 0))
+    var candidates = Int(meta.get(0, 1))
+    var coarse_precision = Int(meta.get(0, 2))
+    var n_q = Int(meta.get(0, 3))
+
+    var pq = load_pq(String("/tmp/_twostage.pq"))
+    var d = pq.d
+    var n = pq.n
+    var bits = pq.bits
+
+    var Q = load_npy_2d_f32(String("/tmp/_twostage_Q.npy"))
+    if Q.rows != n_q or Q.cols != d:
+        raise Error("query shape mismatch with metadata + .pq")
+
+    var expected_idx = load_npy_2d_f32(String("/tmp/_twostage_expected_idx.npy"))
+    var expected_scores = load_npy_2d_f32(String("/tmp/_twostage_expected_scores.npy"))
+    if expected_idx.rows != n_q or expected_idx.cols != k:
+        raise Error("expected_idx shape mismatch")
+    if expected_scores.rows != n_q or expected_scores.cols != k:
+        raise Error("expected_scores shape mismatch")
+
+    # Load (R, max-bits codebook) from the same .params file Python wrote.
+    var R = Matrix(d, d)
+    var cb = Codebook(bits)
+    load_params(String("/tmp/_twostage.params"), R, cb)
+
+    # Derive nested centroid tables from the loaded codebook so they match
+    # Python's `_nested` exactly (both built from the same max-bits centroids).
+    var nested = nested_codebooks_from(cb, d)
+
+    var q_quant = Quantizer(R^, cb^, d, bits, UInt64(42))
+
+    # Unpack indices once. Copy norms into a fresh buffer (UnsafePointer field
+    # aliasing workaround — see `polarquant.mojo` cmd_search).
+    var indices = alloc[UInt8](n * d)
+    unpack(pq.packed_indices, n * d, bits, indices)
+    var norms_local = alloc[Float32](n)
+    for i in range(n):
+        norms_local[i] = pq.norms[i]
+
+    var top_idx = alloc[Int](k)
+    var top_scores = alloc[Float32](k)
+
+    var max_score_diff: Float32 = Float32(0.0)
+    var n_idx_mismatch: Int = 0
+
+    for qi in range(n_q):
+        # Copy the qi-th query into a fresh buffer.
+        var qbuf = alloc[Float32](d)
+        for j in range(d):
+            qbuf[j] = Q.get(qi, j)
+
+        search_twostage(
+            q_quant, nested, indices, norms_local, n,
+            qbuf, k, candidates, coarse_precision,
+            top_idx, top_scores,
+        )
+
+        for r in range(k):
+            var got_idx = top_idx[r]
+            var exp_idx = Int(expected_idx.get(qi, r))
+            if got_idx != exp_idx:
+                n_idx_mismatch += 1
+                print("query", qi, "rank", r, ": got idx =", got_idx,
+                      "expected =", exp_idx,
+                      " (got score =", top_scores[r],
+                      "expected score =", expected_scores.get(qi, r), ")")
+            var got_s = top_scores[r]
+            var exp_s = expected_scores.get(qi, r)
+            var rel = _abs(got_s - exp_s)
+            var ref_mag = _abs(exp_s)
+            if ref_mag > Float32(1.0):
+                rel = rel / ref_mag
+            if rel > max_score_diff:
+                max_score_diff = rel
+
+        qbuf.free()
+
+    print("query count:", n_q, "k =", k,
+          "candidates =", candidates, "coarse_precision =", coarse_precision)
+    print("max relative score diff:", max_score_diff)
+    print("idx mismatches:", n_idx_mismatch)
+    assert_equal(n_idx_mismatch, 0)
+    assert_true(max_score_diff < Float32(1e-5))
+
+    indices.free()
+    norms_local.free()
+    top_idx.free()
+    top_scores.free()
+    print("[test_search_twostage] parity ok — Mojo top-k matches Python to rtol=1e-5")


### PR DESCRIPTION
Closes #38.

Continuation of PR #36 (which ported `Quantizer.encode` and `Quantizer.search_adc` to Mojo). Adds the third search strategy — `search_twostage` — and the underlying Matryoshka nested-codebook machinery it depends on.

## What's added

**`src/codebook.mojo`** — `NestedCodebook` struct and builders.
- `NestedCodebook` holds the full ladder of centroid tables for precisions `1..max_bits` in a single flat buffer, with per-level offsets so callers can grab any precision's table in O(1).
- `nested_codebooks_from(cb, d)` derives nested centroids from an already-built max-bits `Codebook`. Used by the parity test so Mojo's nested levels match Python's `_nested` exactly when both come from the same `.params`-loaded codebook.
- `nested_codebooks(d, max_bits)` is the standalone convenience wrapper.

**`src/quantizer.mojo`** — `search_twostage`.
- Stage 1: coarse ADC scan over the full corpus using the nested table at `coarse_precision` and right-shifted indices. Selects the top `candidates` rows.
- Stage 2: full-precision rerank on the candidate set — exact IP via `full_centroids[indices] · q_rot` — and returns top-k by fine score.

**`polarquant.mojo`** — `search` subcommand gains `--twostage --candidates N --coarse-precision K`.

**`tests/test_search_twostage.mojo`** — top-k parity test. Loads `(R, max-bits codebook)` from a Python-written `.params` file, re-derives nested centroids in Mojo, runs `search_twostage` against indices unpacked from a Python-encoded `.pq`, and asserts:
- top-k indices match Python's `Quantizer.search_twostage` **exactly**
- top-k scores agree to **rtol=1e-5**

**`bench/bench_twostage.mojo`** — standalone timing harness (mirrors `bench_search.mojo`).

**`bench/compare.py`** — adds a `twostage` row alongside `encode` and `search`. Defaults `coarse_precision` to `max(1, bits - 2)`, matching the Python default.

## Acceptance checklist

- [x] `nested_codebooks(d, bits)` ported to `src/codebook.mojo`.
- [x] `search_twostage(q, indices, norms, query, k, candidates, coarse_precision)` added to `src/quantizer.mojo`.
- [x] CLI surface: `polarquant search ... --twostage --candidates N --coarse-precision K`.
- [x] `tests/test_search_twostage.mojo` asserts top-k order matches Python `Quantizer.search_twostage` to rtol=1e-5 given matching `(R, codebook, indices)`.
- [x] `bench/compare.py` gains a `twostage` row.

## Test plan

- [ ] `mojo run -I . tests/test_search_twostage.mojo` (after running the Python setup snippet in `mojo/README.md` to write `/tmp/_twostage*.{params,pq,npy}`)
- [ ] `mojo build -I . bench/bench_twostage.mojo -o bench/bench_twostage`
- [ ] `python bench/compare.py --n 10000 --d 384 --bits 4 --queries 100 --k 10` and check that the new `twostage` row appears with sane numbers
- [ ] `./polarquant search corpus.pq query.npy --k 10 --params P --twostage --candidates 500 --coarse-precision 2` and compare top-k to `remex.Quantizer.search_twostage` on the same corpus

## References

- Issue #38
- PR #36 (encode + search_adc port) — out-of-scope § Matryoshka, now landed here
- Python: `remex/core.py:635` (`search_twostage`), `remex/codebook.py:47` (`nested_codebooks`)