### PR TITLE
Mojo port: IVFCoarseIndex parity with Python

### DIFF
--- a/remex/mojo/README.md
+++ b/remex/mojo/README.md
@@ -25,6 +25,7 @@ remex/mojo/
 │   ├── pq_format.mojo       # .pq binary format read/write
 │   ├── params_format.mojo   # .params dump (R + boundaries + centroids)
 │   ├── quantizer.mojo       # Quantizer struct: encode + ADC search + two-stage + decode
+│   ├── ivf.mojo             # IVFCoarseIndex: data-oblivious IVF over Matryoshka coarse tier
 │   └── gpu/                 # GPU/MAX kernels — scaffolding, see issue #42
 │       ├── device.mojo      # is_gpu_available() probe
 │       ├── encode.mojo      # gpu_encode_batch (stub)
@@ -38,12 +39,15 @@ remex/mojo/
 │   ├── test_encode.mojo            # bit-identical encode parity vs Python
 │   ├── test_decode.mojo            # decode parity vs Python (full + coarse precision)
 │   ├── test_search_twostage.mojo   # top-k parity for search_twostage vs Python
+│   ├── test_ivf.mojo               # IVFCoarseIndex parity vs Python (cell IDs + search)
+│   ├── build_ivf_fixture.py        # Python fixture builder for test_ivf.mojo
 │   ├── test_gpu_encode.mojo        # encode parity for --device gpu (skipped without GPU)
 │   └── test_gpu_search.mojo        # ADC parity vs CPU for --device gpu (skipped without GPU)
 └── bench/
     ├── bench_encode.mojo
     ├── bench_search.mojo
     ├── bench_twostage.mojo
+    ├── bench_ivf.mojo              # IVF two-stage latency at varying nprobe
     ├── bench_gpu_encode.mojo       # GPU encode timing (skipped without GPU)
     ├── bench_gpu_search.mojo       # GPU ADC timing (skipped without GPU)
     └── compare.py           # Mojo vs NumPy comparison driver
@@ -66,6 +70,7 @@ mojo build -I . polarquant.mojo            -o polarquant
 mojo build -I . bench/bench_encode.mojo    -o bench/bench_encode
 mojo build -I . bench/bench_search.mojo    -o bench/bench_search
 mojo build -I . bench/bench_twostage.mojo  -o bench/bench_twostage
+mojo build -I . bench/bench_ivf.mojo       -o bench/bench_ivf
 ```
 
 ## CLI usage
@@ -249,6 +254,10 @@ np.save('/tmp/_twostage_expected_idx.npy', expected_idx)
 np.save('/tmp/_twostage_expected_scores.npy', expected_scores)
 "
 mojo run -I . tests/test_search_twostage.mojo
+
+# IVFCoarseIndex parity (cell IDs in both modes + search at full nprobe):
+python remex/mojo/tests/build_ivf_fixture.py
+mojo run -I . tests/test_ivf.mojo
 ```
 
 ## Benchmarks
@@ -256,6 +265,10 @@ mojo run -I . tests/test_search_twostage.mojo
 ```bash
 cd remex/mojo
 python bench/compare.py --n 10000 --d 384 --bits 4 --queries 100 --k 10
+
+# IVF latency at varying nprobe (auto doubling sweep up to n_cells).
+./bench/bench_ivf --n 100000 --d 384 --bits 4 --queries 100 --k 10 \
+    --n-bits 8 --mode rotated_prefix --candidates 500 --coarse-precision 2
 ```
 
 See `bench/RESULTS.md` (in this PR) for current numbers.

--- a/remex/mojo/bench/bench_ivf.mojo
+++ b/remex/mojo/bench/bench_ivf.mojo
@@ -1,0 +1,190 @@
+"""Time IVFCoarseIndex.search_twostage at varying nprobe.
+
+Mirrors `bench_twostage` but goes through the IVF stage-1 instead of a
+flat coarse scan. Reports per-query latency at each `--nprobe` value
+plus the candidate-pool size, so the latency-recall trade-off can be
+read off alongside the candidate-fraction sweep that the Python
+`bench/specter2_eval.py` produces.
+
+Usage:
+    bench_ivf --n N --d D --bits B --queries Q --k K
+              [--n-bits NB] [--mode lsh|rotated_prefix]
+              [--candidates C] [--coarse-precision K] [--seed S]
+
+The nprobe sweep is fixed at `[1, 2, 4, 8, ..., n_cells]`, mirroring
+the doubling schedule used by the Python IVF benchmark.
+
+Default `coarse_precision` is `max(1, bits - 2)`, matching `bench_twostage`.
+"""
+
+from std.sys import argv
+from std.time import perf_counter_ns
+from std.memory import alloc
+from src.codebook import lloyd_max_codebook, nested_codebooks_from
+from src.ivf import (
+    IVFCoarseIndex,
+    MODE_LSH,
+    MODE_ROTATED_PREFIX,
+    build_ivf,
+    candidate_count,
+    search_twostage,
+)
+from src.matrix import Matrix
+from src.packed_vectors import PackedVectors, from_indices
+from src.quantizer import Quantizer, encode_batch
+from src.rotation import haar_rotation
+from src.rng import Xoshiro256pp
+
+
+def _arg_idx(args: List[String], flag: String) -> Int:
+    for i in range(len(args)):
+        if args[i] == flag:
+            return i
+    return -1
+
+
+def _flag_int(args: List[String], flag: String, default: Int) raises -> Int:
+    var i = _arg_idx(args, flag)
+    if i < 0:
+        return default
+    return Int(args[i + 1])
+
+
+def _flag_str(args: List[String], flag: String,
+              default: String) raises -> String:
+    var i = _arg_idx(args, flag)
+    if i < 0:
+        return default
+    return args[i + 1]
+
+
+def _doubling_sweep(n_cells: Int) -> List[Int]:
+    """Generate `[1, 2, 4, 8, ..., n_cells]` for the latency sweep.
+
+    Tracks the typical exponential nprobe schedule used in IVF benchmarks
+    — each step roughly doubles the candidate pool, so the latency curve
+    is readable on a log-x axis.
+    """
+    var out = List[Int]()
+    var v = 1
+    while v < n_cells:
+        out.append(v)
+        v = v * 2
+    out.append(n_cells)
+    return out^
+
+
+def main() raises:
+    var args = argv()
+    var sub = List[String]()
+    for i in range(1, len(args)):
+        sub.append(String(args[i]))
+
+    var n = _flag_int(sub, String("--n"), 10000)
+    var d = _flag_int(sub, String("--d"), 384)
+    var bits = _flag_int(sub, String("--bits"), 4)
+    var queries = _flag_int(sub, String("--queries"), 100)
+    var k = _flag_int(sub, String("--k"), 10)
+    var n_bits = _flag_int(sub, String("--n-bits"), 8)
+    var mode_str = _flag_str(sub, String("--mode"), String("rotated_prefix"))
+    var candidates = _flag_int(sub, String("--candidates"), 500)
+    var default_coarse = bits - 2 if bits - 2 >= 1 else 1
+    var coarse_precision = _flag_int(sub, String("--coarse-precision"),
+                                     default_coarse)
+    var seed = UInt64(_flag_int(sub, String("--seed"), 42))
+
+    var mode_int: Int
+    if mode_str == "lsh":
+        mode_int = MODE_LSH
+    elif mode_str == "rotated_prefix":
+        mode_int = MODE_ROTATED_PREFIX
+    else:
+        raise Error("--mode must be 'lsh' or 'rotated_prefix'")
+
+    print("bench_ivf: n =", n, "d =", d, "bits =", bits,
+          "queries =", queries, "k =", k,
+          "n_bits =", n_bits, "mode =", mode_str,
+          "candidates =", candidates,
+          "coarse_precision =", coarse_precision)
+
+    # Build corpus and quantizer (xoshiro path — fastest startup; cell
+    # IDs aren't compared here, only latency).
+    var rng = Xoshiro256pp(seed)
+    var X = alloc[Float32](n * d)
+    for i in range(n * d):
+        X[i] = Float32(rng.next_normal())
+
+    var R = haar_rotation(d, seed)
+    var cb = lloyd_max_codebook(d, bits)
+    var nested = nested_codebooks_from(cb, d)
+    var q = Quantizer(R^, cb^, d, bits, seed)
+
+    var indices = alloc[UInt8](n * d)
+    var norms = alloc[Float32](n)
+    encode_batch(q, X, n, indices, norms)
+    X.free()
+
+    var packed = from_indices(indices, norms, n, d, bits)
+    indices.free()
+    norms.free()
+
+    # Build the IVF index — counted separately so we can report the
+    # one-time index build cost.
+    var t_build0 = perf_counter_ns()
+    var ivf = build_ivf(q, packed, n_bits, mode_int, seed)
+    var t_build1 = perf_counter_ns()
+    var build_ms = Float64(Int(t_build1 - t_build0)) / 1000000.0
+    print("  build_ivf:", build_ms, "ms (n_cells =", ivf.n_cells,
+          ", index_nbytes =", ivf.index_nbytes(), ")")
+
+    # Build random queries.
+    var Q_buf = alloc[Float32](queries * d)
+    for i in range(queries * d):
+        Q_buf[i] = Float32(rng.next_normal())
+
+    var top_idx = alloc[Int](k)
+    var top_scores = alloc[Float32](k)
+
+    var nprobes = _doubling_sweep(ivf.n_cells)
+
+    # Warmup once at nprobe=1.
+    var qbuf0 = alloc[Float32](d)
+    for j in range(d):
+        qbuf0[j] = Q_buf[j]
+    var _w = search_twostage(ivf, q, nested, packed, qbuf0, k, candidates, 1,
+                             coarse_precision, top_idx, top_scores)
+    qbuf0.free()
+
+    print("  nprobe   ms/query   avg_candidates")
+    for ni in range(len(nprobes)):
+        var nprobe = nprobes[ni]
+        if nprobe <= 0 or nprobe > ivf.n_cells:
+            continue
+
+        # First sweep: capture average candidate-pool size at this nprobe.
+        var total_cands: Int = 0
+        for qi in range(queries):
+            var qbuf = alloc[Float32](d)
+            for j in range(d):
+                qbuf[j] = Q_buf[qi * d + j]
+            total_cands += candidate_count(ivf, q, qbuf, nprobe)
+            qbuf.free()
+        var avg_cands = Float64(total_cands) / Float64(queries)
+
+        # Second sweep: timed twostage search at this nprobe.
+        var t0 = perf_counter_ns()
+        for qi in range(queries):
+            var qbuf = alloc[Float32](d)
+            for j in range(d):
+                qbuf[j] = Q_buf[qi * d + j]
+            var _r = search_twostage(ivf, q, nested, packed, qbuf,
+                                     k, candidates, nprobe,
+                                     coarse_precision, top_idx, top_scores)
+            qbuf.free()
+        var t1 = perf_counter_ns()
+        var ms_per_q = Float64(Int(t1 - t0)) / Float64(queries) / 1000000.0
+        print(" ", nprobe, "  ", ms_per_q, "  ", avg_cands)
+
+    Q_buf.free()
+    top_idx.free()
+    top_scores.free()

