### PR TITLE
bench: add Gemini gemini-embedding-001 embedding cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ build/
 .pytest_cache/
 *.npz
 bench/.specter2_cache/
+bench/.gemini_cache/
 bench/.onebit_cache/
 bench/plots/
 

--- a/bench/fetch_gemini_cache.sh
+++ b/bench/fetch_gemini_cache.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Fetch precomputed Gemini gemini-embedding-001 embeddings into
+# bench/.gemini_cache/ for parallel-encoder comparisons against the
+# SPECTER2 baseline (see fetch_specter2_cache.sh).
+#
+# Both partitions use IDENTICAL text inputs as their SPECTER2 counterparts
+# (the same `title [SEP] abstract` strings from the Semantic Scholar
+# bulk-search API), so vectors are 1:1 comparable across encoders.
+#
+# Cache contents (~240 MB total):
+#   gemini_nlp_broad.npy            — (10000, 3072) float32, broad NLP
+#   gemini_nlp_broad_meta.json      — model id, taskType, dim, truncation count
+#   gemini_nlp_narrow.npy           — (10000, 3072) float32, narrow subfield
+#                                     (transformer attention mechanism)
+#   gemini_nlp_narrow_meta.json     — same schema as broad meta
+#
+# Source texts are NOT duplicated here — pull them with
+# fetch_specter2_cache.sh (writes to bench/.specter2_cache/) since the
+# string content is byte-identical.
+#
+# Source: oaustegard/claude-container-layers releases.
+set -euo pipefail
+
+REPO=${GEMINI_CACHE_REPO:-oaustegard/claude-container-layers}
+BROAD_TAG=${GEMINI_BROAD_TAG:-gemini-nlp-broad-10k}
+NARROW_TAG=${GEMINI_NARROW_TAG:-gemini-nlp-narrow-10k}
+CACHE_DIR="$(cd "$(dirname "$0")" && pwd)/.gemini_cache"
+
+mkdir -p "$CACHE_DIR"
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "error: gh CLI not found. Install: https://cli.github.com/" >&2
+  exit 1
+fi
+
+fetch_assets() {
+  local tag="$1"; shift
+  for asset in "$@"; do
+    out="$CACHE_DIR/$asset"
+    echo "fetching $asset → $out"
+    gh release download "$tag" --repo "$REPO" --pattern "$asset" \
+      --output "$out" --clobber
+  done
+}
+
+fetch_assets "$BROAD_TAG"  gemini_nlp_broad.npy  gemini_nlp_broad_meta.json
+fetch_assets "$NARROW_TAG" gemini_nlp_narrow.npy gemini_nlp_narrow_meta.json
+
+echo "done. embeddings in $CACHE_DIR"
+echo "(text inputs are in bench/.specter2_cache/ — same strings as SPECTER2)"


### PR DESCRIPTION
## Summary

Adds `bench/fetch_gemini_cache.sh` — parallel to `fetch_specter2_cache.sh` — that pulls precomputed Gemini `gemini-embedding-001` embeddings (3072-d, `RETRIEVAL_DOCUMENT` taskType, L2-normalized) for both NLP partitions into `bench/.gemini_cache/`.

## Why

Same 10K papers, same `title [SEP] abstract` strings as the existing SPECTER2 baseline, but encoded with a different model — a 4x longer vector (3072 vs 768) trained on a different corpus. Useful for revisiting the rotation + Lloyd-Max distribution analysis on a contemporary embedder, and for cross-encoder recall comparisons in the remex/remax studies.

## What's in the cache

| File | Shape | Bytes |
| --- | --- | --- |
| `gemini_nlp_broad.npy` | (10000, 3072) f32 | 118 MB |
| `gemini_nlp_broad_meta.json` | — | 333 B |
| `gemini_nlp_narrow.npy` | (10000, 3072) f32 | 118 MB |
| `gemini_nlp_narrow_meta.json` | — | 333 B |

Hosted as GH release assets on `oaustegard/claude-container-layers` under tags `gemini-nlp-broad-10k` and `gemini-nlp-narrow-10k`. Source texts are byte-identical to `specter2_*_texts.json` and not duplicated here — pull them with `fetch_specter2_cache.sh`.

## Encoding details

- Model: `gemini-embedding-001` (GA 2025-Q4)
- Input cap: 7800 chars (~1950 tokens) to fit the 2048-token model limit
- Truncations: 38/10000 broad, 2/10000 narrow
- Encoded via Cloudflare AI Gateway, 100-input batches, concurrency 8 — full 10K partition in ~130 s, ~\$0.45 sync API spend per partition

## Test plan

- [x] `bash bench/fetch_gemini_cache.sh` — pulls 4 assets cleanly
- [x] `np.load(...)` returns (10000, 3072) float32 with unit norms for both partitions
- [x] meta.json parses and reports `model=gemini-embedding-001`, `truncated_count` matches encoding run
- [ ] Downstream: re-run rotation + Lloyd-Max distribution analysis (`bench/specter2_eval.py`-equivalent) on the gemini cache — follow-up