### PR TITLE
Revert encode R^T transpose (1.8× regression on Apple Metal); keep GPUCorpus search win

### DIFF
--- a/remex/mojo/bench/RESULTS.md
+++ b/remex/mojo/bench/RESULTS.md
@@ -52,42 +52,47 @@ indicative measurements (pre-#51, unaffected by it).
 | 2026-04 | [#48](https://github.com/oaustegard/remex/pull/48) | bench | Refresh; flagged twostage as weak spot | 19.0 ms (0.91×) |
 | 2026-05 | [#51](https://github.com/oaustegard/remex/pull/51) | twostage | Min-heap coarse top-k (O(n·k) → O(n log k)) | 3.18 ms (5.5×) |
 
-## GPU port (Apple M1, first cut — PR [#65](https://github.com/oaustegard/remex/pull/65))
+## GPU port (Apple M1 native, measured)
 
-**Hardware**: Apple M1 (7-core GPU, 68 GB/s unified memory), n=10000, d=384, bits=4
+**Hardware**: Apple M1 native (no container), Mojo 1.0.0b1, Xcode Metal Toolchain.
+Workload: n=10000, d=384, bits=4, seed=42, 1-trial timed after warmup.
 
 | Stage | Mojo CPU | Mojo GPU (M1 Metal) | vs CPU |
 |---|---|---|---|
-| encode (µs/vec) | 11.2 | 41.8 | 3.7× slower |
-| search (ms/q, per-call corpus H2D) | 5.6 | 10.6 | 1.9× slower |
+| encode (µs/vec) | 11.7 | 43.1 | 3.7× slower |
+| search (ms/q) | 5.74 | **4.42** | **1.30× faster** |
 
-Both GPU paths were correct but slower than the optimised CPU path.
-PR [#65](https://github.com/oaustegard/remex/pull/65) identified two root causes:
+**Search wins**: PR [#66](https://github.com/oaustegard/remex/pull/66)'s
+`GPUCorpus` stages the corpus (indices + norms, ~3.87 MB) to the device once
+and reuses it across queries. Per-query H2D drops to just the lookup table
+(~24 KB) — ~160× less transfer per query. Result: GPU search now beats CPU
+search at d=384, where before it was 1.9× slower.
 
-**Encode** — the `_encode_kernel` reads `R[col * d + j]` for each thread.
-Adjacent warp threads have different `col` values, so their R addresses
-differ by `d * 4 = 1536` bytes — one cache miss per thread per j step.
-Fix (this PR): pre-transpose R on the host → send `R_T[j * d + col]` to
-device → adjacent threads read adjacent addresses → one cache line per 16
-threads instead of 16 cache lines.
+**Encode loses**: PR [#66](https://github.com/oaustegard/remex/pull/66) also
+attempted to coalesce `R` reads across warp threads by pre-transposing R on
+the host and reading `R_T[j*d + col]`.  On Apple Metal this made encode
+*worse*: 43.1 µs/vec → 77.2 µs/vec (1.8× slowdown), reverted in PR
+[#67](https://github.com/oaustegard/remex/pull/67).
 
-**Search** — `gpu_adc_search` staged the full corpus (indices + norms,
-~3.87 MB at n=10000 d=384) to the device on every query call. Per-query
-H2D at 68 GB/s: ~57 µs corpus transfer alone. Fix (this PR): `GPUCorpus`
-stages the corpus once; `gpu_adc_search_corpus` only H2Ds the per-query
-lookup table (~24 KB) → ~160× less H2D per query.
+The transpose trades per-thread sequential reads (`R[ci*d + j]` increments
+by 1 in j) for per-thread strided reads (`R_T[j*d + ci]` strides by d).
+On NVIDIA SIMT GPUs across-warp coalescing dominates; on Apple's TBDR
+architecture the per-thread sequential pattern wins because the L1 +
+hardware prefetcher already amortises the strided across-thread cost,
+while strided per-thread reads thrash L1.  Lesson: validate GPU
+optimisations against the actual silicon — don't port NVIDIA intuition to
+Metal blind.
 
-**Expected post-PR numbers** (to be measured on a Metal host after merge):
+The `bench/RESULTS.md § Mojo port` GPU row will be populated when GPU
+numbers are competitive with a CuPy/PyTorch baseline (issue #42 acceptance
+criteria) — encode still needs work.  Avenues to investigate:
 
-| Stage | Before | After (projected) |
-|---|---|---|
-| encode (µs/vec) | 41.8 | ~10–15 (coalescing fix) |
-| search (ms/q) | 10.6 | ~0.3–1.0 (corpus cache) |
-
-The GPU encode result will be added to this table once measured.
-`bench/RESULTS.md § Mojo port` GPU row will be populated when the
-optimized numbers are competitive with a CuPy/PyTorch baseline (issue #42
-acceptance criteria).
+- One thread per row, full d-element dot in a single thread (minimises
+  R-row reuse across blocks; works because n=10k is plenty of parallelism)
+- `threadgroup` shared memory tiling — load BLOCK_X rows of R once per
+  block, all threads in the block reuse them across j
+- Vectorised per-thread loads (`SIMD[Float32, 4]`) inside the existing
+  per-thread sequential pattern
 
 ## Notes
 

--- a/remex/mojo/src/gpu/encode.mojo
+++ b/remex/mojo/src/gpu/encode.mojo
@@ -24,27 +24,6 @@ coordinates near a boundary may still flip due to operand-order
 differences in the FMA pipeline; the test (test_gpu_encode.mojo) starts
 with a strict byte-equal assert and is documented to fall back to a
 fraction-within-tolerance check if real silicon disagrees.
-
-## Memory access optimization
-
-The kernel receives R_T, the column-major transpose of R (stored row-major
-as R_T[j, k] = R[k, j]).  This turns what was a strided-by-d access into
-a coalesced access: adjacent threads in the x-dimension (adjacent `col`
-values) read R_T[j * d + col], which are contiguous in memory.
-
-Without transposition:
-  thread `col` reads R[col * d + j] — between adjacent threads the
-  addresses differ by d = 384 floats = 1536 bytes → 32 cache misses per
-  warp step.
-
-With R_T:
-  thread `col` reads R_T[j * d + col] — adjacent threads differ by one
-  float = 4 bytes → one cache line covers an entire 16-thread group.
-
-R_T is computed on the host once per `gpu_encode_batch` call via an O(d²)
-transpose (< 600 µs at d=384) and sent to the device in place of R.
-X reads are already broadcast-efficient (all threads in a warp share the
-same row and therefore the same X[row, j] at each j step).
 """
 
 from std.math import sqrt
@@ -57,7 +36,7 @@ from src.quantizer import Quantizer
 
 def _encode_kernel(
     X: UnsafePointer[Float32, MutAnyOrigin],
-    R_T: UnsafePointer[Float32, MutAnyOrigin],  # R transposed: R_T[j*d+k] = R[k*d+j]
+    R: UnsafePointer[Float32, MutAnyOrigin],
     inv_norms: UnsafePointer[Float32, MutAnyOrigin],
     boundaries: UnsafePointer[Float32, MutAnyOrigin],
     indices_out: UnsafePointer[UInt8, MutAnyOrigin],
@@ -75,12 +54,9 @@ def _encode_kernel(
     var di = Int(d)
 
     # Rotation matvec — left-to-right accumulation matches CPU `_dot_f32`.
-    # R_T[j * d + ci] = R[ci * d + j]: reading R_T with fixed j and varying ci
-    # (across warp threads) gives coalesced access — adjacent ci addresses
-    # differ by 4 bytes, vs 384*4 bytes for the original R[ci*d+j] layout.
     var rot: Float32 = 0.0
     for j in range(di):
-        rot += R_T[j * di + ci] * X[ri * di + j]
+        rot += R[ci * di + j] * X[ri * di + j]
     rot *= inv_norms[ri]
 
     # searchsorted_left: smallest i such that rot < boundaries[i]; else n_b.
@@ -121,19 +97,11 @@ def gpu_encode_batch(q: Quantizer,
         norms_out[i] = nm
         inv_norms[i] = Float32(1.0) / nm if nm > Float32(1e-8) else Float32(1.0 / 1e-8)
 
-    # 2. Pre-transpose R so the kernel sees coalesced R_T reads.
-    #    R_T[j, k] = R[k, j] stored row-major: R_T[j*d+k] = q.R.data[k*d+j].
-    #    O(d²) = ~148K ops at d=384; negligible vs O(n*d²) kernel work.
-    var R_T = alloc[Float32](d * d)
-    for k in range(d):
-        for j in range(d):
-            R_T[j * d + k] = q.R.data[k * d + j]
-
-    # 3. Stage to device, launch kernel, drain back.
+    # 2. Stage to device, launch kernel, drain back.
     var ctx = DeviceContext()
 
     var X_host = ctx.enqueue_create_host_buffer[DType.float32](n * d)
-    var RT_host = ctx.enqueue_create_host_buffer[DType.float32](d * d)
+    var R_host = ctx.enqueue_create_host_buffer[DType.float32](d * d)
     var inv_host = ctx.enqueue_create_host_buffer[DType.float32](n)
     var bnd_host = ctx.enqueue_create_host_buffer[DType.float32](n_b)
     ctx.synchronize()
@@ -141,20 +109,20 @@ def gpu_encode_batch(q: Quantizer,
     for i in range(n * d):
         X_host[i] = X[i]
     for i in range(d * d):
-        RT_host[i] = R_T[i]
+        R_host[i] = q.R.data[i]
     for i in range(n):
         inv_host[i] = inv_norms[i]
     for i in range(n_b):
         bnd_host[i] = q.cb.boundaries[i]
 
     var X_dev = ctx.enqueue_create_buffer[DType.float32](n * d)
-    var RT_dev = ctx.enqueue_create_buffer[DType.float32](d * d)
+    var R_dev = ctx.enqueue_create_buffer[DType.float32](d * d)
     var inv_dev = ctx.enqueue_create_buffer[DType.float32](n)
     var bnd_dev = ctx.enqueue_create_buffer[DType.float32](n_b)
     var idx_dev = ctx.enqueue_create_buffer[DType.uint8](n * d)
 
     ctx.enqueue_copy(dst_buf=X_dev, src_buf=X_host)
-    ctx.enqueue_copy(dst_buf=RT_dev, src_buf=RT_host)
+    ctx.enqueue_copy(dst_buf=R_dev, src_buf=R_host)
     ctx.enqueue_copy(dst_buf=inv_dev, src_buf=inv_host)
     ctx.enqueue_copy(dst_buf=bnd_dev, src_buf=bnd_host)
 
@@ -165,7 +133,7 @@ def gpu_encode_batch(q: Quantizer,
 
     ctx.enqueue_function[_encode_kernel, _encode_kernel](
         X_dev.unsafe_ptr(),
-        RT_dev.unsafe_ptr(),
+        R_dev.unsafe_ptr(),
         inv_dev.unsafe_ptr(),
         bnd_dev.unsafe_ptr(),
         idx_dev.unsafe_ptr(),
@@ -183,5 +151,4 @@ def gpu_encode_batch(q: Quantizer,
     for i in range(n * d):
         indices_out[i] = idx_host[i]
 
-    R_T.free()
     inv_norms.free()


### PR DESCRIPTION
## What this is

A correctness/honesty fix on top of [#66](https://github.com/oaustegard/remex/pull/66), driven by **actual measurement on Apple M1 native** (Mojo 1.0.0b1, n=10000 d=384 bits=4):

| Stage | Mojo CPU | Mojo GPU (#65 kernel) | Mojo GPU (#66 R^T) |
|---|---|---|---|
| encode µs/vec | 11.7 | **43.1** | **77.2** ← #66 regressed by 1.8× |
| search ms/q | 5.74 | (10.6 in #65) | **4.42** ← #66 win is real |

**Search** (`GPUCorpus` + `gpu_adc_search_corpus`): kept. The corpus cache eliminates ~3.87 MB of per-query H2D, and GPU search now beats CPU search at d=384 (4.42 vs 5.74 ms/q).

**Encode** (R^T pre-transpose + transposed kernel access): reverted to the PR [#65](https://github.com/oaustegard/remex/pull/65) implementation.

## Why R^T hurt on Apple Metal

The PR #66 description argued for coalescing across threads: with `R[ci*d+j]`, adjacent threads stride by `d*4 = 1536` bytes between memory accesses, vs 4 bytes with `R_T[j*d+ci]`. That analysis is correct for NVIDIA SIMT, where 32 lanes share the load/store unit and warp coalescing is the dominant memory-traffic factor.

It's wrong for Apple's TBDR. With R^T, *per-thread* reads stride by d (since j increments) instead of being sequential. Apple's per-thread L1 + hardware prefetcher amortises the strided across-thread cost effectively, but strided per-thread reads thrash L1. Net effect: 1.8× slowdown.

The general lesson is in `bench/RESULTS.md`: validate GPU optimisations against actual silicon — NVIDIA intuition doesn't port blind to Metal.

## What's next for encode

Listed in `RESULTS.md`:
1. One thread per row, full d-element dot in-thread (minimises R reuse across blocks; n=10k provides plenty of parallelism)
2. `threadgroup` shared memory tiling — load BLOCK_X rows of R into shared memory once per block, all threads in the block reuse them across j
3. Per-thread vectorised loads (`SIMD[Float32, 4]`) within the existing sequential pattern

Each of those needs the same kind of measurement-driven validation that this PR is doing — projections aren't enough.

## Test plan

- [x] `mojo run -I . tests/test_gpu_search.mojo` — passes; legacy and corpus paths bit-identical
- [x] `bench_gpu_encode --n 10000 --d 384 --bits 4` — 43.1 µs/vec restored (was 77.2 with R^T)
- [x] `bench_gpu_search --n 10000 --d 384 --bits 4 --queries 100 --k 10` — 4.42 ms/q (corpus win retained)

Measured on Apple M1, Mojo 1.0.0b1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)