--- a/remex/mojo/src/ivf.mojo
+++ b/remex/mojo/src/ivf.mojo
@@ -1,0 +1,624 @@
+"""Coarse IVF index over the Matryoshka tier — Mojo port of `remex.ivf`.
+
+Mirrors `remex.ivf.IVFCoarseIndex` (Python). Partitions a `PackedVectors`
+corpus into `2**n_bits` cells via a *data-oblivious* hash (no k-means,
+no training). Visiting only `nprobe` cells per query trades recall for
+stage-1 latency in two-stage retrieval.
+
+Two hash modes — both reproduce the Python cell assignments byte-for-byte
+when seeded the same way:
+
+  - `MODE_LSH` — random-hyperplane SimHash. `n_bits` hyperplanes are drawn
+    from the NumPy-compatible Ziggurat normal RNG (`NumpyNormalRNG`), so
+    `(d, n_bits, seed)` produces the *same* hyperplane matrix as
+    `np.random.default_rng(seed).standard_normal((n_bits, d))`. Cell ID
+    is the bit-pattern of `sign(H @ s)` where `s = 2*MSB(idx) - 1` is the
+    1-bit reconstruction in rotated space.
+
+  - `MODE_ROTATED_PREFIX` — sign of the first `n_bits` post-rotation
+    coordinates, taken directly as the MSBs of the encoded indices. Free
+    given the existing rotation matrix.
+
+Multi-probe ordering: cells are ranked by Hamming distance to the query
+hash, ties broken by ascending cell ID. `nprobe = n_cells` recovers a
+flat coarse scan exactly. This is enforced by both
+`tests/test_ivf.py::TestSearchCoarse::test_full_nprobe_matches_search_adc`
+(Python) and `tests/test_ivf.mojo::test_full_nprobe_matches_adc_search`
+(Mojo).
+
+Closes issue #61 (Mojo parity with Python `IVFCoarseIndex` from PR #58 / #53).
+"""
+
+from std.math import sqrt
+from std.memory import alloc, UnsafePointer
+from src.codebook import NestedCodebook
+from src.matrix import Matrix
+from src.packed_vectors import PackedVectors, unpack_at, unpack_rows
+from src.quantizer import Quantizer
+from src.rng_numpy import NumpyNormalRNG
+
+
+alias MODE_LSH = 0
+alias MODE_ROTATED_PREFIX = 1
+
+
+fn _popcount32(x: UInt32) -> Int:
+    """Hamming weight of a 32-bit integer (SWAR popcount)."""
+    var v = x
+    v = v - ((v >> UInt32(1)) & UInt32(0x55555555))
+    v = (v & UInt32(0x33333333)) + ((v >> UInt32(2)) & UInt32(0x33333333))
+    v = (v + (v >> UInt32(4))) & UInt32(0x0F0F0F0F)
+    v = (v * UInt32(0x01010101)) >> UInt32(24)
+    return Int(v)
+
+
+struct IVFCoarseIndex(Movable):
+    """Inverted-file index over a `PackedVectors` corpus.
+
+    Owning struct: `__init__` allocates the cell metadata + (optionally)
+    the LSH hyperplane matrix; `__del__` frees them. The underlying
+    `PackedVectors` is *not* owned — callers must keep it alive for the
+    lifetime of the index (parity with the Python class, which stores
+    `compressed` by reference).
+
+    Layout matches `remex.ivf.IVFCoarseIndex`:
+      - `cell_ids`   (n,)             uint16 cell ID per corpus row
+      - `sorted_idx` (n,)             int64 corpus row indices sorted by cell
+      - `cell_offsets` (n_cells + 1,) int64 CSR-style offsets into sorted_idx
+      - `hyperplanes` (n_bits, d)     float32 row-major (LSH only; otherwise
+                                      a 1-Float32 sentinel buffer)
+    """
+    var cell_ids: UnsafePointer[UInt16, MutExternalOrigin]
+    var sorted_idx: UnsafePointer[Int, MutExternalOrigin]
+    var cell_offsets: UnsafePointer[Int, MutExternalOrigin]
+    var hyperplanes: UnsafePointer[Float32, MutExternalOrigin]
+    var has_hyperplanes: Bool
+    var n: Int
+    var d: Int
+    var bits: Int
+    var n_bits: Int
+    var n_cells: Int
+    var mode: Int
+    var seed: UInt64
+
+    def __init__(out self, n: Int, d: Int, bits: Int,
+                 n_bits: Int, n_cells: Int, mode: Int, seed: UInt64,
+                 has_hyperplanes: Bool):
+        self.n = n
+        self.d = d
+        self.bits = bits
+        self.n_bits = n_bits
+        self.n_cells = n_cells
+        self.mode = mode
+        self.seed = seed
+        self.has_hyperplanes = has_hyperplanes
+        self.cell_ids = alloc[UInt16](n)
+        self.sorted_idx = alloc[Int](n)
+        self.cell_offsets = alloc[Int](n_cells + 1)
+        var hp_size = n_bits * d if has_hyperplanes else 1
+        self.hyperplanes = alloc[Float32](hp_size)
+
+    def __del__(deinit self):
+        self.cell_ids.free()
+        self.sorted_idx.free()
+        self.cell_offsets.free()
+        self.hyperplanes.free()
+
+    fn index_nbytes(self) -> Int:
+        """In-RAM bytes of the IVF structure (excluding the corpus).
+
+        Mirrors `IVFCoarseIndex.index_nbytes`. Counts only the CSR layout
+        + the hyperplane matrix (when LSH); the underlying `PackedVectors`
+        is reported separately by the caller.
+        """
+        var total = self.n * 2  # cell_ids: uint16
+        total += self.n * 8     # sorted_idx: int64
+        total += (self.n_cells + 1) * 8  # cell_offsets: int64
+        if self.has_hyperplanes:
+            total += self.n_bits * self.d * 4  # float32
+        return total
+
+
+# ---------------------------------------------------------------------------
+# Cell-ID computation
+# ---------------------------------------------------------------------------
+
+
+fn _pack_bits_to_cell(sign_bits: UnsafePointer[UInt8, MutExternalOrigin],
+                      n_bits: Int) -> UInt32:
+    """Pack `n_bits` {0,1} values (LSB-first) into a uint32 cell ID.
+
+    Bit `b` of the output comes from `sign_bits[b]`. Matches Python's
+    `_pack_bits_to_cell` (which ORs `sign_bits[:, b] << b` per column).
+    """
+    var cid: UInt32 = UInt32(0)
+    for b in range(n_bits):
+        if sign_bits[b] != UInt8(0):
+            cid = cid | (UInt32(1) << UInt32(b))
+    return cid
+
+
+def _cell_ids_rotated_prefix(mut ivf: IVFCoarseIndex, packed: PackedVectors) raises:
+    """Compute cell IDs from the first `n_bits` MSBs of the encoded indices.
+
+    1-bit MSB extraction == sign of the rotated coordinate, so this is a
+    free deterministic hash. Mirrors `IVFCoarseIndex._cell_ids_rotated_prefix`.
+    """
+    var n = packed.n
+    var d = packed.d
+    var bits = packed.bits
+    var n_bits = ivf.n_bits
+    var shift = bits - 1
+
+    var chunk = 65536
+    var unpacked = alloc[UInt8](chunk * d)
+    var sign_bits = alloc[UInt8](n_bits)
+
+    var start = 0
+    while start < n:
+        var end = start + chunk
+        if end > n:
+            end = n
+        var n_rows = end - start
+        unpack_rows(packed, start, end, unpacked)
+        for r in range(n_rows):
+            var row = unpacked + r * d
+            for b in range(n_bits):
+                sign_bits[b] = (row[b] >> UInt8(shift)) & UInt8(1)
+            ivf.cell_ids[start + r] = UInt16(Int(_pack_bits_to_cell(sign_bits, n_bits)))
+        start = end
+
+    unpacked.free()
+    sign_bits.free()
+
+
+def _draw_hyperplanes(mut ivf: IVFCoarseIndex) raises:
+    """Sample `(n_bits, d)` standard-normal hyperplanes via the
+    NumPy-compatible Ziggurat RNG.
+
+    Order matches Python's `np.random.default_rng(seed).standard_normal((n_bits, d))`:
+    row-major fill, draw `(b, k)` at flat index `b * d + k`. End-to-end this
+    means a Mojo `IVFCoarseIndex(n_bits, mode='lsh', seed=S)` gets the same
+    hyperplane matrix — and therefore the same cell IDs — as the Python one
+    seeded identically.
+    """
+    var rng = NumpyNormalRNG(ivf.seed)
+    var total = ivf.n_bits * ivf.d
+    for i in range(total):
+        ivf.hyperplanes[i] = Float32(rng.next_normal())
+
+
+def _cell_ids_lsh(mut ivf: IVFCoarseIndex, packed: PackedVectors) raises:
+    """Random-hyperplane LSH on the 1-bit reconstruction of the corpus.
+
+    Mirrors `IVFCoarseIndex._cell_ids_lsh`: for each row, build
+    `signed = 2 * MSB(idx) - 1` (a length-d ±1 vector in float32),
+    project onto every hyperplane, and threshold at zero. Reduction
+    order is `sum_k H[b, k] * signed[k]` per (row, b), matching Python's
+    `signed @ H.T`.
+    """
+    var n = packed.n
+    var d = packed.d
+    var bits = packed.bits
+    var n_bits = ivf.n_bits
+    var shift = bits - 1
+
+    var chunk = 4096
+    var unpacked = alloc[UInt8](chunk * d)
+    var signed = alloc[Float32](d)
+    var sign_bits = alloc[UInt8](n_bits)
+
+    var start = 0
+    while start < n:
+        var end = start + chunk
+        if end > n:
+            end = n
+        var n_rows = end - start
+        unpack_rows(packed, start, end, unpacked)
+        for r in range(n_rows):
+            var row = unpacked + r * d
+            for k in range(d):
+                var msb = Float32((row[k] >> UInt8(shift)) & UInt8(1))
+                signed[k] = Float32(2.0) * msb - Float32(1.0)
+            for b in range(n_bits):
+                var hplane = ivf.hyperplanes + b * d
+                var s: Float32 = Float32(0.0)
+                for k in range(d):
+                    s += signed[k] * hplane[k]
+                sign_bits[b] = UInt8(1) if s > Float32(0.0) else UInt8(0)
+            ivf.cell_ids[start + r] = UInt16(Int(_pack_bits_to_cell(sign_bits, n_bits)))
+        start = end
+
+    unpacked.free()
+    signed.free()
+    sign_bits.free()
+
+
+def _build_inverted_lists(mut ivf: IVFCoarseIndex) raises:
+    """Build CSR `(sorted_idx, cell_offsets)` from `cell_ids`.
+
+    Counting sort, stable by row index — equivalent to numpy's
+    `argsort(kind='stable')` over `cell_ids`. Within-cell ordering is
+    ascending row index, matching Python.
+    """
+    var n = ivf.n
+    var n_cells = ivf.n_cells
+
+    # Histogram of cell_ids
+    for c in range(n_cells + 1):
+        ivf.cell_offsets[c] = 0
+    for i in range(n):
+        var c = Int(ivf.cell_ids[i])
+        ivf.cell_offsets[c + 1] += 1
+    # Prefix-sum to get CSR offsets
+    for c in range(1, n_cells + 1):
+        ivf.cell_offsets[c] += ivf.cell_offsets[c - 1]
+
+    # Place: walk i in order, drop into the next free slot of its cell.
+    # Use a scratch cursor copy so cell_offsets stays as the canonical CSR.
+    var cursor = alloc[Int](n_cells)
+    for c in range(n_cells):
+        cursor[c] = ivf.cell_offsets[c]
+    for i in range(n):
+        var c = Int(ivf.cell_ids[i])
+        ivf.sorted_idx[cursor[c]] = i
+        cursor[c] += 1
+    cursor.free()
+
+
+def build_ivf(q: Quantizer, packed: PackedVectors,
+              n_bits: Int, mode: Int, seed: UInt64) raises -> IVFCoarseIndex:
+    """Construct an IVFCoarseIndex over `packed` using `q.R` for hashing.
+
+    Args:
+        q: Quantizer that produced `packed` (provides `R` for query
+           rotation and `bits` for the MSB shift).
+        packed: PackedVectors corpus to index.
+        n_bits: 1..16, number of hash bits → `n_cells = 2**n_bits`.
+        mode: `MODE_LSH` (0) or `MODE_ROTATED_PREFIX` (1).
+        seed: LSH hyperplane seed (ignored for rotated_prefix).
+
+    Returns: an owning `IVFCoarseIndex`. The underlying `packed` is *not*
+    copied — keep it alive for the lifetime of the returned index.
+    """
+    if n_bits < 1 or n_bits > 16:
+        raise Error("build_ivf: n_bits must be 1..16")
+    if mode != MODE_LSH and mode != MODE_ROTATED_PREFIX:
+        raise Error("build_ivf: mode must be MODE_LSH or MODE_ROTATED_PREFIX")
+    if mode == MODE_ROTATED_PREFIX and n_bits > q.d:
+        raise Error("build_ivf: n_bits exceeds quantizer.d for rotated_prefix")
+
+    var n_cells = 1 << n_bits
+    var has_hp = (mode == MODE_LSH)
+    var ivf = IVFCoarseIndex(packed.n, q.d, q.bits, n_bits, n_cells,
+                             mode, seed, has_hp)
+
+    if mode == MODE_LSH:
+        _draw_hyperplanes(ivf)
+        _cell_ids_lsh(ivf, packed)
+    else:
+        _cell_ids_rotated_prefix(ivf, packed)
+
+    _build_inverted_lists(ivf)
+    return ivf^
+
+
+# ---------------------------------------------------------------------------
+# Query helpers
+# ---------------------------------------------------------------------------
+
+
+fn _q_rot(q: Quantizer, query: UnsafePointer[Float32, MutExternalOrigin],
+          mut out: UnsafePointer[Float32, MutExternalOrigin]):
+    """`out = q.R @ query`. Plain row-major matvec; reduction order matches
+    `Quantizer._dot_f32` modulo SIMD blocking — IVF uses scalar accumulators
+    everywhere downstream, so cell-ID assignment is unaffected.
+    """
+    var d = q.d
+    for i in range(d):
+        var s: Float32 = Float32(0.0)
+        var rrow = q.R.data + i * d
+        for j in range(d):
+            s += rrow[j] * query[j]
+        out[i] = s
+
+
+fn _query_cell_from_rot(ivf: IVFCoarseIndex,
+                        q_rot: UnsafePointer[Float32, MutExternalOrigin]) -> Int:
+    """Cell ID for a pre-rotated query. Mirrors Python `_query_cell_from_rot`."""
+    var cid: Int = 0
+    if ivf.mode == MODE_ROTATED_PREFIX:
+        for b in range(ivf.n_bits):
+            if q_rot[b] > Float32(0.0):
+                cid = cid | (1 << b)
+    else:
+        for b in range(ivf.n_bits):
+            var hplane = ivf.hyperplanes + b * ivf.d
+            var s: Float32 = Float32(0.0)
+            for k in range(ivf.d):
+                s += hplane[k] * q_rot[k]
+            if s > Float32(0.0):
+                cid = cid | (1 << b)
+    return cid
+
+
+def query_cell(ivf: IVFCoarseIndex, q: Quantizer,
+               query: UnsafePointer[Float32, MutExternalOrigin]) raises -> Int:
+    """Compute the cell ID for a single query vector (rotates internally).
+
+    Mirrors `IVFCoarseIndex.query_cell`.
+    """
+    var q_rot = alloc[Float32](q.d)
+    _q_rot(q, query, q_rot)
+    var cid = _query_cell_from_rot(ivf, q_rot)
+    q_rot.free()
+    return cid
+
+
+def probe_cells(ivf: IVFCoarseIndex, query_cell: Int, nprobe: Int,
+                mut out_cells: UnsafePointer[Int, MutExternalOrigin]) raises -> Int:
+    """Write the top `nprobe` cells (by Hamming distance) into `out_cells`.
+
+    Tie-break: ascending cell ID, matching Python's
+    `np.lexsort((all_cells, hd))`. Done as a bucket sort over Hamming
+    distance — n_cells <= 65536 and there are at most n_bits + 1 buckets.
+    Returns the number of cells written (in [0, min(nprobe, n_cells)]).
+    """
+    if nprobe <= 0:
+        return 0
+    if nprobe >= ivf.n_cells:
+        for c in range(ivf.n_cells):
+            out_cells[c] = c
+        return ivf.n_cells
+
+    var n_buckets = ivf.n_bits + 1
+    var counts = alloc[Int](n_buckets)
+    for b in range(n_buckets):
+        counts[b] = 0
+    for c in range(ivf.n_cells):
+        var hd = _popcount32(UInt32(c) ^ UInt32(query_cell))
+        counts[hd] += 1
+    var bucket_off = alloc[Int](n_buckets)
+    bucket_off[0] = 0
+    for b in range(1, n_buckets):
+        bucket_off[b] = bucket_off[b - 1] + counts[b - 1]
+
+    # Walk cells ascending and place into bucket slots — within-bucket
+    # order ends up ascending by cell ID, which is what np.lexsort gives.
+    var cursor = alloc[Int](n_buckets)
+    for b in range(n_buckets):
+        cursor[b] = bucket_off[b]
+    var sorted_cells = alloc[Int](ivf.n_cells)
+    for c in range(ivf.n_cells):
+        var hd = _popcount32(UInt32(c) ^ UInt32(query_cell))
+        sorted_cells[cursor[hd]] = c
+        cursor[hd] += 1
+
+    var k = nprobe if nprobe <= ivf.n_cells else ivf.n_cells
+    for i in range(k):
+        out_cells[i] = sorted_cells[i]
+
+    counts.free()
+    bucket_off.free()
+    cursor.free()
+    sorted_cells.free()
+    return k
+
+
+def candidate_indices(ivf: IVFCoarseIndex, query_cell: Int, nprobe: Int,
+                      mut out_idx: UnsafePointer[Int, MutExternalOrigin]) raises -> Int:
+    """Write candidate corpus row indices for the top `nprobe` cells into
+    `out_idx` and return the count.
+
+    `out_idx` must be sized for `ivf.n` (the worst case at `nprobe == n_cells`).
+    Mirrors `IVFCoarseIndex.candidate_indices`.
+    """
+    var cells = alloc[Int](ivf.n_cells)
+    var n_visited = probe_cells(ivf, query_cell, nprobe, cells)
+    var written: Int = 0
+    for ci in range(n_visited):
+        var c = cells[ci]
+        var lo = ivf.cell_offsets[c]
+        var hi = ivf.cell_offsets[c + 1]
+        for j in range(lo, hi):
+            out_idx[written] = ivf.sorted_idx[j]
+            written += 1
+    cells.free()
+    return written
+
+
+def candidate_count(ivf: IVFCoarseIndex, q: Quantizer,
+                    query: UnsafePointer[Float32, MutExternalOrigin],
+                    nprobe: Int) raises -> Int:
+    """Total candidate corpus rows in the top `nprobe` cells (no allocation).
+
+    Mirrors `IVFCoarseIndex.candidate_count`.
+    """
+    var qc = query_cell(ivf, q, query)
+    var cells = alloc[Int](ivf.n_cells)
+    var n_visited = probe_cells(ivf, qc, nprobe, cells)
+    var total: Int = 0
+    for ci in range(n_visited):
+        var c = cells[ci]
+        total += ivf.cell_offsets[c + 1] - ivf.cell_offsets[c]
+    cells.free()
+    return total
+
+
+# ---------------------------------------------------------------------------
+# Search
+# ---------------------------------------------------------------------------
+
+
+def search_coarse(ivf: IVFCoarseIndex, q: Quantizer, nested: NestedCodebook,
+                  packed: PackedVectors,
+                  query: UnsafePointer[Float32, MutExternalOrigin],
+                  k: Int, nprobe: Int, precision: Int,
+                  mut top_idx: UnsafePointer[Int, MutExternalOrigin],
+                  mut top_scores: UnsafePointer[Float32, MutExternalOrigin]) raises -> Int:
+    """IVF coarse ADC: visit `nprobe` cells, score by ADC, return top-k.
+
+    Mirrors `IVFCoarseIndex.search_coarse`. Equivalent to `Quantizer.adc_search`
+    restricted to the union of the `nprobe` cells closest (in Hamming
+    distance) to the query's hash.
+
+    Args:
+        ivf, q, nested, packed: index + quantizer + nested codebook + corpus.
+        query: (d,) raw query vector.
+        k: number of coarse candidates to return.
+        nprobe: cells to visit. `n_cells` recovers a flat scan exactly.
+        precision: 0 = full precision (use `q.cb.centroids`); otherwise
+            1..bits (use `nested.get_table(precision)` and right-shift
+            indices by `bits - precision`).
+        top_idx, top_scores: output buffers, must be sized for `min(k, n)`.
+
+    Returns: number of results written (= `min(k, n_visited)`).
+    """
+    var d = q.d
+    var bits = q.bits
+    var use_full = (precision == 0 or precision == bits)
+    if not use_full and (precision < 1 or precision > bits):
+        raise Error("search_coarse: precision must be 0 or 1..bits")
+
+    var q_rot = alloc[Float32](d)
+    _q_rot(q, query, q_rot)
+
+    var qc = _query_cell_from_rot(ivf, q_rot)
+    var cand = alloc[Int](ivf.n)
+    var n_cand = candidate_indices(ivf, qc, nprobe, cand)
+    if n_cand == 0:
+        cand.free()
+        q_rot.free()
+        return 0
+
+    # Build ADC table: outer(q_rot, centroids[at precision])
+    var n_levels: Int
+    var centroids: UnsafePointer[Float32, MutExternalOrigin]
+    if use_full:
+        n_levels = q.cb.n_levels
+        centroids = q.cb.centroids
+    else:
+        n_levels = 1 << precision
+        centroids = nested.get_table(precision)
+    var shift = 0 if use_full else bits - precision
+
+    var table = alloc[Float32](d * n_levels)
+    for j in range(d):
+        var qj = q_rot[j]
+        var trow = j * n_levels
+        for c in range(n_levels):
+            table[trow + c] = qj * centroids[c]
+
+    # Score each candidate by unpacking its row and looking up table entries.
+    var row = alloc[UInt8](d)
+    var scores = alloc[Float32](n_cand)
+    for ci in range(n_cand):
+        var i = cand[ci]
+        unpack_at(packed, i, row)
+        var s: Float32 = Float32(0.0)
+        for j in range(d):
+            var c_full = Int(row[j])
+            var c = c_full >> shift if shift > 0 else c_full
+            s += table[j * n_levels + c]
+        scores[ci] = s * packed.norms[i]
+
+    # Top-k by score (descending). Mirrors `adc_search`'s O(n*k) selection.
+    var kk = k if k <= n_cand else n_cand
+    var used = alloc[UInt8](n_cand)
+    for i in range(n_cand):
+        used[i] = UInt8(0)
+    for outer in range(kk):
+        var best_i: Int = -1
+        var best_s: Float32 = Float32(0.0)
+        for ci in range(n_cand):
+            if used[ci] == UInt8(0):
+                if best_i < 0 or scores[ci] > best_s:
+                    best_i = ci
+                    best_s = scores[ci]
+        top_idx[outer] = cand[best_i]
+        top_scores[outer] = best_s
+        used[best_i] = UInt8(1)
+
+    used.free()
+    scores.free()
+    row.free()
+    table.free()
+    cand.free()
+    q_rot.free()
+    return kk
+
+
+def search_twostage(ivf: IVFCoarseIndex, q: Quantizer, nested: NestedCodebook,
+                    packed: PackedVectors,
+                    query: UnsafePointer[Float32, MutExternalOrigin],
+                    k: Int, candidates: Int, nprobe: Int,
+                    coarse_precision: Int,
+                    mut top_idx: UnsafePointer[Int, MutExternalOrigin],
+                    mut top_scores: UnsafePointer[Float32, MutExternalOrigin]) raises -> Int:
+    """IVF coarse + full-precision rerank.
+
+    Mirrors `IVFCoarseIndex.search_twostage`. Stage 1 is `search_coarse` at
+    `coarse_precision` over `nprobe` cells, keeping the top `candidates`
+    rows by coarse score. Stage 2 reranks those at full precision and
+    returns the top `k`.
+
+    Args:
+        coarse_precision: 1..bits. Pass `0` to mean "full precision";
+            for parity with Python's `Quantizer.search_twostage` default,
+            callers typically pass `max(1, q.bits - 2)`.
+
+    Returns: number of results written (= `min(k, candidates, n_visited)`).
+    """
+    var d = q.d
+    var bits = q.bits
+
+    # Stage 1: coarse ADC over the IVF candidate set.
+    var stage1_idx = alloc[Int](candidates)
+    var stage1_scores = alloc[Float32](candidates)
+    var n_stage1 = search_coarse(ivf, q, nested, packed, query,
+                                 candidates, nprobe, coarse_precision,
+                                 stage1_idx, stage1_scores)
+    if n_stage1 == 0:
+        stage1_idx.free()
+        stage1_scores.free()
+        return 0
+
+    # Stage 2: full-precision rerank.
+    var q_rot = alloc[Float32](d)
+    _q_rot(q, query, q_rot)
+    var fine_centroids = q.cb.centroids
+    var fine_scores = alloc[Float32](n_stage1)
+    var row = alloc[UInt8](d)
+    for ci in range(n_stage1):
+        var i = stage1_idx[ci]
+        unpack_at(packed, i, row)
+        var s: Float32 = Float32(0.0)
+        for j in range(d):
+            var c = Int(row[j])
+            s += q_rot[j] * fine_centroids[c]
+        fine_scores[ci] = s * packed.norms[i]
+
+    # Top-k by fine score.
+    var kk = k if k <= n_stage1 else n_stage1
+    var used = alloc[UInt8](n_stage1)
+    for i in range(n_stage1):
+        used[i] = UInt8(0)
+    for outer in range(kk):
+        var best_i: Int = -1
+        var best_s: Float32 = Float32(0.0)
+        for ci in range(n_stage1):
+            if used[ci] == UInt8(0):
+                if best_i < 0 or fine_scores[ci] > best_s:
+                    best_i = ci
+                    best_s = fine_scores[ci]
+        top_idx[outer] = stage1_idx[best_i]
+        top_scores[outer] = best_s
+        used[best_i] = UInt8(1)
+
+    used.free()
+    fine_scores.free()
+    row.free()
+    q_rot.free()
+    stage1_idx.free()
+    stage1_scores.free()
+    return kk

