### PR TITLE
Mojo port: decode() + PackedVectors — closes #39

### DIFF
--- a/remex/mojo/README.md
+++ b/remex/mojo/README.md
@@ -1,16 +1,18 @@
 # remex Mojo port (`polarquant`)
 
-A pure-Mojo port of the remex Quantizer's encode + ADC search path,
-shipped as a standalone CLI binary.
+A pure-Mojo port of the remex Quantizer's encode + ADC search +
+decode path, shipped as a standalone CLI binary.
 
-Closes [issue #5](https://github.com/oaustegard/remex/issues/5).
+Closes [issue #5](https://github.com/oaustegard/remex/issues/5),
+[issue #38](https://github.com/oaustegard/remex/issues/38), and
+[issue #39](https://github.com/oaustegard/remex/issues/39).
 
 ## What's here
 
 ```
 remex/mojo/
 ├── README.md                # This file
-├── polarquant.mojo          # CLI entrypoint (encode + search)
+├── polarquant.mojo          # CLI entrypoint (encode + search + decode)
 ├── src/
 │   ├── mathx.mojo           # erf-based normal CDF / PDF
 │   ├── rng.mojo             # xoshiro256++ + Marsaglia polar normal
@@ -18,16 +20,19 @@ remex/mojo/
 │   ├── rotation.mojo        # Householder QR → Haar orthogonal matrix
 │   ├── codebook.mojo        # Lloyd-Max iteration on N(0, 1/d) + Matryoshka nested tables
 │   ├── packing.mojo         # 1/2/3/4/8-bit pack and unpack
-│   ├── npy.mojo             # .npy reader (float32, 2D, C-contiguous)
+│   ├── packed_vectors.mojo  # Bit-packed in-memory storage with on-demand unpack
+│   ├── npy.mojo             # .npy reader/writer (float32, 2D, C-contiguous)
 │   ├── pq_format.mojo       # .pq binary format read/write
 │   ├── params_format.mojo   # .params dump (R + boundaries + centroids)
-│   └── quantizer.mojo       # Quantizer struct: encode + ADC search + two-stage search
+│   └── quantizer.mojo       # Quantizer struct: encode + ADC search + two-stage + decode
 ├── tests/
 │   ├── test_rng.mojo
 │   ├── test_rotation.mojo
 │   ├── test_codebook.mojo
 │   ├── test_packing.mojo
+│   ├── test_packed_vectors.mojo    # PackedVectors round-trip + at_precision parity
 │   ├── test_encode.mojo            # bit-identical encode parity vs Python
+│   ├── test_decode.mojo            # decode parity vs Python (full + coarse precision)
 │   └── test_search_twostage.mojo   # top-k parity for search_twostage vs Python
 └── bench/
     ├── bench_encode.mojo
@@ -68,6 +73,11 @@ mojo build -I . bench/bench_twostage.mojo  -o bench/bench_twostage
 # precision, full-precision rerank on the top `--candidates` rows.
 ./polarquant search corpus.pq query.npy --k 10 --seed 42 \
     --twostage --candidates 500 --coarse-precision 2
+
+# Reconstruct float32 vectors from a .pq → .npy. Optional --precision
+# uses the nested codebook at a coarser bit width (1..bits).
+./polarquant decode corpus.pq --params P.bin -o reconstructed.npy
+./polarquant decode corpus.pq --params P.bin --precision 2 -o coarse.npy
 ```
 
 The same `corpus.pq` round-trips through the Python library:
@@ -114,6 +124,51 @@ save_params('/tmp/_parity.params', q)
 save_pq('/tmp/_parity_ref.pq', q.encode(X))
 "
 mojo run -I . tests/test_encode.mojo
+
+# Decode parity (full precision + coarse via nested codebook):
+python -c "
+import numpy as np
+from remex import Quantizer, save_pq, save_params
+
+np.random.seed(0)
+n, d, bits = 80, 16, 4
+coarse_precision = 2
+
+X = np.random.randn(n, d).astype(np.float32)
+q = Quantizer(d=d, bits=bits, seed=42)
+save_params('/tmp/_decode.params', q)
+cv = q.encode(X)
+save_pq('/tmp/_decode.pq', cv)
+
+np.save('/tmp/_decode_X.npy', X)
+np.save('/tmp/_decode_full.npy', q.decode(cv).astype(np.float32))
+np.save('/tmp/_decode_coarse.npy',
+        q.decode(cv, precision=coarse_precision).astype(np.float32))
+np.save('/tmp/_decode_meta.npy',
+        np.array([[coarse_precision]], dtype=np.float32))
+"
+mojo run -I . tests/test_decode.mojo
+
+# PackedVectors round-trip + at_precision parity:
+python -c "
+import numpy as np
+from remex import Quantizer, PackedVectors
+
+np.random.seed(0)
+n, d, bits = 80, 16, 4
+target_bits = 2
+
+X = np.random.randn(n, d).astype(np.float32)
+q = Quantizer(d=d, bits=bits, seed=42)
+cv = q.encode(X)
+packed = PackedVectors.from_compressed(cv)
+np.save('/tmp/_pv_indices.npy', cv.indices.astype(np.float32))
+np.save('/tmp/_pv_indices_at.npy',
+        packed.at_precision(target_bits).unpack_rows(0, n).astype(np.float32))
+np.save('/tmp/_pv_meta.npy',
+        np.array([[n, d, bits, target_bits]], dtype=np.float32))
+"
+mojo run -I . tests/test_packed_vectors.mojo
 
 # search_twostage parity (also requires Python remex installed):
 python -c "

--- a/remex/mojo/polarquant.mojo
+++ b/remex/mojo/polarquant.mojo
@@ -17,10 +17,10 @@ from std.sys import argv
 from std.memory import alloc, UnsafePointer
 from src.codebook import Codebook, NestedCodebook, lloyd_max_codebook, nested_codebooks_from
 from src.matrix import Matrix
-from src.npy import load_npy_2d_f32
+from src.npy import load_npy_2d_f32, save_npy_2d_f32
 from src.params_format import load_params
 from src.pq_format import save_pq, load_pq
-from src.quantizer import Quantizer, encode_batch, adc_search, search_twostage
+from src.quantizer import Quantizer, encode_batch, adc_search, search_twostage, decode_batch
 from src.packing import pack, packed_nbytes
 from src.rotation import haar_rotation
 
@@ -55,6 +55,7 @@ def _print_usage():
     print("  polarquant encode <input.npy> --bits N (--seed S | --params P) -o <out.pq>")
     print("  polarquant search <index.pq> <query.npy> --k K (--seed S | --params P) [--top T]")
     print("                   [--twostage --candidates N --coarse-precision K]")
+    print("  polarquant decode <index.pq> (--seed S | --params P) [--precision P] -o <out.npy>")
 
 
 def cmd_encode(args: List[String]) raises:
@@ -209,6 +210,72 @@ def cmd_search(args: List[String]) raises:
     top_scores.free()
 
 
+def cmd_decode(args: List[String]) raises:
+    """Decode subcommand: load .pq, reconstruct float32 vectors, write .npy.
+
+    End-to-end reconstruction parity with `Quantizer.decode` from the
+    Python library: same params + same .pq + same `--precision` produce
+    a float32 (n, d) array matching to within 1e-5 max abs diff.
+    """
+    if len(args) < 2:
+        _print_usage()
+        raise Error("decode: missing index.pq")
+    var index_path = args[1]
+
+    var seed_idx = _arg_idx(args, String("--seed"))
+    var params_idx = _arg_idx(args, String("--params"))
+    if seed_idx < 0 and params_idx < 0:
+        raise Error("decode: provide --seed or --params")
+    var seed: UInt64 = UInt64(42)
+    if seed_idx >= 0:
+        seed = UInt64(Int(_arg_str(args, seed_idx + 1)))
+    var params_path = String("")
+    if params_idx >= 0:
+        params_path = _arg_str(args, params_idx + 1)
+
+    var prec_idx = _arg_idx(args, String("--precision"))
+    var precision = 0  # 0 means full precision
+    if prec_idx >= 0:
+        precision = Int(_arg_str(args, prec_idx + 1))
+
+    var out_idx = _arg_idx(args, String("-o"))
+    if out_idx < 0:
+        raise Error("decode: -o <out.npy> required")
+    var out_path = _arg_str(args, out_idx + 1)
+
+    var pq = load_pq(index_path)
+    print("decode:", index_path, "→", out_path,
+          "(n =", pq.n, ", d =", pq.d, ", bits =", pq.bits,
+          ", precision =", precision if precision > 0 else pq.bits, ")")
+
+    var q_quant = _build_quantizer(pq.d, pq.bits, seed, params_path)
+
+    # Build nested centroid tables from the loaded codebook so they match
+    # what Python would compute for the same Quantizer (mirrors the
+    # search_twostage path).
+    var nested = nested_codebooks_from(q_quant.cb, pq.d)
+
+    # Unpack indices into uint8 (n*d). Copy norms into a fresh buffer too
+    # (UnsafePointer field aliasing workaround — see test_encode.mojo).
+    from src.packing import unpack
+    var indices = alloc[UInt8](pq.n * pq.d)
+    unpack(pq.packed_indices, pq.n * pq.d, pq.bits, indices)
+    var norms_local = alloc[Float32](pq.n)
+    for i in range(pq.n):
+        norms_local[i] = pq.norms[i]
+
+    var X_hat = alloc[Float32](pq.n * pq.d)
+    decode_batch(q_quant, nested, indices, norms_local, pq.n,
+                 precision, X_hat)
+
+    save_npy_2d_f32(out_path, X_hat, pq.n, pq.d)
+    print("  wrote", pq.n * pq.d * 4, "float32 bytes")
+
+    indices.free()
+    norms_local.free()
+    X_hat.free()
+
+
 def main() raises:
     var args = argv()
     if len(args) < 2:
@@ -223,6 +290,8 @@ def main() raises:
         cmd_encode(sub_args)
     elif cmd == "search":
         cmd_search(sub_args)
+    elif cmd == "decode":
+        cmd_decode(sub_args)
     else:
         _print_usage()
         raise Error(String("unknown subcommand: ") + cmd)

--- a/remex/mojo/src/codebook.mojo
+++ b/remex/mojo/src/codebook.mojo
@@ -112,7 +112,7 @@ struct NestedCodebook(Movable):
     var offsets: InlineArray[Int, 10]
     var max_bits: Int
 
-    def __init__(out self, max_bits: Int):
+    def __init__(out self, max_bits: Int) raises:
         if max_bits < 1 or max_bits > NESTED_MAX_BITS:
             raise Error("nested codebook: max_bits must be 1..8")
         self.max_bits = max_bits
@@ -140,7 +140,7 @@ struct NestedCodebook(Movable):
         self.centroids.free()
 
 
-def nested_codebooks_from(cb: Codebook, d: Int) -> NestedCodebook:
+def nested_codebooks_from(cb: Codebook, d: Int) raises -> NestedCodebook:
     """Build nested centroid tables from an already-computed max-bits codebook.
 
     The Gaussian distribution is successively refinable: the top `b` bits of
@@ -205,7 +205,7 @@ def nested_codebooks_from(cb: Codebook, d: Int) -> NestedCodebook:
     return nested^
 
 
-def nested_codebooks(d: Int, max_bits: Int) -> NestedCodebook:
+def nested_codebooks(d: Int, max_bits: Int) raises -> NestedCodebook:
     """Build a Lloyd-Max codebook for `(d, max_bits)` and return its nested tables.
 
     Convenience wrapper around `lloyd_max_codebook` + `nested_codebooks_from`.

--- a/remex/mojo/src/npy.mojo
+++ b/remex/mojo/src/npy.mojo
@@ -186,3 +186,71 @@ def load_npy_2d_f32(path: String) raises -> Npy2D:
     for i in range(n * 4):
         bp[i] = raw[data_offset + i]
     return out^
+
+
+def _int_to_str(v: Int) -> String:
+    """Convert a non-negative integer to its decimal ASCII string."""
+    if v == 0:
+        return String("0")
+    var digits = String("")
+    var x = v
+    while x > 0:
+        var d = x % 10
+        digits = chr(Int(ord("0")) + d) + digits
+        x = x // 10
+    return digits
+
+
+def save_npy_2d_f32(path: String,
+                    data: UnsafePointer[Float32, MutExternalOrigin],
+                    rows: Int, cols: Int) raises:
+    """Write a 2D float32 C-contiguous .npy file (v1.0 format).
+
+    The header is padded with spaces so that `(magic + version + len + header)`
+    is a multiple of 64 bytes — matches `np.save`'s alignment convention,
+    so NumPy can read what we write.
+    """
+    # Build header dict in NumPy's exact format. The trailing space + newline
+    # before the closing brace mimics np.save's header.
+    var header_core = (
+        String("{'descr': '<f4', 'fortran_order': False, 'shape': (")
+        + _int_to_str(rows) + String(", ") + _int_to_str(cols) + String("), }")
+    )
+    # Pad with spaces so total preamble + header_len is a multiple of 64.
+    # Final header byte must be '\n'.
+    var preamble = 10  # magic (6) + version (2) + header_len (2)
+    var min_total = preamble + len(header_core) + 1  # +1 for '\n'
+    var aligned_total = ((min_total + 63) // 64) * 64
+    var pad = aligned_total - min_total
+    var header_str = header_core
+    for _ in range(pad):
+        header_str += String(" ")
+    header_str += String("\n")
+    var header_len = len(header_str)
+    var data_offset = preamble + header_len
+
+    var n_floats = rows * cols
+    var total = data_offset + n_floats * 4
+    var buf = alloc[UInt8](total)
+    buf[0] = UInt8(0x93)
+    buf[1] = UInt8(ord("N"))
+    buf[2] = UInt8(ord("U"))
+    buf[3] = UInt8(ord("M"))
+    buf[4] = UInt8(ord("P"))
+    buf[5] = UInt8(ord("Y"))
+    buf[6] = UInt8(1)  # major
+    buf[7] = UInt8(0)  # minor
+    buf[8] = UInt8(header_len & 0xFF)
+    buf[9] = UInt8((header_len >> 8) & 0xFF)
+
+    var hbytes = header_str.as_bytes()
+    for i in range(header_len):
+        buf[preamble + i] = hbytes[i]
+
+    var src_bytes = data.bitcast[UInt8]()
+    for i in range(n_floats * 4):
+        buf[data_offset + i] = src_bytes[i]
+
+    var span = Span[UInt8, MutExternalOrigin](ptr=buf, length=total)
+    Path(path).write_bytes(span)
+    buf.free()

--- a/remex/mojo/src/packed_vectors.mojo
+++ b/remex/mojo/src/packed_vectors.mojo
@@ -1,0 +1,190 @@
+"""Memory-efficient packed storage for quantized vectors.
+
+Mirrors `remex.core.PackedVectors`: indices are stored bit-packed in a
+single contiguous `(n, row_bytes)` buffer with row-aligned offsets, and
+unpacked on demand. For sub-byte widths this uses 2-4x less RAM than the
+unpacked uint8 layout used by `CompressedVectors`.
+
+`row_aligned` is true when `(d * bits) % 8 == 0`. In that case the
+flat-packed and row-by-row-packed layouts coincide, so a single
+`pack(flat, n*d, bits, ...)` produces the same bytes as packing each
+row independently. When false (e.g. d=10 at 3 bits), each row carries
+internal padding and must be packed/unpacked individually.
+
+The on-disk `.pq` format always stores indices flat-packed across the
+whole `n*d` value stream — which is identical to the row-aligned
+PackedVectors layout, but not the row-padded one. `from_pq` and
+`to_pq_bytes` handle that distinction.
+"""
+
+from std.memory import alloc, UnsafePointer
+from src.packing import pack, unpack, packed_nbytes
+
+
+struct PackedVectors(Movable):
+    """Bit-packed (n, row_bytes) index storage with on-demand unpack.
+
+    Owning struct: `__init__` allocates `packed` and `norms`, `__del__`
+    frees them. Use `from_indices` to build from an unpacked (n, d) uint8
+    buffer; use `from_pq_bytes` to adopt a flat `.pq`-style packed buffer.
+    """
+    var packed: UnsafePointer[UInt8, MutExternalOrigin]      # (n * row_bytes)
+    var norms: UnsafePointer[Float32, MutExternalOrigin]     # (n,)
+    var n: Int
+    var d: Int
+    var bits: Int
+    var row_bytes: Int
+    var row_aligned: Bool
+
+    def __init__(out self, n: Int, d: Int, bits: Int) raises:
+        self.n = n
+        self.d = d
+        self.bits = bits
+        self.row_bytes = packed_nbytes(d, bits)
+        self.row_aligned = ((d * bits) % 8) == 0
+        self.packed = alloc[UInt8](n * self.row_bytes)
+        self.norms = alloc[Float32](n)
+
+    def __del__(deinit self):
+        self.packed.free()
+        self.norms.free()
+
+
+def from_indices(indices: UnsafePointer[UInt8, MutExternalOrigin],
+                 norms: UnsafePointer[Float32, MutExternalOrigin],
+                 n: Int, d: Int, bits: Int) raises -> PackedVectors:
+    """Build a PackedVectors from an unpacked (n, d) uint8 buffer."""
+    var pv = PackedVectors(n, d, bits)
+    var packed_buf = pv.packed
+    if pv.row_aligned:
+        # Flat layout matches: pack the whole stream in one shot.
+        pack(indices, n * d, bits, packed_buf)
+    else:
+        # Pack each row independently into its own row_bytes-sized slot.
+        # `pack` requires a mutable pointer arg, and arithmetic on a struct
+        # field returns an immutable view — copy the base into a local first.
+        for i in range(n):
+            var dst = packed_buf + i * pv.row_bytes
+            pack(indices + i * d, d, bits, dst)
+    for i in range(n):
+        pv.norms[i] = norms[i]
+    return pv^
+
+
+def from_pq_bytes(packed_flat: UnsafePointer[UInt8, MutExternalOrigin],
+                  flat_nbytes: Int,
+                  norms: UnsafePointer[Float32, MutExternalOrigin],
+                  n: Int, d: Int, bits: Int) raises -> PackedVectors:
+    """Build a PackedVectors from a `.pq`-style flat packed buffer.
+
+    `.pq` packs `n*d` values as a single stream. For row-aligned widths
+    this is the same layout as PackedVectors._packed and we copy verbatim;
+    for row-padded widths we unpack the stream and repack row-by-row.
+    """
+    var pv = PackedVectors(n, d, bits)
+    var packed_buf = pv.packed
+    if pv.row_aligned:
+        if flat_nbytes != n * pv.row_bytes:
+            raise Error("from_pq_bytes: flat_nbytes != n * row_bytes (row-aligned)")
+        for i in range(n * pv.row_bytes):
+            packed_buf[i] = packed_flat[i]
+    else:
+        var unpacked = alloc[UInt8](n * d)
+        unpack(packed_flat, n * d, bits, unpacked)
+        for i in range(n):
+            var dst = packed_buf + i * pv.row_bytes
+            pack(unpacked + i * d, d, bits, dst)
+        unpacked.free()
+    for i in range(n):
+        pv.norms[i] = norms[i]
+    return pv^
+
+
+def unpack_rows(pv: PackedVectors, start: Int, end: Int,
+                mut out: UnsafePointer[UInt8, MutExternalOrigin]) raises:
+    """Unpack rows [start, end) into `out` (size `(end - start) * d` uint8).
+
+    Mirrors `PackedVectors.unpack_rows` in `remex/core.py`.
+    """
+    if start < 0 or end > pv.n or start > end:
+        raise Error("unpack_rows: invalid [start, end)")
+    var n_rows = end - start
+    if pv.row_aligned:
+        # Contiguous flat slice — single unpack call.
+        var src = pv.packed + start * pv.row_bytes
+        unpack(src, n_rows * pv.d, pv.bits, out)
+    else:
+        for i in range(n_rows):
+            var src = pv.packed + (start + i) * pv.row_bytes
+            var dst = out + i * pv.d
+            unpack(src, pv.d, pv.bits, dst)
+
+
+def unpack_all(pv: PackedVectors,
+               mut out: UnsafePointer[UInt8, MutExternalOrigin]) raises:
+    """Unpack all rows into `out` (size `n * d` uint8)."""
+    unpack_rows(pv, 0, pv.n, out)
+
+
+def unpack_at(pv: PackedVectors, idx: Int,
+              mut out: UnsafePointer[UInt8, MutExternalOrigin]) raises:
+    """Unpack a single row `idx` into `out` (size `d` uint8)."""
+    if idx < 0 or idx >= pv.n:
+        raise Error("unpack_at: index out of range")
+    var src = pv.packed + idx * pv.row_bytes
+    unpack(src, pv.d, pv.bits, out)
+
+
+def at_precision(pv: PackedVectors, target_bits: Int) raises -> PackedVectors:
+    """Derive a lower-bit PackedVectors via Matryoshka right-shift.
+
+    Mirrors `PackedVectors.at_precision`: unpacks rows in chunks, shifts
+    by `bits - target_bits`, and repacks at `target_bits`. When
+    `target_bits == pv.bits` returns a fresh copy (Mojo lacks shared
+    ownership, so we don't alias the input buffer).
+    """
+    if target_bits < 1 or target_bits > pv.bits:
+        raise Error("at_precision: target_bits must be 1..bits")
+
+    if target_bits == pv.bits:
+        # Copy: caller owns the result independently.
+        var same = PackedVectors(pv.n, pv.d, pv.bits)
+        for i in range(pv.n * pv.row_bytes):
+            same.packed[i] = pv.packed[i]
+        for i in range(pv.n):
+            same.norms[i] = pv.norms[i]
+        return same^
+
+    var shift = pv.bits - target_bits
+    var pv_out = PackedVectors(pv.n, pv.d, target_bits)
+    var out_buf = pv_out.packed
+    var chunk = 4096
+    var unpacked = alloc[UInt8](chunk * pv.d)
+    var shifted = alloc[UInt8](chunk * pv.d)
+
+    var start = 0
+    while start < pv.n:
+        var end = start + chunk
+        if end > pv.n:
+            end = pv.n
+        var n_rows = end - start
+
+        unpack_rows(pv, start, end, unpacked)
+        for i in range(n_rows * pv.d):
+            shifted[i] = unpacked[i] >> UInt8(shift)
+
+        if pv_out.row_aligned:
+            var dst = out_buf + start * pv_out.row_bytes
+            pack(shifted, n_rows * pv.d, target_bits, dst)
+        else:
+            for i in range(n_rows):
+                var dst = out_buf + (start + i) * pv_out.row_bytes
+                pack(shifted + i * pv.d, pv.d, target_bits, dst)
+        start = end
+
+    for i in range(pv.n):
+        pv_out.norms[i] = pv.norms[i]
+
+    unpacked.free()
+    shifted.free()
+    return pv_out^

--- a/remex/mojo/src/quantizer.mojo
+++ b/remex/mojo/src/quantizer.mojo
@@ -191,6 +191,98 @@ def adc_search(q: Quantizer,
     q_rot.free()
 
 
+fn _accum_row_f32(dst: UnsafePointer[Float32, MutExternalOrigin],
+                  r_row: UnsafePointer[Float32, MutExternalOrigin],
+                  scale: Float32, n: Int):
+    """Fused multiply-add row accumulation: dst[j] += scale * r_row[j].
+
+    Used by `decode_batch` for the rotation matvec. Iterating with the
+    outer loop over k and an inner broadcast-FMA over j means R is
+    accessed sequentially row-by-row and `dst` is reused without a
+    transpose — same access pattern as the encode hot loop.
+    """
+    var bcast = SIMD[DType.float32, _W](scale)
+    var j = 0
+    while j + _W <= n:
+        var rv = r_row.load[width=_W](j)
+        var ov = dst.load[width=_W](j)
+        dst.store(j, bcast.fma(rv, ov))
+        j += _W
+    while j < n:
+        dst[j] += scale * r_row[j]
+        j += 1
+
+
+def decode_batch(q: Quantizer,
+                 nested: NestedCodebook,
+                 indices: UnsafePointer[UInt8, MutExternalOrigin],
+                 norms: UnsafePointer[Float32, MutExternalOrigin],
+                 n: Int,
+                 precision: Int,
+                 mut X_hat_out: UnsafePointer[Float32, MutExternalOrigin]) raises:
+    """Reconstruct float32 vectors from packed indices + norms.
+
+    Mirrors `Quantizer.decode` in `remex/core.py`. `precision == 0` (or
+    `precision == q.bits`) means full precision and uses the full-precision
+    centroid table from `q.cb`; lower precisions use the matching nested
+    table from `nested` and right-shift the indices by `q.bits - precision`.
+
+    Output layout: `X_hat_out` is a contiguous (n, d) float32 buffer.
+    For each row i, the formula is:
+
+        X_hat_rot[i, k] = centroids[indices[i, k] >> shift]
+        X_hat_unit[i, j] = sum_k X_hat_rot[i, k] * R[k, j]
+        X_hat[i, j]      = X_hat_unit[i, j] * norms[i]
+
+    `nested` may be unused when precision is full; pass any
+    `NestedCodebook` with `max_bits == q.bits` for that case (cheap to
+    build via `nested_codebooks_from(q.cb, d)`).
+    """
+    var d = q.d
+    var bits = q.bits
+    if precision < 0 or precision > bits:
+        raise Error("decode_batch: precision must be 0..bits")
+    if precision != 0 and precision != bits and nested.max_bits != bits:
+        raise Error("decode_batch: nested.max_bits must equal q.bits")
+
+    var use_full = (precision == 0 or precision == bits)
+    var shift = 0 if use_full else bits - precision
+
+    var centroids: UnsafePointer[Float32, MutExternalOrigin]
+    if use_full:
+        centroids = q.cb.centroids
+    else:
+        centroids = nested.get_table(precision)
+
+    # Per-row dequantized rotated vector. Keeping it as a single d-long
+    # scratch buffer avoids materializing the full (n, d) X_hat_rot matrix.
+    var xhrot = alloc[Float32](d)
+
+    for i in range(n):
+        var base = i * d
+        # Stage 1: lookup centroids per coordinate.
+        for k in range(d):
+            var c = Int(indices[base + k])
+            if shift > 0:
+                c = c >> shift
+            xhrot[k] = centroids[c]
+
+        # Stage 2: rotate back. Zero the output row, then accumulate
+        # `xhrot[k] * R[k, :]` for k in [0, d). R is row-major so R[k, :]
+        # is a contiguous run of d float32s starting at q.R.data + k*d.
+        for j in range(d):
+            X_hat_out[base + j] = Float32(0.0)
+        for k in range(d):
+            _accum_row_f32(X_hat_out + base, q.R.data + k * d, xhrot[k], d)
+
+        # Stage 3: rescale by per-row norm.
+        var nm = norms[i]
+        for j in range(d):
+            X_hat_out[base + j] *= nm
+
+    xhrot.free()
+
+
 def search_twostage(q: Quantizer,
                     nested: NestedCodebook,
                     indices: UnsafePointer[UInt8, MutExternalOrigin],

--- a/remex/mojo/tests/test_decode.mojo
+++ b/remex/mojo/tests/test_decode.mojo
@@ -1,0 +1,113 @@
+"""Parity test for `decode_batch`.
+
+A Python runner builds a Quantizer with `(d, bits, seed)`, dumps the params,
+encodes a corpus to .pq, then saves the Python-decoded output at full
+precision and at a coarser precision. This test reconstructs the same
+two outputs in Mojo from the loaded params + .pq + nested codebook and
+asserts max abs diff < 1e-5 in both cases.
+
+Setup (run before this test):
+
+    python -c "
+    import numpy as np
+    from remex import Quantizer, save_pq, save_params
+
+    np.random.seed(0)
+    n, d, bits = 80, 16, 4
+    coarse_precision = 2
+
+    X = np.random.randn(n, d).astype(np.float32)
+    q = Quantizer(d=d, bits=bits, seed=42)
+    save_params('/tmp/_decode.params', q)
+    cv = q.encode(X)
+    save_pq('/tmp/_decode.pq', cv)
+
+    np.save('/tmp/_decode_X.npy', X)
+    np.save('/tmp/_decode_full.npy', q.decode(cv).astype(np.float32))
+    np.save('/tmp/_decode_coarse.npy',
+            q.decode(cv, precision=coarse_precision).astype(np.float32))
+    np.save('/tmp/_decode_meta.npy',
+            np.array([[coarse_precision]], dtype=np.float32))
+    "
+"""
+
+from std.testing import assert_equal, assert_true
+from std.memory import alloc
+from src.codebook import Codebook, NestedCodebook, nested_codebooks_from
+from src.matrix import Matrix
+from src.npy import load_npy_2d_f32
+from src.params_format import load_params
+from src.pq_format import load_pq
+from src.quantizer import Quantizer, decode_batch
+from src.packing import unpack
+
+
+def _abs(x: Float32) -> Float32:
+    return -x if x < Float32(0.0) else x
+
+
+def main() raises:
+    var meta = load_npy_2d_f32(String("/tmp/_decode_meta.npy"))
+    var coarse_precision = Int(meta.get(0, 0))
+
+    var pq = load_pq(String("/tmp/_decode.pq"))
+    var d = pq.d
+    var n = pq.n
+    var bits = pq.bits
+
+    var expected_full = load_npy_2d_f32(String("/tmp/_decode_full.npy"))
+    var expected_coarse = load_npy_2d_f32(String("/tmp/_decode_coarse.npy"))
+    if expected_full.rows != n or expected_full.cols != d:
+        raise Error("expected_full shape mismatch")
+    if expected_coarse.rows != n or expected_coarse.cols != d:
+        raise Error("expected_coarse shape mismatch")
+
+    var R = Matrix(d, d)
+    var cb = Codebook(bits)
+    load_params(String("/tmp/_decode.params"), R, cb)
+    var nested = nested_codebooks_from(cb, d)
+    var q_quant = Quantizer(R^, cb^, d, bits, UInt64(42))
+
+    # Unpack indices once. Copy norms into a fresh buffer (UnsafePointer
+    # field aliasing workaround — same as in test_encode.mojo).
+    var indices = alloc[UInt8](n * d)
+    unpack(pq.packed_indices, n * d, bits, indices)
+    var norms_local = alloc[Float32](n)
+    for i in range(n):
+        norms_local[i] = pq.norms[i]
+
+    var X_hat_full = alloc[Float32](n * d)
+    decode_batch(q_quant, nested, indices, norms_local, n, 0, X_hat_full)
+
+    var max_diff_full: Float32 = Float32(0.0)
+    for i in range(n):
+        for j in range(d):
+            var a = X_hat_full[i * d + j]
+            var b = expected_full.get(i, j)
+            var diff = _abs(a - b)
+            if diff > max_diff_full:
+                max_diff_full = diff
+    print("decode full-precision max abs diff:", max_diff_full)
+    assert_true(max_diff_full < Float32(1e-5))
+
+    var X_hat_coarse = alloc[Float32](n * d)
+    decode_batch(q_quant, nested, indices, norms_local, n,
+                 coarse_precision, X_hat_coarse)
+
+    var max_diff_coarse: Float32 = Float32(0.0)
+    for i in range(n):
+        for j in range(d):
+            var a = X_hat_coarse[i * d + j]
+            var b = expected_coarse.get(i, j)
+            var diff = _abs(a - b)
+            if diff > max_diff_coarse:
+                max_diff_coarse = diff
+    print("decode coarse-precision (", coarse_precision, "bit) max abs diff:",
+          max_diff_coarse)
+    assert_true(max_diff_coarse < Float32(1e-5))
+
+    indices.free()
+    norms_local.free()
+    X_hat_full.free()
+    X_hat_coarse.free()
+    print("[test_decode] parity ok — Mojo decode matches Python to max abs diff < 1e-5")

--- a/remex/mojo/tests/test_packed_vectors.mojo
+++ b/remex/mojo/tests/test_packed_vectors.mojo
@@ -1,0 +1,184 @@
+"""Tests for `PackedVectors`: pack/unpack round-trips at all supported bit
+widths plus `at_precision` parity vs Python's `PackedVectors.at_precision`.
+
+The bit-width round-trips are self-contained (random uint8 values, mask
+to `bits`, pack into PackedVectors via `from_indices`, unpack back, byte
+compare). The at_precision parity is driven by a Python fixture written
+once before the test runs.
+
+Setup (run before this test):
+
+    python -c "
+    import numpy as np
+    from remex import Quantizer, PackedVectors
+
+    np.random.seed(0)
+    n, d, bits = 80, 16, 4
+    target_bits = 2
+
+    X = np.random.randn(n, d).astype(np.float32)
+    q = Quantizer(d=d, bits=bits, seed=42)
+    cv = q.encode(X)
+    packed = PackedVectors.from_compressed(cv)
+    np.save('/tmp/_pv_indices.npy', cv.indices.astype(np.float32))
+
+    packed_low = packed.at_precision(target_bits)
+    np.save('/tmp/_pv_indices_at.npy',
+            packed_low.unpack_rows(0, packed_low.n).astype(np.float32))
+
+    np.save('/tmp/_pv_meta.npy',
+            np.array([[n, d, bits, target_bits]], dtype=np.float32))
+    "
+"""
+
+from std.testing import assert_equal, assert_true
+from std.memory import alloc
+from src.npy import load_npy_2d_f32
+from src.packed_vectors import (
+    PackedVectors, from_indices, unpack_rows, unpack_all, unpack_at, at_precision,
+)
+from src.rng import Xoshiro256pp
+
+
+def _roundtrip_random(n: Int, d: Int, bits: Int, seed: UInt64) raises:
+    """Generate random uint8 indices, pack into PackedVectors, unpack, compare."""
+    var rng = Xoshiro256pp(seed)
+    var mask = UInt64((1 << bits) - 1) if bits < 8 else UInt64(0xFF)
+
+    var indices = alloc[UInt8](n * d)
+    for i in range(n * d):
+        indices[i] = UInt8(rng.next_u64() & mask)
+    var norms = alloc[Float32](n)
+    for i in range(n):
+        norms[i] = Float32(i) * Float32(0.5)
+
+    var pv = from_indices(indices, norms, n, d, bits)
+
+    # Round-trip 1: unpack_all
+    var out_all = alloc[UInt8](n * d)
+    unpack_all(pv, out_all)
+    for i in range(n * d):
+        assert_equal(Int(out_all[i]), Int(indices[i]))
+
+    # Round-trip 2: unpack_rows over a sub-range
+    if n >= 4:
+        var sub_start = 1
+        var sub_end = n - 1
+        var sub_count = sub_end - sub_start
+        var sub_out = alloc[UInt8](sub_count * d)
+        unpack_rows(pv, sub_start, sub_end, sub_out)
+        for i in range(sub_count):
+            for j in range(d):
+                assert_equal(Int(sub_out[i * d + j]),
+                             Int(indices[(sub_start + i) * d + j]))
+        sub_out.free()
+
+    # Round-trip 3: unpack_at single row
+    if n > 0:
+        var single = alloc[UInt8](d)
+        unpack_at(pv, n // 2, single)
+        for j in range(d):
+            assert_equal(Int(single[j]), Int(indices[(n // 2) * d + j]))
+        single.free()
+
+    # Norms preserved
+    for i in range(n):
+        assert_true(_abs(pv.norms[i] - norms[i]) < Float32(1e-7))
+
+    indices.free()
+    norms.free()
+    out_all.free()
+
+
+def _abs(x: Float32) -> Float32:
+    return -x if x < Float32(0.0) else x
+
+
+def test_roundtrips_all_widths() raises:
+    """Round-trip across all supported bit widths and a mix of d values.
+
+    The d list covers both row-aligned cases (d * bits divisible by 8) and
+    row-padded cases (e.g. d=10 at 3 bits → 30 bits per row, 6 row_bytes).
+    """
+    var widths = [1, 2, 3, 4, 8]
+    # (n, d) pairs — vary d so we hit row-aligned and row-padded layouts.
+    var ns = [1, 8, 100]
+    var ds = [4, 8, 10, 16, 17]
+    for bw in widths:
+        for n in ns:
+            for d in ds:
+                _roundtrip_random(n, d, bw, UInt64(bw * 1000 + d))
+        print("  bits =", bw, " roundtrips ok")
+
+
+def test_at_precision_parity() raises:
+    """Match Python's `PackedVectors.at_precision(target_bits).unpack_rows()`.
+
+    Loads the n, d, bits, target_bits and the expected unpacked indices
+    written by the Python fixture above, builds a Mojo PackedVectors from
+    the original indices, calls `at_precision(target_bits)`, and asserts
+    every uint8 cell matches.
+    """
+    var meta = load_npy_2d_f32(String("/tmp/_pv_meta.npy"))
+    var n = Int(meta.get(0, 0))
+    var d = Int(meta.get(0, 1))
+    var bits = Int(meta.get(0, 2))
+    var target_bits = Int(meta.get(0, 3))
+
+    var orig = load_npy_2d_f32(String("/tmp/_pv_indices.npy"))
+    var expected_at = load_npy_2d_f32(String("/tmp/_pv_indices_at.npy"))
+    if orig.rows != n or orig.cols != d:
+        raise Error("test_at_precision_parity: orig shape mismatch")
+    if expected_at.rows != n or expected_at.cols != d:
+        raise Error("test_at_precision_parity: expected_at shape mismatch")
+
+    # Build indices buffer from the float32 npy (values are 0..2^bits-1).
+    var indices = alloc[UInt8](n * d)
+    for i in range(n):
+        for j in range(d):
+            indices[i * d + j] = UInt8(Int(orig.get(i, j)))
+    var norms = alloc[Float32](n)
+    for i in range(n):
+        norms[i] = Float32(0.0)
+
+    var pv = from_indices(indices, norms, n, d, bits)
+    var pv_low = at_precision(pv, target_bits)
+    assert_equal(pv_low.bits, target_bits)
+    assert_equal(pv_low.n, n)
+    assert_equal(pv_low.d, d)
+
+    var unpacked = alloc[UInt8](n * d)
+    unpack_all(pv_low, unpacked)
+
+    var n_diff: Int = 0
+    for i in range(n):
+        for j in range(d):
+            var got = Int(unpacked[i * d + j])
+            var exp = Int(expected_at.get(i, j))
+            if got != exp:
+                n_diff += 1
+    print("at_precision(", target_bits, ") cell mismatches:", n_diff,
+          "out of", n * d)
+    assert_equal(n_diff, 0)
+
+    # at_precision(self.bits) returns a copy that round-trips identically.
+    var pv_same = at_precision(pv, bits)
+    var roundtrip = alloc[UInt8](n * d)
+    unpack_all(pv_same, roundtrip)
+    var n_diff_same: Int = 0
+    for i in range(n * d):
+        if Int(roundtrip[i]) != Int(indices[i]):
+            n_diff_same += 1
+    assert_equal(n_diff_same, 0)
+    print("at_precision(bits) self-copy round-trip ok")
+
+    indices.free()
+    norms.free()
+    unpacked.free()
+    roundtrip.free()
+
+
+def main() raises:
+    test_roundtrips_all_widths()
+    test_at_precision_parity()
+    print("[test_packed_vectors] all passed")


### PR DESCRIPTION
## Summary

Implements [issue #39](https://github.com/oaustegard/remex/issues/39): the Mojo
port now mirrors the Python library's reconstruction-side surface — `decode`
(approximate float32 reconstruction at full or nested precision) and
`PackedVectors` (memory-efficient bit-packed storage with row-aligned
offsets and Matryoshka downsampling).

- **`decode_batch` in `src/quantizer.mojo`** — per-row centroid lookup +
  rotation matvec (SIMD broadcast-FMA, same kernel shape as the encode
  hot loop) + norm rescale. Accepts a `precision` parameter; lower
  precisions look up the matching nested centroid table and right-shift
  the indices.
- **`src/packed_vectors.mojo`** — standalone `PackedVectors` struct
  mirroring `remex.core.PackedVectors`. Stores indices in `(n, row_bytes)`
  with `row_aligned` switching between flat-pack (when `d * bits` is a
  multiple of 8) and row-by-row pack with internal padding. Exposes
  `from_indices`, `from_pq_bytes`, `unpack_rows`, `unpack_all`,
  `unpack_at`, and `at_precision`.
- **CLI:** `polarquant decode in.pq --params P.bin [--precision K] -o out.npy`
  + a new `save_npy_2d_f32` writer in `src/npy.mojo` (v1.0 .npy that
  NumPy reads back directly).
- **Tests:** `tests/test_decode.mojo` (full + coarse-precision parity vs
  `Quantizer.decode`) and `tests/test_packed_vectors.mojo` (round-trips
  at 1/2/3/4/8 bits including row-padded layouts, plus `at_precision`
  parity vs Python).

## Acceptance criteria — verified

- `tests/test_decode.mojo`: max abs diff < 1e-5 vs Python `Quantizer.decode`
  given matching `(R, codebook, indices, norms)` — observed 0.0 (bit-
  identical) at full precision and at coarse precision (2 bits).
- `tests/test_packed_vectors.mojo`: pack/unpack round-trip across all
  supported bit widths (n × d combinations covering both row-aligned and
  row-padded layouts), plus `at_precision` parity vs Python's
  `PackedVectors.at_precision` — 0 cell mismatches out of 1280.
- CLI parity: `polarquant decode` written .npy matches Python's
  `Quantizer.decode(...).astype(np.float32)` to max abs diff 0.0 at both
  full and coarse precision.

## Drive-by fix

Marked `NestedCodebook.__init__` and `nested_codebooks{,_from}` as
`raises` so they parse under the current Mojo (0.26.2). Without this the
existing `test_search_twostage` also fails to compile in this container —
the parser no longer auto-promotes `def` with a `raise` to `raises` in
this context.

## Test plan

- [x] `mojo run -I . tests/test_packing.mojo` (regression — existing test still passes)
- [x] `mojo run -I . tests/test_encode.mojo` (regression)
- [x] `mojo run -I . tests/test_search_twostage.mojo` (regression — and required the codebook.mojo fix)
- [x] `mojo run -I . tests/test_decode.mojo` (new)
- [x] `mojo run -I . tests/test_packed_vectors.mojo` (new)
- [x] End-to-end: `polarquant decode` output bit-identical to Python decode

https://claude.ai/code/session_01Ew3k1hv9VjpNwR22wmoeCR