### PR TITLE
Add SPECTER2 embeddings cache fetcher (skip the 50-min transformer encode)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,12 @@ pytest tests/test_adc_gpu.py -v  # just ADC/GPU tests, ~30s
 python bench/benchmark.py               # synthetic data, no extra deps
 pip install -e ".[bench]"               # for real embedding benchmarks
 python bench/real_embedding_eval.py     # needs sentence-transformers + faiss-cpu
+
+# SPECTER2 (allenai/specter2_base, d=768) — encoding the transformer takes
+# ~50 min on CPU per 10k papers. Skip the encode by pulling a precomputed
+# cache from GH release:
+bash bench/fetch_specter2_cache.sh      # ~45 MB, restores .specter2_cache/
+python bench/specter2_eval.py --cached  # then run the bench against the cache
 ```
 
 ## Code conventions

--- a/bench/fetch_specter2_cache.sh
+++ b/bench/fetch_specter2_cache.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Fetch precomputed SPECTER2 embeddings into bench/.specter2_cache/ so that
+# `python bench/specter2_eval.py --cached` works without rerunning the
+# ~50-minute CPU encode of the SPECTER2 transformer model.
+#
+# Cache contents (~45 MB total):
+#   specter2_nlp_broad.npy         — (10000, 768) float32 SPECTER2 embeddings
+#   specter2_nlp_broad_texts.json  — original "title [SEP] abstract" strings
+#
+# Source: oaustegard/claude-container-layers releases (free GH-hosted asset).
+# Re-run safe; --clobber-equivalent overwrite via gh release download -O.
+set -euo pipefail
+
+REPO=${SPECTER2_CACHE_REPO:-oaustegard/claude-container-layers}
+TAG=${SPECTER2_CACHE_TAG:-specter2-nlp-broad-10k}
+CACHE_DIR="$(cd "$(dirname "$0")" && pwd)/.specter2_cache"
+
+mkdir -p "$CACHE_DIR"
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "error: gh CLI not found. Install: https://cli.github.com/" >&2
+  exit 1
+fi
+
+for asset in specter2_nlp_broad.npy specter2_nlp_broad_texts.json; do
+  out="$CACHE_DIR/$asset"
+  echo "fetching $asset → $out"
+  gh release download "$TAG" --repo "$REPO" --pattern "$asset" \
+    --output "$out" --clobber
+done
+
+echo "done. run: python bench/specter2_eval.py --cached"


### PR DESCRIPTION
## Summary

Adds `bench/fetch_specter2_cache.sh` so `bench/specter2_eval.py --cached`
can be run from any fresh container in seconds, instead of waiting ~50
minutes for the SPECTER2 transformer to re-encode 10k papers on CPU.

The cache lives as a GitHub release asset on
`oaustegard/claude-container-layers` (release tag `specter2-nlp-broad-10k`).
The fetcher writes to `.specter2_cache/specter2_nlp_broad.npy` /
`_texts.json` — exactly the paths `specter2_eval.py` already looks for.

## Why this and not something fancier

- **Float32 source, not quantized variants** — encoding the SPECTER2
  transformer is the slow step (~300 ms/vec on CPU). The Lloyd-Max
  quantization that turns float32 → 1/2/3/4/8-bit indices is fast in
  both Python (44 µs/vec at d=768) and Mojo (40 µs/vec), so caching
  variants would save microseconds. Caching the source captures all
  the value.
- **GitHub Release asset, not LFS or HF Hub** — ~45 MB total, fits
  trivially as a release asset, no LFS overhead, no external
  dependency. If we ever publish the SPECTER2 1-bit Matryoshka result
  externally, an HF Hub dataset would be the right home for that
  separately.
- **Configurable via env vars** — `SPECTER2_CACHE_REPO` and
  `SPECTER2_CACHE_TAG` let someone point the fetcher at a different
  release if they cache a different corpus.

## Follow-up

Numbers from the n=10k SPECTER2 bench (currently encoding) will land
as a separate PR updating `bench/RESULTS.md` once the encode + bench
+ release upload pipeline completes.

## Test plan

- [ ] `bash bench/fetch_specter2_cache.sh` in a fresh checkout
      pulls the two assets into `.specter2_cache/`
- [ ] `python bench/specter2_eval.py --cached` runs end-to-end
      against the fetched cache
- [ ] Re-running the fetcher overwrites cleanly (no duplicate files,
      no permission prompts)

*Filed by Muninn*