--- a/remex/mojo/tests/build_ivf_fixture.py
+++ b/remex/mojo/tests/build_ivf_fixture.py
@@ -1,0 +1,163 @@
+"""Build the cross-runtime fixture for `test_ivf.mojo`.
+
+Run this once before the Mojo test:
+
+    python remex/mojo/tests/build_ivf_fixture.py
+
+Outputs (under /tmp/, all .npy float32 / .pq / .params):
+  /tmp/_ivf.params              — Quantizer R + boundaries + centroids
+  /tmp/_ivf.pq                  — Encoded corpus (PackedVectors-compatible)
+  /tmp/_ivf_corpus.npy          — Original corpus (n, d) float32
+  /tmp/_ivf_queries.npy         — Query batch (n_q, d) float32
+  /tmp/_ivf_meta.npy            — (1, M) float32 metadata row
+  /tmp/_ivf_lsh_hyperplanes.npy — (n_bits, d) float32 LSH hyperplanes
+  /tmp/_ivf_lsh_cell_ids.npy    — (n,) cell IDs (LSH mode)
+  /tmp/_ivf_rp_cell_ids.npy     — (n,) cell IDs (rotated_prefix mode)
+  /tmp/_ivf_lsh_query_cells.npy — (n_q,) per-query cell IDs (LSH)
+  /tmp/_ivf_rp_query_cells.npy  — (n_q,) per-query cell IDs (rotated_prefix)
+  /tmp/_ivf_full_adc_idx.npy    — (n_q, k) Quantizer.adc top-k indices (ground truth)
+  /tmp/_ivf_full_adc_scores.npy — (n_q, k) Quantizer.adc top-k scores
+  /tmp/_ivf_full_adc_p1_idx.npy — (n_q, k) Quantizer.adc top-k indices @ precision=1
+  /tmp/_ivf_full_2stage_idx.npy — (n_q, k) Quantizer.search_twostage indices
+  /tmp/_ivf_full_2stage_scores.npy — (n_q, k) Quantizer.search_twostage scores
+
+Metadata layout (all float32, all integers):
+  [n, d, bits, n_bits, seed, n_q, k, candidates, coarse_precision]
+
+The Mojo test loads these and asserts:
+  - Mojo-built LSH hyperplanes == Python's (byte-identical, modulo
+    rare libm tail rounding in the Ziggurat sampler).
+  - Mojo-built cell_ids match Python's in *both* modes (byte-for-byte).
+  - Per-query cell IDs match.
+  - search_coarse with nprobe = n_cells reproduces adc_search exactly
+    at precision=None and precision=1.
+  - search_twostage with nprobe = n_cells reproduces Quantizer.search_twostage.
+  - probe_cells produces the right Hamming-ranked order.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import numpy as np
+
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.abspath(os.path.join(THIS_DIR, "..", "..", ".."))
+sys.path.insert(0, REPO_ROOT)
+
+from remex import (  # noqa: E402
+    IVFCoarseIndex,
+    PackedVectors,
+    Quantizer,
+    save_params,
+    save_pq,
+)
+
+
+# Fixture parameters. Kept small so the Mojo test runs in seconds.
+N = 256
+D = 16
+BITS = 4
+N_BITS = 4
+SEED = 42
+N_Q = 4
+K = 10
+CANDIDATES = 50
+COARSE_PRECISION = 2
+RNG_SEED = 0
+
+
+def main() -> None:
+    rng = np.random.default_rng(RNG_SEED)
+
+    # Synthetic corpus + queries. Random Gaussian, no normalization needed
+    # for IVF — `Quantizer.encode` divides by per-row norm internally.
+    X = rng.standard_normal((N, D)).astype(np.float32)
+    Q = rng.standard_normal((N_Q, D)).astype(np.float32)
+
+    q = Quantizer(d=D, bits=BITS, seed=SEED)
+    save_params("/tmp/_ivf.params", q)
+
+    cv = q.encode(X)
+    save_pq("/tmp/_ivf.pq", cv)
+
+    np.save("/tmp/_ivf_corpus.npy", X)
+    np.save("/tmp/_ivf_queries.npy", Q)
+
+    meta = np.array(
+        [[N, D, BITS, N_BITS, SEED, N_Q, K, CANDIDATES, COARSE_PRECISION]],
+        dtype=np.float32,
+    )
+    np.save("/tmp/_ivf_meta.npy", meta)
+
+    # Build IVF in both modes. Use PackedVectors as the Mojo side does.
+    packed = PackedVectors.from_compressed(cv)
+
+    ivf_lsh = IVFCoarseIndex(q, packed, n_bits=N_BITS, mode="lsh", seed=SEED)
+    ivf_rp = IVFCoarseIndex(q, packed, n_bits=N_BITS, mode="rotated_prefix")
+
+    # The Mojo `load_npy_2d_f32` requires a 2D shape — wrap 1D arrays as
+    # (1, N) row-vectors so the loader doesn't reject them.
+    np.save("/tmp/_ivf_lsh_hyperplanes.npy", ivf_lsh.hyperplanes.astype(np.float32))
+    np.save(
+        "/tmp/_ivf_lsh_cell_ids.npy",
+        ivf_lsh.cell_ids.astype(np.float32).reshape(1, -1),
+    )
+    np.save(
+        "/tmp/_ivf_rp_cell_ids.npy",
+        ivf_rp.cell_ids.astype(np.float32).reshape(1, -1),
+    )
+
+    # Per-query cell IDs (one int per query, both modes), saved as (1, n_q).
+    lsh_qc = np.zeros((1, N_Q), dtype=np.float32)
+    rp_qc = np.zeros((1, N_Q), dtype=np.float32)
+    for i in range(N_Q):
+        lsh_qc[0, i] = ivf_lsh.query_cell(Q[i])
+        rp_qc[0, i] = ivf_rp.query_cell(Q[i])
+    np.save("/tmp/_ivf_lsh_query_cells.npy", lsh_qc)
+    np.save("/tmp/_ivf_rp_query_cells.npy", rp_qc)
+
+    # Ground-truth flat ADC results (full precision).
+    full_idx = np.zeros((N_Q, K), dtype=np.float32)
+    full_scores = np.zeros((N_Q, K), dtype=np.float32)
+    for i in range(N_Q):
+        ti, ts = q.search_adc(cv, Q[i], k=K)
+        full_idx[i] = ti.astype(np.float32)
+        full_scores[i] = ts
+    np.save("/tmp/_ivf_full_adc_idx.npy", full_idx)
+    np.save("/tmp/_ivf_full_adc_scores.npy", full_scores)
+
+    # Ground-truth flat ADC at precision=1 (1-bit Matryoshka coarse).
+    p1_idx = np.zeros((N_Q, K), dtype=np.float32)
+    for i in range(N_Q):
+        ti, _ = q.search_adc(cv, Q[i], k=K, precision=1)
+        p1_idx[i] = ti.astype(np.float32)
+    np.save("/tmp/_ivf_full_adc_p1_idx.npy", p1_idx)
+
+    # Ground-truth two-stage results.
+    ts_idx = np.zeros((N_Q, K), dtype=np.float32)
+    ts_scores = np.zeros((N_Q, K), dtype=np.float32)
+    for i in range(N_Q):
+        ti, ts = q.search_twostage(
+            cv,
+            Q[i],
+            k=K,
+            candidates=CANDIDATES,
+            coarse_precision=COARSE_PRECISION,
+        )
+        ts_idx[i] = ti.astype(np.float32)
+        ts_scores[i] = ts
+    np.save("/tmp/_ivf_full_2stage_idx.npy", ts_idx)
+    np.save("/tmp/_ivf_full_2stage_scores.npy", ts_scores)
+
+    print(
+        f"[build_ivf_fixture] wrote /tmp/_ivf_* — "
+        f"n={N} d={D} bits={BITS} n_bits={N_BITS} seed={SEED} "
+        f"n_q={N_Q} k={K} candidates={CANDIDATES} "
+        f"coarse_precision={COARSE_PRECISION}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/remex/mojo/tests/test_ivf.mojo
+++ b/remex/mojo/tests/test_ivf.mojo
@@ -1,0 +1,541 @@
+"""Tests for `IVFCoarseIndex` (Mojo port of `remex.ivf.IVFCoarseIndex`).
+
+Cross-runtime parity test against a Python-built fixture. The Python
+side builds an IVF index in both modes, runs `search_coarse` and
+`search_twostage` at full nprobe, and dumps everything to /tmp. The
+Mojo side rebuilds the index from the same params + corpus and asserts:
+
+  - LSH hyperplanes byte-for-byte match Python's (modulo rare libm
+    Ziggurat tail rounding — the only known cross-runtime drift).
+  - cell_ids match in *both* modes.
+  - Per-query cell IDs match in both modes.
+  - search_coarse with `nprobe = n_cells` reproduces `Quantizer.adc_search`
+    byte-identically (full precision) and at `precision=1`.
+  - search_twostage with `nprobe = n_cells` reproduces
+    `Quantizer.search_twostage`.
+  - probe_cells multi-probe order: first `n_bits + 1` cells = q_cell
+    plus all single-bit flips of it (Hamming distance 0, then 1).
+
+Closes the Mojo half of issue #61.
+
+Setup (run before this test):
+
+    python remex/mojo/tests/build_ivf_fixture.py
+"""
+
+from std.testing import assert_equal, assert_true
+from std.memory import alloc, UnsafePointer
+from src.codebook import Codebook, nested_codebooks_from
+from src.ivf import (
+    IVFCoarseIndex,
+    MODE_LSH,
+    MODE_ROTATED_PREFIX,
+    build_ivf,
+    candidate_count,
+    candidate_indices,
+    probe_cells,
+    query_cell,
+    search_coarse,
+    search_twostage,
+)
+from src.matrix import Matrix
+from src.npy import load_npy_2d_f32
+from src.packed_vectors import PackedVectors, from_pq_bytes
+from src.params_format import load_params
+from src.pq_format import load_pq
+from src.quantizer import Quantizer
+
+
+def _abs(x: Float32) -> Float32:
+    return -x if x < Float32(0.0) else x
+
+
+# ---------------------------------------------------------------------------
+# Fixture loader: load /tmp/_ivf_* once, return everything the tests need.
+# ---------------------------------------------------------------------------
+
+
+struct Fixture(Movable):
+    """Container for the Python-built IVF fixture."""
+    var meta_n: Int
+    var meta_d: Int
+    var meta_bits: Int
+    var meta_n_bits: Int
+    var meta_seed: UInt64
+    var meta_n_q: Int
+    var meta_k: Int
+    var meta_candidates: Int
+    var meta_coarse_precision: Int
+
+    fn __init__(out self):
+        self.meta_n = 0
+        self.meta_d = 0
+        self.meta_bits = 0
+        self.meta_n_bits = 0
+        self.meta_seed = UInt64(0)
+        self.meta_n_q = 0
+        self.meta_k = 0
+        self.meta_candidates = 0
+        self.meta_coarse_precision = 0
+
+
+def _load_meta() raises -> Fixture:
+    var meta = load_npy_2d_f32(String("/tmp/_ivf_meta.npy"))
+    var f = Fixture()
+    f.meta_n = Int(meta.get(0, 0))
+    f.meta_d = Int(meta.get(0, 1))
+    f.meta_bits = Int(meta.get(0, 2))
+    f.meta_n_bits = Int(meta.get(0, 3))
+    f.meta_seed = UInt64(Int(meta.get(0, 4)))
+    f.meta_n_q = Int(meta.get(0, 5))
+    f.meta_k = Int(meta.get(0, 6))
+    f.meta_candidates = Int(meta.get(0, 7))
+    f.meta_coarse_precision = Int(meta.get(0, 8))
+    return f^
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_quantizer(d: Int, bits: Int, seed: UInt64) raises -> Quantizer:
+    """Load (R, codebook) from the fixture's .params and wrap them."""
+    var R = Matrix(d, d)
+    var cb = Codebook(bits)
+    load_params(String("/tmp/_ivf.params"), R, cb)
+    return Quantizer(R^, cb^, d, bits, seed)
+
+
+def _load_packed(d: Int, bits: Int) raises -> PackedVectors:
+    """Load the corpus from the fixture's .pq into a PackedVectors.
+
+    Copies `pq.packed_indices` and `pq.norms` into fresh buffers before
+    handing them to `from_pq_bytes` — same field-aliasing workaround the
+    other Mojo tests use (see `test_search_twostage.mojo` and the comment
+    in `polarquant.mojo::cmd_search`). Without this, the first row of the
+    resulting buffer comes back zeroed.
+    """
+    var pq = load_pq(String("/tmp/_ivf.pq"))
+    if pq.d != d or pq.bits != bits:
+        raise Error("_load_packed: .pq d/bits mismatch with metadata")
+    var n = pq.n
+    var nbytes = pq.packed_bytes
+    var local_packed = alloc[UInt8](nbytes)
+    for i in range(nbytes):
+        local_packed[i] = pq.packed_indices[i]
+    var local_norms = alloc[Float32](n)
+    for i in range(n):
+        local_norms[i] = pq.norms[i]
+    var packed = from_pq_bytes(local_packed, nbytes, local_norms, n, d, bits)
+    local_packed.free()
+    local_norms.free()
+    return packed^
+
+
+def _copy_query(Q_npy_rows: Int, Q_npy_cols: Int, qi: Int,
+                Q_data: UnsafePointer[Float32, MutExternalOrigin],
+                d: Int) -> UnsafePointer[Float32, MutExternalOrigin]:
+    """Fresh d-element query buffer from row qi of an Npy2D."""
+    var qbuf = alloc[Float32](d)
+    for j in range(d):
+        qbuf[j] = Q_data[qi * Q_npy_cols + j]
+    return qbuf
+
+
+# ---------------------------------------------------------------------------
+# 1. Hyperplane parity (LSH only)
+# ---------------------------------------------------------------------------
+
+
+def test_lsh_hyperplanes_parity() raises:
+    """Mojo-built LSH hyperplanes must equal Python's
+    `np.random.default_rng(seed).standard_normal((n_bits, d))` byte-for-byte
+    (modulo rare libm Ziggurat tail rounding).
+    """
+    var f = _load_meta()
+    var q = _build_quantizer(f.meta_d, f.meta_bits, f.meta_seed)
+    var packed = _load_packed(f.meta_d, f.meta_bits)
+    var ivf = build_ivf(q, packed, f.meta_n_bits, MODE_LSH, f.meta_seed)
+
+    var hp = load_npy_2d_f32(String("/tmp/_ivf_lsh_hyperplanes.npy"))
+    if hp.rows != f.meta_n_bits or hp.cols != f.meta_d:
+        raise Error("test_lsh_hyperplanes_parity: hyperplane shape mismatch")
+
+    var max_diff: Float32 = Float32(0.0)
+    var n_diff: Int = 0
+    for b in range(f.meta_n_bits):
+        for k in range(f.meta_d):
+            var got = ivf.hyperplanes[b * f.meta_d + k]
+            var exp = hp.get(b, k)
+            var diff = _abs(got - exp)
+            if diff > max_diff:
+                max_diff = diff
+            if diff > Float32(0.0):
+                n_diff += 1
+    print("LSH hyperplane max diff:", max_diff,
+          "  nonzero diffs:", n_diff,
+          "/", f.meta_n_bits * f.meta_d)
+    # libm Ziggurat tail can drift in the last ulp (~1e-7). Allow a tiny tol.
+    assert_true(max_diff < Float32(1e-5))
+    print("[test_lsh_hyperplanes_parity] ok")
+
+
+# ---------------------------------------------------------------------------
+# 2. Cell ID parity in both modes
+# ---------------------------------------------------------------------------
+
+
+def test_lsh_cell_ids_parity() raises:
+    var f = _load_meta()
+    var q = _build_quantizer(f.meta_d, f.meta_bits, f.meta_seed)
+    var packed = _load_packed(f.meta_d, f.meta_bits)
+    var ivf = build_ivf(q, packed, f.meta_n_bits, MODE_LSH, f.meta_seed)
+
+    var expected = load_npy_2d_f32(String("/tmp/_ivf_lsh_cell_ids.npy"))
+    # 1D arrays come in as (1, n) in our loader (or (n, 1) — accept either).
+    var n_expected = expected.rows * expected.cols
+    if n_expected != f.meta_n:
+        raise Error("test_lsh_cell_ids_parity: expected.size != n")
+
+    var n_diff: Int = 0
+    for i in range(f.meta_n):
+        var got = Int(ivf.cell_ids[i])
+        var exp_idx = i if expected.cols == 1 else i  # both layouts flatten the same
+        var exp: Int
+        if expected.rows == 1:
+            exp = Int(expected.get(0, i))
+        else:
+            exp = Int(expected.get(i, 0))
+        if got != exp:
+            n_diff += 1
+            if n_diff <= 5:
+                print("  LSH cell_id mismatch row", i, ": got", got, "exp", exp)
+    print("LSH cell_id mismatches:", n_diff, "/", f.meta_n)
+    assert_equal(n_diff, 0)
+    print("[test_lsh_cell_ids_parity] ok")
+
+
+def test_rotated_prefix_cell_ids_parity() raises:
+    var f = _load_meta()
+    var q = _build_quantizer(f.meta_d, f.meta_bits, f.meta_seed)
+    var packed = _load_packed(f.meta_d, f.meta_bits)
+    var ivf = build_ivf(q, packed, f.meta_n_bits, MODE_ROTATED_PREFIX, f.meta_seed)
+
+    var expected = load_npy_2d_f32(String("/tmp/_ivf_rp_cell_ids.npy"))
+    var n_expected = expected.rows * expected.cols
+    if n_expected != f.meta_n:
+        raise Error("test_rotated_prefix_cell_ids_parity: expected.size != n")
+
+    var n_diff: Int = 0
+    for i in range(f.meta_n):
+        var got = Int(ivf.cell_ids[i])
+        var exp: Int
+        if expected.rows == 1:
+            exp = Int(expected.get(0, i))
+        else:
+            exp = Int(expected.get(i, 0))
+        if got != exp:
+            n_diff += 1
+            if n_diff <= 5:
+                print("  rotated_prefix cell_id mismatch row", i,
+                      ": got", got, "exp", exp)
+    print("rotated_prefix cell_id mismatches:", n_diff, "/", f.meta_n)
+    assert_equal(n_diff, 0)
+    print("[test_rotated_prefix_cell_ids_parity] ok")
+
+
+# ---------------------------------------------------------------------------
+# 3. CSR layout invariant: every row in cell c has cell_ids[row] == c
+# ---------------------------------------------------------------------------
+
+
+def test_csr_layout_correct() raises:
+    """sorted_idx[cell_offsets[c]:cell_offsets[c+1]] must contain exactly the
+    rows whose cell_id == c, and the offsets must cover [0, n) exactly once.
+    """
+    var f = _load_meta()
+    var q = _build_quantizer(f.meta_d, f.meta_bits, f.meta_seed)
+    var packed = _load_packed(f.meta_d, f.meta_bits)
+    var ivf = build_ivf(q, packed, f.meta_n_bits, MODE_LSH, f.meta_seed)
+
+    assert_equal(Int(ivf.cell_offsets[0]), 0)
+    assert_equal(Int(ivf.cell_offsets[ivf.n_cells]), f.meta_n)
+
+    # Counts non-decreasing
+    for c in range(ivf.n_cells):
+        assert_true(ivf.cell_offsets[c + 1] >= ivf.cell_offsets[c])
+
+    # Every row in cell c has cell_ids[row] == c.
+    for c in range(ivf.n_cells):
+        var lo = ivf.cell_offsets[c]
+        var hi = ivf.cell_offsets[c + 1]
+        for j in range(lo, hi):
+            var row = ivf.sorted_idx[j]
+            assert_equal(Int(ivf.cell_ids[row]), c)
+    print("[test_csr_layout_correct] ok")
+
+
+# ---------------------------------------------------------------------------
+# 4. Per-query cell ID parity
+# ---------------------------------------------------------------------------
+
+
+def test_query_cell_parity() raises:
+    var f = _load_meta()
+    var q = _build_quantizer(f.meta_d, f.meta_bits, f.meta_seed)
+    var packed = _load_packed(f.meta_d, f.meta_bits)
+    var ivf_lsh = build_ivf(q, packed, f.meta_n_bits, MODE_LSH, f.meta_seed)
+    var ivf_rp = build_ivf(q, packed, f.meta_n_bits, MODE_ROTATED_PREFIX, f.meta_seed)
+
+    var Q = load_npy_2d_f32(String("/tmp/_ivf_queries.npy"))
+    if Q.rows != f.meta_n_q or Q.cols != f.meta_d:
+        raise Error("test_query_cell_parity: query shape mismatch")
+    var lsh_qc = load_npy_2d_f32(String("/tmp/_ivf_lsh_query_cells.npy"))
+    var rp_qc = load_npy_2d_f32(String("/tmp/_ivf_rp_query_cells.npy"))
+
+    for qi in range(f.meta_n_q):
+        var qbuf = _copy_query(Q.rows, Q.cols, qi, Q.data, f.meta_d)
+        var got_lsh = query_cell(ivf_lsh, q, qbuf)
+        var got_rp = query_cell(ivf_rp, q, qbuf)
+        var exp_lsh = Int(lsh_qc.get(0, qi)) if lsh_qc.rows == 1 else Int(lsh_qc.get(qi, 0))
+        var exp_rp = Int(rp_qc.get(0, qi)) if rp_qc.rows == 1 else Int(rp_qc.get(qi, 0))
+        assert_equal(got_lsh, exp_lsh)
+        assert_equal(got_rp, exp_rp)
+        qbuf.free()
+    print("[test_query_cell_parity] ok — n_q =", f.meta_n_q)
+
+
+# ---------------------------------------------------------------------------
+# 5. probe_cells Hamming ordering: q_cell + single-bit flips
+# ---------------------------------------------------------------------------
+
+
+def test_probe_cells_hamming_ordering() raises:
+    """First `n_bits + 1` cells visited must be q_cell (HD=0) + every
+    single-bit flip (HD=1), in ascending cell-ID within each Hamming bucket.
+    """
+    var f = _load_meta()
+    var q = _build_quantizer(f.meta_d, f.meta_bits, f.meta_seed)
+    var packed = _load_packed(f.meta_d, f.meta_bits)
+    var ivf = build_ivf(q, packed, f.meta_n_bits, MODE_LSH, f.meta_seed)
+
+    var n_bits = f.meta_n_bits
+    var q_cell = 5  # arbitrary; just needs to fit in n_bits
+    if q_cell >= ivf.n_cells:
+        q_cell = ivf.n_cells // 2
+    var nprobe = 1 + n_bits
+
+    var cells = alloc[Int](nprobe)
+    var got_n = probe_cells(ivf, q_cell, nprobe, cells)
+    assert_equal(got_n, nprobe)
+    assert_equal(cells[0], q_cell)
+
+    # Build the set of expected single-bit flips as a sorted list.
+    var expected_flips = alloc[Int](n_bits)
+    for b in range(n_bits):
+        expected_flips[b] = q_cell ^ (1 << b)
+    # Bubble-sort the flip list (n_bits <= 16 — trivially small).
+    for i in range(n_bits):
+        for j in range(0, n_bits - 1 - i):
+            if expected_flips[j] > expected_flips[j + 1]:
+                var t = expected_flips[j]
+                expected_flips[j] = expected_flips[j + 1]
+                expected_flips[j + 1] = t
+
+    for b in range(n_bits):
+        assert_equal(cells[1 + b], expected_flips[b])
+
+    cells.free()
+    expected_flips.free()
+    print("[test_probe_cells_hamming_ordering] ok — n_bits =", n_bits)
+
+
+# ---------------------------------------------------------------------------
+# 6. Full nprobe == flat ADC scan
+# ---------------------------------------------------------------------------
+
+
+def _check_full_nprobe(precision: Int, expected_idx_path: String,
+                       expected_scores_path: String) raises:
+    """Run search_coarse at nprobe=n_cells and assert top-k matches the
+    Python flat ADC reference for every query at the given `precision`
+    (0 = full)."""
+    var f = _load_meta()
+    var q = _build_quantizer(f.meta_d, f.meta_bits, f.meta_seed)
+    var packed = _load_packed(f.meta_d, f.meta_bits)
+    # Use rotated_prefix here so the cell assignment is deterministic from
+    # the .params alone — no extra Mojo/Python LSH-RNG agreement needed.
+    var ivf = build_ivf(q, packed, f.meta_n_bits, MODE_ROTATED_PREFIX, f.meta_seed)
+    var nested = nested_codebooks_from(q.cb, f.meta_d)
+
+    var Q = load_npy_2d_f32(String("/tmp/_ivf_queries.npy"))
+    var exp_idx = load_npy_2d_f32(expected_idx_path)
+    var exp_scores: UnsafePointer[Float32, MutExternalOrigin]
+    var exp_scores_rows: Int = 0
+    var exp_scores_cols: Int = 0
+    var exp_scores_loaded = False
+    if len(expected_scores_path) > 0:
+        var es = load_npy_2d_f32(expected_scores_path)
+        exp_scores_rows = es.rows
+        exp_scores_cols = es.cols
+        exp_scores = alloc[Float32](exp_scores_rows * exp_scores_cols)
+        for i in range(exp_scores_rows):
+            for j in range(exp_scores_cols):
+                exp_scores[i * exp_scores_cols + j] = es.get(i, j)
+        exp_scores_loaded = True
+    else:
+        exp_scores = alloc[Float32](1)
+
+    var top_idx = alloc[Int](f.meta_k)
+    var top_scores = alloc[Float32](f.meta_k)
+
+    var n_idx_mismatch: Int = 0
+    var max_score_diff: Float32 = Float32(0.0)
+    for qi in range(f.meta_n_q):
+        var qbuf = _copy_query(Q.rows, Q.cols, qi, Q.data, f.meta_d)
+        var n_returned = search_coarse(
+            ivf, q, nested, packed, qbuf,
+            f.meta_k, ivf.n_cells, precision,
+            top_idx, top_scores,
+        )
+        assert_equal(n_returned, f.meta_k)
+        for r in range(f.meta_k):
+            var got_idx = top_idx[r]
+            var exp = Int(exp_idx.get(qi, r))
+            if got_idx != exp:
+                n_idx_mismatch += 1
+                if n_idx_mismatch <= 5:
+                    print("  q", qi, "rank", r, " got", got_idx, " exp", exp)
+            if exp_scores_loaded:
+                var got_s = top_scores[r]
+                var es = exp_scores[qi * exp_scores_cols + r]
+                var diff = _abs(got_s - es)
+                var ref_mag = _abs(es)
+                if ref_mag > Float32(1.0):
+                    diff = diff / ref_mag
+                if diff > max_score_diff:
+                    max_score_diff = diff
+        qbuf.free()
+
+    print("  precision =", precision,
+          " idx mismatches:", n_idx_mismatch,
+          " max score diff:", max_score_diff)
+    assert_equal(n_idx_mismatch, 0)
+    if exp_scores_loaded:
+        assert_true(max_score_diff < Float32(1e-5))
+
+    top_idx.free()
+    top_scores.free()
+    exp_scores.free()
+
+
+def test_full_nprobe_matches_adc_search_full_precision() raises:
+    _check_full_nprobe(
+        0,
+        String("/tmp/_ivf_full_adc_idx.npy"),
+        String("/tmp/_ivf_full_adc_scores.npy"),
+    )
+    print("[test_full_nprobe_matches_adc_search_full_precision] ok")
+
+
+def test_full_nprobe_matches_adc_search_precision_1() raises:
+    _check_full_nprobe(
+        1,
+        String("/tmp/_ivf_full_adc_p1_idx.npy"),
+        String(""),  # only check indices at p=1 (scores are tested at full)
+    )
+    print("[test_full_nprobe_matches_adc_search_precision_1] ok")
+
+
+# ---------------------------------------------------------------------------
+# 7. Two-stage parity at full nprobe
+# ---------------------------------------------------------------------------
+
+
+def test_full_nprobe_matches_search_twostage() raises:
+    var f = _load_meta()
+    var q = _build_quantizer(f.meta_d, f.meta_bits, f.meta_seed)
+    var packed = _load_packed(f.meta_d, f.meta_bits)
+    var ivf = build_ivf(q, packed, f.meta_n_bits, MODE_ROTATED_PREFIX, f.meta_seed)
+    var nested = nested_codebooks_from(q.cb, f.meta_d)
+
+    var Q = load_npy_2d_f32(String("/tmp/_ivf_queries.npy"))
+    var exp_idx = load_npy_2d_f32(String("/tmp/_ivf_full_2stage_idx.npy"))
+    var exp_scores = load_npy_2d_f32(String("/tmp/_ivf_full_2stage_scores.npy"))
+
+    var top_idx = alloc[Int](f.meta_k)
+    var top_scores = alloc[Float32](f.meta_k)
+
+    var n_idx_mismatch: Int = 0
+    var max_score_diff: Float32 = Float32(0.0)
+    for qi in range(f.meta_n_q):
+        var qbuf = _copy_query(Q.rows, Q.cols, qi, Q.data, f.meta_d)
+        var n_returned = search_twostage(
+            ivf, q, nested, packed, qbuf,
+            f.meta_k, f.meta_candidates, ivf.n_cells,
+            f.meta_coarse_precision,
+            top_idx, top_scores,
+        )
+        assert_equal(n_returned, f.meta_k)
+        for r in range(f.meta_k):
+            var got_idx = top_idx[r]
+            var exp = Int(exp_idx.get(qi, r))
+            if got_idx != exp:
+                n_idx_mismatch += 1
+                if n_idx_mismatch <= 5:
+                    print("  q", qi, "rank", r, " got", got_idx, " exp", exp)
+            var diff = _abs(top_scores[r] - exp_scores.get(qi, r))
+            var ref_mag = _abs(exp_scores.get(qi, r))
+            if ref_mag > Float32(1.0):
+                diff = diff / ref_mag
+            if diff > max_score_diff:
+                max_score_diff = diff
+        qbuf.free()
+
+    print("  twostage idx mismatches:", n_idx_mismatch,
+          " max score diff:", max_score_diff)
+    assert_equal(n_idx_mismatch, 0)
+    assert_true(max_score_diff < Float32(1e-5))
+    top_idx.free()
+    top_scores.free()
+    print("[test_full_nprobe_matches_search_twostage] ok")
+
+
+# ---------------------------------------------------------------------------
+# 8. candidate_count sanity
+# ---------------------------------------------------------------------------
+
+
+def test_candidate_count_full_equals_n() raises:
+    """At nprobe = n_cells, every corpus row is a candidate."""
+    var f = _load_meta()
+    var q = _build_quantizer(f.meta_d, f.meta_bits, f.meta_seed)
+    var packed = _load_packed(f.meta_d, f.meta_bits)
+    var ivf = build_ivf(q, packed, f.meta_n_bits, MODE_ROTATED_PREFIX, f.meta_seed)
+
+    var Q = load_npy_2d_f32(String("/tmp/_ivf_queries.npy"))
+    var qbuf = _copy_query(Q.rows, Q.cols, 0, Q.data, f.meta_d)
+    var got = candidate_count(ivf, q, qbuf, ivf.n_cells)
+    assert_equal(got, f.meta_n)
+    qbuf.free()
+    print("[test_candidate_count_full_equals_n] ok")
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main() raises:
+    test_lsh_hyperplanes_parity()
+    test_lsh_cell_ids_parity()
+    test_rotated_prefix_cell_ids_parity()
+    test_csr_layout_correct()
+    test_query_cell_parity()
+    test_probe_cells_hamming_ordering()
+    test_full_nprobe_matches_adc_search_full_precision()
+    test_full_nprobe_matches_adc_search_precision_1()
+    test_full_nprobe_matches_search_twostage()
+    test_candidate_count_full_equals_n()
+    print("[test_ivf] all passed")


