### PR TITLE
Add --device auto for per-stage device routing (efficient default)

### DIFF
--- a/remex/mojo/README.md
+++ b/remex/mojo/README.md
@@ -273,13 +273,30 @@ python bench/compare.py --n 10000 --d 384 --bits 4 --queries 100 --k 10
 
 See `bench/RESULTS.md` (in this PR) for current numbers.
 
-## GPU / MAX path (`--device gpu`)
+## GPU / MAX path (`--device auto|cpu|gpu`)
 
-**Status: scaffolding only.** The CLI flag, dispatch, test harness, and
-bench drivers are wired, but the kernels in `src/gpu/encode.mojo` and
-`src/gpu/adc.mojo` are stubs that raise `Error` until the real
-MAX-graph or kernel-launch implementation lands. Tracked by
-[issue #42](https://github.com/oaustegard/remex/issues/42).
+**Status: kernels live, auto policy steers per stage.** Encode and
+ADC-search kernels in `src/gpu/encode.mojo` and `src/gpu/adc.mojo`
+landed via PRs [#65](https://github.com/oaustegard/remex/pull/65)
+and [#66](https://github.com/oaustegard/remex/pull/66). The CLI now
+defaults to `--device auto`, which resolves per stage based on what's
+been measured:
+
+- **encode → CPU.** Mojo CPU encode is 11.7 µs/vec at d=384; Apple Metal
+  GPU is 43.1 µs/vec (3.7× slower) on the same host (PR
+  [#67](https://github.com/oaustegard/remex/pull/67)). NVIDIA/AMD encode
+  is unmeasured; auto stays on the safe path until that changes.
+- **search → GPU when an accelerator is reachable.** GPU ADC search with
+  the corpus cache is 1.30× faster than CPU on Apple Metal at d=384
+  (PR [#66](https://github.com/oaustegard/remex/pull/66)); falls back
+  to CPU when no accelerator is available.
+
+Use `--device cpu` or `--device gpu` to force a backend explicitly —
+useful for benchmarking or for non-Apple GPU hosts where the auto
+policy may be too conservative on encode. Forcing `--device gpu` for
+encode on Apple Metal still works but prints a one-line warning. See
+[issue #42](https://github.com/oaustegard/remex/issues/42) for the
+broader GPU acceptance criteria.
 
 ### Build
 
@@ -303,9 +320,13 @@ mojo build -I . bench/bench_gpu_search.mojo    -o bench/bench_gpu_search
 ### Run
 
 ```bash
-# Encode + search on GPU (errors with a clear message until kernels land).
+# Default: auto picks CPU encode, GPU search on hosts with an accelerator.
+./polarquant encode corpus.npy --bits 4 --params P.bin -o corpus.pq
+./polarquant search corpus.pq query.npy --k 10 --params P.bin --top 10
+
+# Force a backend (e.g. for benchmarking).
 ./polarquant encode corpus.npy --bits 4 --params P.bin --device gpu -o corpus.pq
-./polarquant search corpus.pq query.npy --k 10 --params P.bin --device gpu --top 10
+./polarquant search corpus.pq query.npy --k 10 --params P.bin --device cpu --top 10
 ```
 
 ### Tests
@@ -360,10 +381,12 @@ already works.
   candidate selection is O(n*candidates). Mirrors the structure of
   `adc_search` in this port. Tighter inner-loop kernels — especially
   for the coarse-stage reduction at low precision — are a follow-up.
-- **GPU kernels are stubbed.** `--device gpu` is wired through the CLI,
-  tests, and bench drivers, but `src/gpu/encode.mojo` and
-  `src/gpu/adc.mojo` raise until the MAX implementation lands — see
-  the `## GPU / MAX path` section above and issue #42.
+- **GPU kernels live; default policy is per-stage.** `--device auto`
+  (the default) routes encode to CPU and ADC search to GPU when an
+  accelerator is present. Apple Metal GPU encode is measured 3.7× slower
+  than CPU at d=384 (PR #67); NVIDIA/AMD encode is unmeasured, and the
+  auto policy stays conservative there until a baseline lands. See the
+  `## GPU / MAX path` section above and issue #42.
 - **Seed parity** with NumPy's `default_rng` is now bit-identical at
   1–4 bits via `src/rng_numpy.mojo` (PCG64 + SeedSequence + Ziggurat,
   issue #40). 8-bit byte parity is blocked by Mojo `std.math.erf`

--- a/remex/mojo/bench/RESULTS.md
+++ b/remex/mojo/bench/RESULTS.md
@@ -74,6 +74,13 @@ the host and reading `R_T[j*d + col]`.  On Apple Metal this made encode
 *worse*: 43.1 µs/vec → 77.2 µs/vec (1.8× slowdown), reverted in PR
 [#67](https://github.com/oaustegard/remex/pull/67).
 
+**Default policy** (`--device auto`, the new default): encode runs on
+CPU, search runs on GPU when an accelerator is reachable. CPU encode
+beats GPU encode on every measured host today (Apple M1: 3.7× slower on
+GPU); NVIDIA/AMD encode is unmeasured, so auto stays on CPU until a
+baseline confirms otherwise. `--device cpu` and `--device gpu` are
+explicit overrides for benchmarking or for re-measuring the policy.
+
 The transpose trades per-thread sequential reads (`R[ci*d + j]` increments
 by 1 in j) for per-thread strided reads (`R_T[j*d + ci]` strides by d).
 On NVIDIA SIMT GPUs across-warp coalescing dominates; on Apple's TBDR

--- a/remex/mojo/polarquant.mojo
+++ b/remex/mojo/polarquant.mojo
@@ -23,7 +23,7 @@ from src.pq_format import save_pq, load_pq
 from src.quantizer import Quantizer, encode_batch, adc_search, search_twostage, decode_batch
 from src.packing import pack, packed_nbytes
 from src.rotation import haar_rotation, haar_rotation_numpy
-from src.gpu.device import is_gpu_available
+from src.gpu.device import is_apple_gpu, is_gpu_available
 from src.gpu.encode import gpu_encode_batch
 from src.gpu.adc import gpu_adc_search
 
@@ -66,32 +66,84 @@ def _build_quantizer(d: Int, bits: Int, seed: UInt64,
 
 def _print_usage():
     print("usage:")
-    print("  polarquant encode <input.npy> --bits N (--seed S | --params P) [--device cpu|gpu] -o <out.pq>")
-    print("  polarquant search <index.pq> <query.npy> --k K (--seed S | --params P) [--device cpu|gpu] [--top T]")
+    print("  polarquant encode <input.npy> --bits N (--seed S | --params P) [--device auto|cpu|gpu] -o <out.pq>")
+    print("  polarquant search <index.pq> <query.npy> --k K (--seed S | --params P) [--device auto|cpu|gpu] [--top T]")
     print("                   [--twostage --candidates N --coarse-precision K]")
     print("  polarquant decode <index.pq> (--seed S | --params P) [--precision P] -o <out.npy>")
+    print("")
+    print("--device defaults to 'auto', which picks the most efficient backend per stage:")
+    print("  encode: always CPU (GPU encode is currently slower on every measured platform;")
+    print("          Apple Metal is 3.7x slower at d=384, see bench/RESULTS.md).")
+    print("  search: GPU if an accelerator is present, else CPU (GPU search is faster on")
+    print("          Apple Metal via the corpus cache; non-Apple GPUs are not yet measured).")
+    print("Use --device cpu or --device gpu to force a backend (e.g. for benchmarking).")
 
 
 def _parse_device(args: List[String]) raises -> String:
-    """Parse --device flag. Returns 'cpu' (default) or 'gpu'.
+    """Parse --device flag. Returns 'auto' (default), 'cpu', or 'gpu'.
 
-    Errors if --device is given an unknown value, or if 'gpu' is requested
-    but no GPU is available (the GPU kernels are stubbed pending issue #42,
-    so `is_gpu_available()` returns False until they land).
+    The actual backend used per stage is decided by `_resolve_encode_device`
+    and `_resolve_search_device`, which apply per-stage policy when 'auto'
+    is requested. Errors only on unknown flag values; 'gpu' availability is
+    checked at resolve time so 'auto' can fall back cleanly.
     """
     var idx = _arg_idx(args, String("--device"))
     if idx < 0:
-        return String("cpu")
+        return String("auto")
     var dev = _arg_str(args, idx + 1)
-    if dev != String("cpu") and dev != String("gpu"):
-        raise Error(String("--device must be 'cpu' or 'gpu', got: ") + dev)
-    if dev == String("gpu") and not is_gpu_available():
-        raise Error(
-            "--device gpu requested but no GPU is available. "
-            "GPU kernels are not yet implemented (see issue #42). "
-            "Drop the flag (or pass --device cpu) to run on CPU."
-        )
+    if dev != String("auto") and dev != String("cpu") and dev != String("gpu"):
+        raise Error(String("--device must be 'auto', 'cpu', or 'gpu', got: ") + dev)
     return dev
+
+
+def _resolve_encode_device(requested: String) raises -> String:
+    """Pick encode backend. Honors explicit cpu/gpu; 'auto' resolves to cpu.
+
+    Auto-policy rationale: GPU encode has been measured slower than CPU on
+    every host tested (3.7x slower on Apple M1 at d=384, PR #67). NVIDIA
+    and AMD GPU encode are unmeasured; the conservative auto choice is CPU
+    until a GPU baseline lands.
+    """
+    if requested == String("cpu"):
+        return String("cpu")
+    if requested == String("gpu"):
+        if not is_gpu_available():
+            raise Error(
+                "--device gpu requested but no GPU is available. "
+                "Drop the flag (or pass --device cpu / --device auto)."
+            )
+        if is_apple_gpu():
+            print(
+                "warning: --device gpu encode on Apple Metal is ~3.7x slower than CPU "
+                "(measured at d=384, see bench/RESULTS.md). Proceeding as requested; "
+                "use --device auto for the efficient default."
+            )
+        return String("gpu")
+    # auto
+    return String("cpu")
+
+
+def _resolve_search_device(requested: String) raises -> String:
+    """Pick search backend. Honors explicit cpu/gpu; 'auto' uses GPU if available.
+
+    Auto-policy rationale: GPU search is measured 1.30x faster than CPU on
+    Apple Metal at d=384 (PR #66 corpus cache). The corpus-cache design
+    generalizes to NVIDIA/AMD; auto enables it whenever an accelerator is
+    reachable, and falls back to CPU otherwise.
+    """
+    if requested == String("cpu"):
+        return String("cpu")
+    if requested == String("gpu"):
+        if not is_gpu_available():
+            raise Error(
+                "--device gpu requested but no GPU is available. "
+                "Drop the flag (or pass --device cpu / --device auto)."
+            )
+        return String("gpu")
+    # auto
+    if is_gpu_available():
+        return String("gpu")
+    return String("cpu")
 
 
 def cmd_encode(args: List[String]) raises:
@@ -122,7 +174,8 @@ def cmd_encode(args: List[String]) raises:
         raise Error("encode: -o <out.pq> required")
     var out_path = _arg_str(args, out_idx + 1)
 
-    var device = _parse_device(args)
+    var requested_device = _parse_device(args)
+    var device = _resolve_encode_device(requested_device)
 
     var rng_idx = _arg_idx(args, String("--rng"))
     var rng_choice = String("numpy")
@@ -131,7 +184,10 @@ def cmd_encode(args: List[String]) raises:
         if rng_choice != "numpy" and rng_choice != "xoshiro":
             raise Error("encode: --rng must be 'numpy' (default) or 'xoshiro'")
 
-    print("encode:", input_path, "→", out_path, "(bits =", bits, ", device =", device, ", rng =", rng_choice, ")")
+    var device_note = String("")
+    if requested_device == String("auto"):
+        device_note = String(" [auto]")
+    print("encode:", input_path, "→", out_path, "(bits =", bits, ", device =", device + device_note, ", rng =", rng_choice, ")")
     var X = load_npy_2d_f32(input_path)
     var n = X.rows
     var d = X.cols
@@ -196,16 +252,25 @@ def cmd_search(args: List[String]) raises:
     if top_idx >= 0:
         print_top = Int(_arg_str(args, top_idx + 1))
 
-    var device = _parse_device(args)
+    var requested_device = _parse_device(args)
 
     # Two-stage mode flags
     var twostage_idx = _arg_idx(args, String("--twostage"))
     var use_twostage = twostage_idx >= 0
-    if use_twostage and device == String("gpu"):
-        raise Error(
-            "search --twostage --device gpu: not supported. "
-            "Issue #42 covers adc_search only; two-stage GPU is a follow-up."
-        )
+    # Twostage runs on CPU only — force CPU when 'auto'; reject explicit 'gpu'.
+    var device: String
+    if use_twostage:
+        if requested_device == String("gpu"):
+            raise Error(
+                "search --twostage --device gpu: not supported. "
+                "Issue #42 covers adc_search only; two-stage GPU is a follow-up. "
+                "Drop the flag (or pass --device auto / --device cpu)."
+            )
+        device = String("cpu")
+    else:
+        device = _resolve_search_device(requested_device)
+    if requested_device == String("auto"):
+        print("search: device resolved to", device, "[auto]")
     var candidates = 0
     var coarse_precision = 0
     if use_twostage:

--- a/remex/mojo/src/gpu/device.mojo
+++ b/remex/mojo/src/gpu/device.mojo
@@ -3,14 +3,38 @@
 Probes whether a Mojo-supported accelerator is present at compile time
 via `std.sys.has_accelerator()`. Mojo 1.0 single-source kernels target
 NVIDIA, AMD, and Apple Metal from the same source.
+
+Apple Metal is detected by elimination: an accelerator is present and
+it is neither NVIDIA nor AMD (i.e. Apple Silicon's integrated GPU,
+which is the only other GPU architecture Mojo currently targets). Used
+by the per-stage device-routing policy in `polarquant.mojo` because
+Apple's TBDR architecture has measured behavior different from
+NVIDIA/AMD SIMT GPUs — see `bench/RESULTS.md § Mojo port` and PR #67.
 """
 
 from std.sys import has_accelerator
+from std.sys.info import has_amd_gpu_accelerator, has_nvidia_gpu_accelerator
 
 
 def is_gpu_available() -> Bool:
     """Return True iff a Mojo-supported GPU is reachable from this build."""
     comptime if has_accelerator():
+        return True
+    else:
+        return False
+
+
+def is_apple_gpu() -> Bool:
+    """Return True iff the accelerator is Apple Silicon's integrated GPU.
+
+    True when an accelerator is present that is neither NVIDIA nor AMD;
+    in Mojo 1.0 the remaining target is Apple Metal. Used by `polarquant`'s
+    `auto` device policy to avoid GPU encode on Apple Metal, which is
+    measured 3.7× slower than CPU at d=384 (see PR #67).
+    """
+    comptime if has_accelerator() \
+            and not has_nvidia_gpu_accelerator() \
+            and not has_amd_gpu_accelerator():
         return True
     else:
         return False


### PR DESCRIPTION
## What this is

Follow-up to [#67](https://github.com/oaustegard/remex/pull/67), which measured that on Apple Metal:

| Stage | Mojo CPU | Mojo GPU | vs CPU |
|---|---|---|---|
| encode | 11.7 µs/vec | 43.1 µs/vec | **3.7× slower** |
| search | 5.74 ms/q | 4.42 ms/q | 1.30× faster |

The current CLI shares one `--device` flag across both stages, so `--device gpu` for search drags encode onto a slow path. This change adds **`--device auto`** (the new default) that resolves per stage:

- **encode → CPU** — measured slower on Apple Metal; NVIDIA/AMD unmeasured, so stay conservative.
- **search → GPU when an accelerator is reachable**, else CPU — corpus-cache design (PR [#66](https://github.com/oaustegard/remex/pull/66)) generalises.

`--device cpu` and `--device gpu` remain as explicit overrides — bench drivers, parity tests, and "let me measure this on a new GPU" all keep working untouched. Forcing `--device gpu` for encode on Apple Metal still works but prints a one-line warning citing the measured regression.

## Why this matters

The [#67](https://github.com/oaustegard/remex/pull/67) lesson — *validate GPU optimisations against actual silicon* — extends to a UX point: the CLI should default to the measured best path so users don't have to memorise "encode CPU, search GPU on Mac". Single global `--device` was the right shape when only one backend was implemented; with both kernels live and Apple Metal having distinct architectural behaviour, per-stage routing is the right shape now.

## What changed

- `src/gpu/device.mojo`: new `is_apple_gpu()` — accelerator present that is neither NVIDIA nor AMD (Mojo 1.0's only remaining accelerator target). Used by the auto policy.
- `polarquant.mojo`: `_parse_device` now defaults to `auto` and accepts `auto|cpu|gpu`. New `_resolve_encode_device` / `_resolve_search_device` apply per-stage policy. Stage prints `[auto]` annotation when policy resolved the choice. `--twostage` paths still force CPU and reject explicit `gpu`.
- `README.md` + `bench/RESULTS.md`: document the new policy. Drop the stale "kernels are stubbed" wording (kernels landed in #65/#66).

`std.sys.info.os_is_macos` isn't exposed in Mojo 1.0.0b1, so Apple Metal detection uses the elimination test rather than an OS check. That's actually slightly more robust — it gates on the accelerator architecture, not the host OS.

## Test plan

Verified on Apple M1, Mojo 1.0.0b1:

- [x] \`polarquant encode ...\` (no --device) → \`device = cpu [auto]\`
- [x] \`polarquant search ...\` (no --device) → \`device resolved to gpu [auto]\`
- [x] \`polarquant encode --device gpu ...\` → emits warning, proceeds with GPU encode
- [x] \`polarquant encode --device cpu ...\` → no auto note, runs CPU
- [x] \`polarquant search --device cpu ...\` → CPU path, top-k matches GPU result
- [x] \`polarquant encode --device foo ...\` → clear error
- [x] \`mojo run -I . tests/test_gpu_search.mojo\` → legacy + corpus paths still bit-identical
- [x] CPU codebook/packing tests still pass

Bench drivers (\`bench_gpu_encode\`, \`bench_gpu_search\`) call the GPU kernels directly and bypass the CLI — they continue to measure GPU as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)