### PR TITLE
docs(bench): refresh for PR #51 twostage min-heap + add mojo/bench/RESULTS.md

### DIFF
--- a/bench/RESULTS.md
+++ b/bench/RESULTS.md
@@ -1,7 +1,7 @@
 # Benchmark Results
 
-**Date**: 2026-04-05
-**Library version**: remex 0.5.0
+**Date**: 2026-04-05 (recall, distribution, SPECTER2) · 2026-05-01 (Mojo twostage refresh, PR [#51](https://github.com/oaustegard/remex/pull/51))
+**Library version**: remex 0.5.1
 **Hardware**: CPU (NumPy), no GPU
 **Seeds**: corpus seed=42, query seed=99, quantizer seed=42
 
@@ -132,7 +132,10 @@ Float32 baseline: 1,536 bytes/vector, 15.36 MB per 10k vectors.
 
 ## Mojo port (`polarquant`) vs NumPy
 
-Standalone Mojo binary built from `remex/mojo/` (issue #5).
+Standalone Mojo binary built from `remex/mojo/` (issue #5). Full Mojo-vs-NumPy
+results — including the build matrix, reproduce commands, and PR-by-PR history
+— live in [`remex/mojo/bench/RESULTS.md`](../remex/mojo/bench/RESULTS.md).
+Headline numbers below.
 
 Since [#40](https://github.com/oaustegard/remex/issues/40), Mojo's
 default `--seed S` path uses the same RNG stack as NumPy
@@ -150,22 +153,26 @@ all-bit-widths bridge.) See `remex/mojo/README.md#two-parameter-modes`.
 |--------------------|---------:|--------:|--------:|
 | encode (µs/vec)    |     17.0 |    13.3 | **1.27x** |
 | ADC search (ms/q)  |     16.4 |     2.7 | **6.0x**  |
-| twostage (ms/q)    |     17.3 |    19.0 | 0.91x   |
+| twostage (ms/q)    |     17.6 |     3.2 | **5.5x**  |
 
-#### Scaling across `d` (1 trial each, indicative)
+#### Scaling across `d`
+
+twostage row is post-[#51](https://github.com/oaustegard/remex/pull/51)
+(min-heap coarse top-k, 5-trial median); encode and search rows are 1-trial
+indicative pre-#51 measurements.
 
 | `d`  | NumPy encode (µs) | Mojo encode (µs) | encode speedup | NumPy search (ms) | Mojo search (ms) | search speedup | NumPy twostage (ms) | Mojo twostage (ms) | twostage speedup |
 |-----:|------------------:|-----------------:|---------------:|------------------:|-----------------:|---------------:|--------------------:|-------------------:|-----------------:|
-|   64 |              3.65 |             1.72 |          2.12x |              2.99 |             0.70 |          4.30x |                3.24 |              16.59 |            0.20x |
-|  256 |             13.21 |             8.24 |          1.60x |             11.63 |             1.85 |          6.28x |               12.38 |              17.60 |            0.70x |
-|  384 |             ~17.0 |            ~13.3 |          1.27x |             16.40 |             2.71 |          6.01x |               17.26 |              19.00 |            0.91x |
-|  768 |             44.52 |            39.65 |          1.12x |             36.28 |             5.36 |          6.77x |               36.69 |              23.58 |          **1.56x** |
+|   64 |              3.65 |             1.72 |          2.12x |              2.99 |             0.70 |          4.30x |                3.42 |               0.51 |          **6.7x** |
+|  256 |             13.21 |             8.24 |          1.60x |             11.63 |             1.85 |          6.28x |               11.40 |               2.01 |          **5.7x** |
+|  384 |             ~17.0 |            ~13.3 |          1.27x |             16.40 |             2.71 |          6.01x |               17.59 |               3.18 |          **5.5x** |
+|  768 |             44.52 |            39.65 |          1.12x |             36.28 |             5.36 |          6.77x |               37.60 |               6.21 |          **6.1x** |
 
 ### Notes
 
 - **Encode** crossed from 1.3x slower (initial port, scalar matvec, `_dot_f32` only) to 1.27x faster after [#37](https://github.com/oaustegard/remex/pull/37) (SIMD vectorization) + [#41](https://github.com/oaustegard/remex/issues/41) (NB=8 row-blocking through `_dot_block_8`). The float64-accumulator norm change in [#40](https://github.com/oaustegard/remex/issues/40) (needed for byte parity vs Python's `np.linalg.norm`) did not measurably regress encode speed — norm is a tiny fraction of the encode hot path.
 - **ADC search** wins consistently (4–7×) because Mojo's gather-then-scalar-add inner loop auto-vectorizes well; NumPy's equivalent is bottlenecked on per-chunk `np.outer` + `table[idx]` gathers.
-- **Twostage** is the weak spot. Mojo's `search_twostage` time is roughly d-independent (~17–24 ms across all d), while NumPy scales with d. Mojo loses at small d (5× slower at d=64) and wins at large d (1.56× faster at d=768). The dominant cost is the O(n·candidates) selection-style coarse top-k loop in `search_twostage` — flagged as "naive" in `remex/mojo/README.md#known-gaps`. A min-heap or quickselect would drop that to O(n log k) ≈ 90× fewer ops at n=10k, candidates=500.
+- **Twostage** was the weak spot before [#51](https://github.com/oaustegard/remex/pull/51): the O(n·candidates) selection-style coarse top-k loop made Mojo slower than NumPy at d ≤ 384 (0.20× at d=64). PR #51 replaced that with a min-heap walked once over `n` scores — O(n·k) → O(n log k), ~90× fewer comparisons at the default (n=10k, candidates=500). Mojo `search_twostage` is now consistently 5.5–6.7× faster than NumPy across all d, restoring it as the right default for memory-constrained workloads (single-stage `search`-cached speed at 4× less memory). The next bottleneck on the coarse pass is the per-row gather+arithmetic in ADC scoring, tracked by [#50](https://github.com/oaustegard/remex/issues/50) (~1.5–2× further estimated).
 - **Encode advantage at d=768** shrinks to 1.12× — the matvec hits memory bandwidth limits, so Mojo and NumPy's BLAS converge.
 
 ### Reproduce

--- a/remex/mojo/bench/RESULTS.md
+++ b/remex/mojo/bench/RESULTS.md
@@ -1,0 +1,124 @@
+# Mojo `polarquant` vs NumPy `remex` — Benchmark Results
+
+**Last refreshed**: 2026-05-01 (twostage post-[#51](https://github.com/oaustegard/remex/pull/51))
+**Library version**: remex 0.5.1 · `polarquant` Mojo binary
+**Hardware**: container CPU (no GPU)
+**Seeds**: corpus seed=42, query seed=99, quantizer seed=42
+**Workload**: n=10000, bits=4, k=10
+
+This file lives next to the comparison driver
+([`compare.py`](compare.py)) and the per-stage bench binaries
+(`bench_encode.mojo`, `bench_search.mojo`, `bench_twostage.mojo`).
+For broader recall, distribution, and SPECTER2 results see
+[`bench/RESULTS.md`](../../../bench/RESULTS.md) at the repo root.
+
+## RNG parity (since [#40](https://github.com/oaustegard/remex/issues/40))
+
+Mojo's default `--rng numpy` path uses the same stack as NumPy
+(`SeedSequence + PCG64 + Ziggurat`) and produces a `.pq` **byte-identical**
+to Python's `save_pq(Quantizer(d, bits, seed=S).encode(X))` at 1–4 bits.
+Pass `--rng xoshiro` to opt back into the legacy xoshiro256++ + Marsaglia
+path; `--params` remains the canonical all-bit-widths bridge between the
+two implementations.
+
+## Headline (d=384, queries=100, median of 5 trials)
+
+| Stage              |    NumPy |    Mojo | Speedup |
+|--------------------|---------:|--------:|--------:|
+| encode (µs/vec)    |     17.0 |    13.3 | **1.27x** |
+| ADC search (ms/q)  |     16.4 |     2.7 | **6.0x**  |
+| twostage (ms/q)    |     17.6 |     3.2 | **5.5x**  |
+
+## Scaling across `d`
+
+twostage column is the post-[#51](https://github.com/oaustegard/remex/pull/51)
+min-heap coarse top-k, 5-trial median. encode and search columns are 1-trial
+indicative measurements (pre-#51, unaffected by it).
+
+| `d`  | NumPy encode (µs) | Mojo encode (µs) | encode speedup | NumPy search (ms) | Mojo search (ms) | search speedup | NumPy twostage (ms) | Mojo twostage (ms) | twostage speedup |
+|-----:|------------------:|-----------------:|---------------:|------------------:|-----------------:|---------------:|--------------------:|-------------------:|-----------------:|
+|   64 |              3.65 |             1.72 |          2.12x |              2.99 |             0.70 |          4.30x |                3.42 |               0.51 |          **6.7x** |
+|  256 |             13.21 |             8.24 |          1.60x |             11.63 |             1.85 |          6.28x |               11.40 |               2.01 |          **5.7x** |
+|  384 |             ~17.0 |            ~13.3 |          1.27x |             16.40 |             2.71 |          6.01x |               17.59 |               3.18 |          **5.5x** |
+|  768 |             44.52 |            39.65 |          1.12x |             36.28 |             5.36 |          6.77x |               37.60 |               6.21 |          **6.1x** |
+
+## History
+
+| When | PR | Stage | Change | d=384 result |
+|------|----|----|--------|--------------|
+| 2026-03 | [#37](https://github.com/oaustegard/remex/pull/37) | encode | SIMD vectorization | 1.3× slower → near parity |
+| 2026-03 | [#41](https://github.com/oaustegard/remex/issues/41) | encode | NB=8 row-blocking via `_dot_block_8` | 1.27× faster vs NumPy |
+| 2026-04 | [#40](https://github.com/oaustegard/remex/issues/40) | encode | float64-accumulator norm for byte parity | unchanged hot path |
+| 2026-04 | [#48](https://github.com/oaustegard/remex/pull/48) | bench | Refresh; flagged twostage as weak spot | 19.0 ms (0.91×) |
+| 2026-05 | [#51](https://github.com/oaustegard/remex/pull/51) | twostage | Min-heap coarse top-k (O(n·k) → O(n log k)) | 3.18 ms (5.5×) |
+
+## Notes
+
+- **Encode** is bandwidth-limited at d=768 — the matvec hits memory bandwidth
+  ceiling, so Mojo and NumPy's BLAS converge to ~1.12×.
+- **ADC search** wins consistently (4–7×) because Mojo's gather-then-scalar-add
+  inner loop auto-vectorizes well; NumPy's equivalent is bottlenecked on
+  per-chunk `np.outer` + `table[idx]` gathers.
+- **Twostage** was the weak spot before [#51](https://github.com/oaustegard/remex/pull/51).
+  The O(n·candidates) selection-style coarse top-k made Mojo *slower* than
+  NumPy at d ≤ 384 (0.20× at d=64), defeating the memory-savings value of
+  `search_twostage` vs single-stage `search`. PR #51 replaced the selection
+  loop with a min-heap walked once over `n` scores — ~90× fewer comparisons
+  at the default (n=10k, candidates=500). Now consistently 5.5–6.7× faster
+  than NumPy across all d.
+- **Next bottleneck**: per-row gather+arithmetic in coarse-stage ADC scoring,
+  tracked by [#50](https://github.com/oaustegard/remex/issues/50). Estimated
+  ~1.5–2× further on the coarse pass.
+
+## Build
+
+```bash
+cd remex/mojo
+
+mojo build -I . polarquant.mojo            -o polarquant
+mojo build -I . bench/bench_encode.mojo    -o bench/bench_encode
+mojo build -I . bench/bench_search.mojo    -o bench/bench_search
+mojo build -I . bench/bench_twostage.mojo  -o bench/bench_twostage
+```
+
+The container needs the Mojo compiler — see
+[`../README.md`](../README.md#build) for installation.
+
+## Reproduce
+
+The headline numbers above:
+
+```bash
+cd remex/mojo
+python bench/compare.py --n 10000 --d 384 --bits 4 --queries 100 --k 10
+```
+
+Scaling sweep (re-runs `compare.py` per `d`):
+
+```bash
+cd remex/mojo
+for d in 64 256 384 768; do
+  python bench/compare.py --n 10000 --d $d --bits 4 --queries 100 --k 10
+done
+```
+
+Individual stages directly:
+
+```bash
+cd remex/mojo
+./bench/bench_encode    --n 10000 --d 384 --bits 4 --seed 42
+./bench/bench_search    --n 10000 --d 384 --bits 4 --queries 100 --k 10 --seed 42
+./bench/bench_twostage  --n 10000 --d 384 --bits 4 --queries 100 --k 10 --seed 42 \
+                        --candidates 500 --coarse-precision 2
+```
+
+## Parity verification
+
+Twostage parity (re-run after any change to coarse top-k or rerank):
+
+```bash
+mojo run -I . tests/test_search_twostage.mojo
+```
+
+PR #51 result: 0 idx mismatches, scores match Python to 2.3e-7 (well within
+`rtol=1e-5`).


### PR DESCRIPTION
Documents the [#51](https://github.com/oaustegard/remex/pull/51) Mojo `search_twostage` min-heap landing.

## Why now

PR #51 dropped Mojo `search_twostage` from 19.0 → 3.18 ms/q at d=384 (0.91× → 5.5× vs NumPy), and made it consistently 5.5–6.7× faster across all d. `bench/RESULTS.md` still showed the pre-#51 numbers and called twostage "the weak spot". Also `remex/mojo/README.md` references `bench/RESULTS.md` ("See `bench/RESULTS.md` (in this PR) for current numbers") but no such file existed under `remex/mojo/bench/`.

## Changes

**`bench/RESULTS.md`** — refresh the Mojo port section:
- Headline d=384 table: twostage row updated to 17.6 / 3.2 ms/q (5.5×)
- Scaling table: twostage column updated with PR #51's 5-trial median numbers (NumPy and Mojo both); encode/search columns left alone (PR #51 didn't touch them)
- Notes: replaced the obsolete "twostage is the weak spot" paragraph with a brief PR #51 history; #50 callout for the next bottleneck
- Added a link to the new `remex/mojo/bench/RESULTS.md` for the focused Mojo-vs-NumPy view
- Date stamp split: original recall/distribution/SPECTER2 stays at 2026-04-05; Mojo refresh at 2026-05-01

**`remex/mojo/bench/RESULTS.md`** (new) — the file the Mojo README has been pointing to. Focused Mojo-vs-NumPy comparison: headline + scaling tables + PR-by-PR history + build/reproduce/parity commands. Lives next to `compare.py` and the `bench_*.mojo` binaries it documents.

## Numbers

All from PR #51 body (5-trial median, n=10000, bits=4, queries=100, container CPU):

| d   | NumPy (ms/q) | Mojo before (ms/q) | Mojo after (ms/q) | vs before | vs NumPy |
|-----|-------------:|-------------------:|------------------:|----------:|---------:|
|  64 |         3.42 |              16.59 |              0.51 |       33× |     6.7× |
| 256 |        11.40 |              17.60 |              2.01 |      8.8× |     5.7× |
| 384 |        17.59 |              19.00 |              3.18 |      6.0× |     5.5× |
| 768 |        37.60 |              23.58 |              6.21 |      3.8× |     6.1× |

## Out of scope

Directory restructure (root `remex/` → `src/`, separating Python/Mojo) is a separate forthcoming PR — orthogonal to this docs refresh.