### PR DESCRIPTION
## Summary

Ports `remex.ivf.IVFCoarseIndex` to Mojo so the Mojo runtime gets the
same sublinear coarse scan the Python runtime got in PR #58. Closes #61.

- `remex/mojo/src/ivf.mojo` — `IVFCoarseIndex` over `PackedVectors`
  with both hash modes:
  - `MODE_LSH` — `n_bits` random hyperplanes drawn from the
    NumPy-compatible Ziggurat RNG (`NumpyNormalRNG`), so
    `(d, n_bits, seed)` produces the same matrix as
    `np.random.default_rng(seed).standard_normal((n_bits, d))`.
  - `MODE_ROTATED_PREFIX` — sign of the first `n_bits` post-rotation
    coords, taken directly as MSBs of the encoded indices.
- Multi-probe by Hamming distance from the query hash, ties broken by
  ascending cell ID. `nprobe = n_cells` recovers a flat scan exactly.
- CSR cell layout via counting sort, stable by row index — equivalent
  to NumPy's `argsort(kind='stable')`.
- `search_coarse` and `search_twostage` — same call shape as the
  Quantizer's flat versions, restricted to the IVF candidate set.
- `remex/mojo/tests/test_ivf.mojo` mirrors `tests/test_ivf.py`. The
  fixture is a Python script (`tests/build_ivf_fixture.py`) that
  builds a Python `IVFCoarseIndex` in both modes, dumps cell IDs +
  hyperplanes + per-query cell IDs + `Quantizer.search_adc` /
  `search_twostage` reference outputs, and the Mojo test asserts:
  - LSH hyperplanes byte-for-byte match Python's.
  - Cell IDs match in **both** modes (256/256 in the small fixture).
  - Per-query cell IDs match.
  - `search_coarse` at `nprobe = n_cells` reproduces
    `Quantizer.search_adc` byte-identically (full precision and
    `precision=1`).
  - `search_twostage` at `nprobe = n_cells` reproduces
    `Quantizer.search_twostage`.
  - `probe_cells` Hamming ordering: q_cell + every single-bit flip.
