### PR TITLE
Mojo search_twostage: heap-based coarse top-k — closes #49

### DIFF
--- a/remex/mojo/src/quantizer.mojo
+++ b/remex/mojo/src/quantizer.mojo
@@ -150,6 +150,45 @@ fn _sumsq_f64(a: UnsafePointer[Float32, MutExternalOrigin], n: Int) -> Float64:
     return s
 
 
+fn _heap_sift_down(scores: UnsafePointer[Float32, MutExternalOrigin],
+                   indices: UnsafePointer[Int, MutExternalOrigin],
+                   root: Int, size: Int):
+    """Sift `root` downward to restore min-heap property keyed by `scores`.
+
+    Min-heap: every parent has a score <= each of its children. The root
+    holds the smallest score in the heap — i.e. the one to evict when a
+    strictly-larger candidate arrives.
+    """
+    var r = root
+    while True:
+        var left = 2 * r + 1
+        var right = 2 * r + 2
+        var smallest = r
+        if left < size and scores[left] < scores[smallest]:
+            smallest = left
+        if right < size and scores[right] < scores[smallest]:
+            smallest = right
+        if smallest == r:
+            return
+        var ts = scores[r]
+        var ti = indices[r]
+        scores[r] = scores[smallest]
+        indices[r] = indices[smallest]
+        scores[smallest] = ts
+        indices[smallest] = ti
+        r = smallest
+
+
+fn _heap_build_min(scores: UnsafePointer[Float32, MutExternalOrigin],
+                   indices: UnsafePointer[Int, MutExternalOrigin],
+                   size: Int):
+    """Bottom-up heapify over `size` parallel score/index slots."""
+    var i = (size - 2) // 2
+    while i >= 0:
+        _heap_sift_down(scores, indices, i, size)
+        i -= 1
+
+
 def _searchsorted(boundaries: UnsafePointer[Float32, MutExternalOrigin],
                   n_b: Int, x: Float32) -> Int:
     """numpy-default 'left' binary search: smallest i such that x < boundaries[i],
@@ -500,23 +539,31 @@ def search_twostage(q: Quantizer,
         coarse_scores[i] = s * norms[i]
     coarse_table.free()
 
-    # Pick the top `coarse_k` candidates by coarse score (selection-style).
-    # Order within the candidate set doesn't matter — only membership does.
+    # Pick the top `coarse_k` candidates by coarse score using a min-heap.
+    # The heap root tracks the smallest-score-currently-kept; replace it
+    # whenever a strictly-larger candidate arrives. Strict ">" matches the
+    # tie-break of the previous selection loop (same-score candidates do
+    # not displace each other), so the candidate-set MEMBERSHIP — and
+    # therefore the rerank output — is identical. Order within the set
+    # doesn't matter for the rerank, so heap order is fine.
+    # O(n log k) ≈ 90× fewer comparisons than the prior O(n·k) at the
+    # default (n=10000, candidates=500) settings — closes issue #49.
+    var heap_scores = alloc[Float32](coarse_k)
+    var heap_idx = alloc[Int](coarse_k)
+    for i in range(coarse_k):
+        heap_scores[i] = coarse_scores[i]
+        heap_idx[i] = i
+    _heap_build_min(heap_scores, heap_idx, coarse_k)
+    for i in range(coarse_k, n):
+        if coarse_scores[i] > heap_scores[0]:
+            heap_scores[0] = coarse_scores[i]
+            heap_idx[0] = i
+            _heap_sift_down(heap_scores, heap_idx, 0, coarse_k)
     var cand_idx = alloc[Int](coarse_k)
-    var used = alloc[UInt8](n)
-    for i in range(n):
-        used[i] = UInt8(0)
-    for outer in range(coarse_k):
-        var best_i: Int = -1
-        var best_s: Float32 = Float32(0.0)
-        for i in range(n):
-            if used[i] == UInt8(0):
-                if best_i < 0 or coarse_scores[i] > best_s:
-                    best_i = i
-                    best_s = coarse_scores[i]
-        cand_idx[outer] = best_i
-        used[best_i] = UInt8(1)
-    used.free()
+    for ci in range(coarse_k):
+        cand_idx[ci] = heap_idx[ci]
+    heap_scores.free()
+    heap_idx.free()
     coarse_scores.free()
 
     # Stage 2: full-precision rerank on the candidate set.


### PR DESCRIPTION
Closes #49.

## Summary

Replaces the O(n·candidates) selection-style coarse top-k in `search_twostage` with a min-heap walked once over `n` scores. O(n·k) → O(n log k), ~90× fewer comparisons at the default (n=10k, candidates=500).

## Why

Per [PR #48's bench refresh](https://github.com/oaustegard/remex/pull/48), the selection loop dominated Mojo's `search_twostage` so heavily that it was *slower* than NumPy at d ≤ 384 — defeating the memory-savings value vs single-stage `search`.

## Bench (n=10k, bits=4, queries=100, container CPU)

| d   | NumPy (ms/q) | Mojo before (ms/q) | Mojo after (ms/q) | Speedup vs before | Speedup vs NumPy |
|-----|-------------:|-------------------:|------------------:|------------------:|-----------------:|
|  64 |         3.42 |              16.59 |              0.51 |              33×  |             6.7× |
| 256 |        11.40 |              17.60 |              2.01 |             8.8×  |             5.7× |
| 384 |        17.59 |              19.00 |              3.18 |             6.0×  |             5.5× |
| 768 |        37.60 |              23.58 |              6.21 |             3.8×  |             6.1× |

Beats #49's <5 ms/q acceptance target at d=384 (3.18 ms/q). Consistently 5–7× faster than NumPy across all d — closing the headline gap from RESULTS.md and making `search_twostage` the right default for memory-constrained workloads (single-stage `search`-cached speed at 4× less memory).

## Implementation

Two new private helpers in `quantizer.mojo`:
- `_heap_sift_down(scores, indices, root, size)` — restore min-heap invariant
- `_heap_build_min(scores, indices, size)` — bottom-up heapify

Replace the selection loop with: heapify first `coarse_k` scores → stream remaining `n - coarse_k` and replace heap root only when **strictly greater** than current min. The strict `>` tie-break matches the original selection's `> best_s`, so candidate-set membership — and therefore the rerank output — is identical.

## Parity

`mojo run -I . tests/test_search_twostage.mojo`: 0 idx mismatches, scores match Python to 2.3e-7 (well within rtol=1e-5).

## Follow-up

#50 (NB=8 row-block the coarse-stage ADC scoring loop) is unblocked. The selection loop was masking it; now the per-row gather+arithmetic in the coarse-stage scoring is the next bottleneck. Estimated ~1.5–2× further on the coarse pass after #50 lands.

## Test plan
- [x] `mojo run -I . tests/test_search_twostage.mojo` — parity vs Python
- [x] All other Mojo tests pass (`test_rng`, `test_rng_numpy`, `test_codebook`, `test_packing`, `test_packed_vectors`)
- [x] `python bench/compare.py --d 384 --n 10000 --queries 100` — 5 trials, median 3.0 ms/q