- `remex/mojo/bench/bench_ivf.mojo` — IVF latency at varying `nprobe`
  (auto doubling sweep up to `n_cells`), reports avg candidate-pool
  size alongside ms/query so the latency-recall trade-off is readable
  next to the Python `bench/specter2_eval.py` numbers.

## Test plan

- [x] `mojo build -I . tests/test_ivf.mojo -o /tmp/test_ivf` (clean)
- [x] `python remex/mojo/tests/build_ivf_fixture.py && /tmp/test_ivf`
      → all 10 tests pass; LSH hyperplane diffs 0/64, LSH cell-id
      diffs 0/256, rotated_prefix cell-id diffs 0/256, idx mismatches 0
      across precision=0, precision=1, and twostage paths.
- [x] `mojo build -I . bench/bench_ivf.mojo -o /tmp/bench_ivf` (clean)
- [x] `pytest tests/test_ivf.py` — 30/30 passing in 213s on the same
      tree (Python side untouched).
- [x] All other Mojo tests still build cleanly (`test_packing`,
      `test_codebook`, `test_rotation`, `test_packed_vectors`,
      `test_rng`, `test_rng_numpy`, `test_decode`,
      `test_search_twostage`, `test_encode`, `test_encode_seed`).

## Notes

- The fixture-loader uses the same `pq.packed_indices` field-aliasing
  workaround as `test_search_twostage.mojo` (copy into a fresh buffer
  before calling `from_pq_bytes`). Without it the first row of the
  resulting `PackedVectors` comes back zeroed — flagged inline in
  `_load_packed`.
- Cross-runtime serialization of an IVF index is out of scope per the
  issue — the contract is "rebuild from the same `(d, n_bits, mode,
  seed)`" and the parity test verifies that contract.