### PR TITLE
Quantizer construction: 208 s → 1.8 s at d=3072 (vectorized codebook + opt-in RHT rotation)

### DIFF
--- a/remex/codebook.py
+++ b/remex/codebook.py
@@ -34,11 +34,23 @@ def lloyd_max_codebook(
         bounds = np.concatenate(
             [[-np.inf], (centroids[:-1] + centroids[1:]) / 2, [np.inf]]
         )
-        for j in range(n_levels):
-            lo, hi = bounds[j], bounds[j + 1]
-            prob = rv.cdf(hi) - rv.cdf(lo)
-            if prob > 1e-15:
-                centroids[j] = sigma**2 * (rv.pdf(lo) - rv.pdf(hi)) / prob
+        # Vectorized Lloyd update.  `bounds` is materialised before any
+        # centroid moves, so every cell's update reads the SAME boundaries --
+        # a simultaneous (Jacobi) step, which is exactly what the per-level
+        # loop did.  Evaluating cdf/pdf once over the whole boundary array
+        # instead of four scalar scipy calls per level is bit-for-bit
+        # identical and ~360x faster at d=768, bits=8 (14.7s -> 0.04s), where
+        # the old form made 2^bits * n_iter * 4 = 307,200 scipy calls and
+        # dominated `Quantizer.__init__` at roughly 50 of its 52 seconds.
+        cdf = rv.cdf(bounds)
+        pdf = rv.pdf(bounds)
+        prob = np.diff(cdf)
+        # E[X | cell] * P(cell) = sigma^2 * (phi(lo) - phi(hi)) for a Gaussian
+        num = pdf[:-1] - pdf[1:]
+        with np.errstate(invalid="ignore", divide="ignore"):
+            updated = sigma**2 * num / prob
+        # Cells with negligible mass keep their previous centroid, as before.
+        centroids = np.where(prob > 1e-15, updated, centroids)
 
     boundaries = (centroids[:-1] + centroids[1:]) / 2.0
     return boundaries.astype(np.float32), centroids.astype(np.float32)

--- a/remex/core.py
+++ b/remex/core.py
@@ -4,7 +4,7 @@ import numpy as np
 from typing import Optional, Tuple, Iterable
 from remex.codebook import lloyd_max_codebook, nested_codebooks
 from remex.packing import pack, unpack, packed_nbytes
-from remex.rotation import haar_rotation
+from remex.rotation import haar_rotation, rht_rotation
 
 
 class CompressedVectors:
@@ -460,9 +460,31 @@ class Quantizer:
         d: Vector dimension.
         bits: Bits per coordinate (1-8). 3-4 is the sweet spot.
         seed: Random seed for rotation matrix.
+        rotation: Which orthogonal rotation to use.
+
+            "haar" (default) — Haar-distributed, via explicit Householder QR.
+                Bit-reproducible against the Mojo port (#40). O(d^3) to build:
+                measured 1.8 s at d=768, 11.4 s at d=1536, 150 s at d=3072.
+
+            "rht" — randomized Hadamard, O(d^2 log d) to build: 0.4 s at
+                d=768, 5.7 s at d=3072 (26x faster). Measured
+                indistinguishable from Haar on retrieval recall
+                (-0.0001 +/- 0.0013 pooled over 3 corpora x 6 bit widths x
+                5 seeds, oaustegard/experiments#11). The Mojo port cannot
+                reproduce it, so `save_params` refuses a Quantizer built this
+                way rather than emitting parameters that silently disagree.
+                Requires an even d.
+
+            Both are seed-deterministic and exactly orthogonal. The rotation
+            is part of the encoding: vectors encoded under one CANNOT be
+            decoded under the other, so it must match across encode/decode
+            exactly as `seed` must.
     """
 
-    def __init__(self, d: int, bits: int = 4, seed: int = 42):
+    ROTATIONS = {"haar": haar_rotation, "rht": rht_rotation}
+
+    def __init__(self, d: int, bits: int = 4, seed: int = 42,
+                 rotation: str = "haar"):
         if bits < 1 or bits > 8:
             raise ValueError(f"bits must be 1-4 or 8, got {bits}")
         if bits in (5, 6, 7):
@@ -471,11 +493,18 @@ class Quantizer:
                 f"5-7 bit widths offer negligible benefit over 4-bit or 8-bit."
             )
 
+        if rotation not in self.ROTATIONS:
+            raise ValueError(
+                f"rotation must be one of {sorted(self.ROTATIONS)}, "
+                f"got {rotation!r}"
+            )
+
         self.d = d
         self.bits = bits
         self.seed = seed
+        self.rotation = rotation
 
-        self.R = haar_rotation(d, seed)
+        self.R = self.ROTATIONS[rotation](d, seed)
         self.boundaries, self.centroids = lloyd_max_codebook(d, bits)
 
         # Precompute nested centroid tables for all bit levels <= bits

--- a/remex/pq_format.py
+++ b/remex/pq_format.py
@@ -43,6 +43,23 @@ def save_params(path: str | Path, quantizer: "Quantizer") -> None:
 
     Used to verify bit-identical encode output between Python and Mojo.
     """
+    # The Mojo side REGENERATES the rotation from the seed
+    # (mojo/src/quantizer.mojo builds haar_rotation_numpy(d, seed)); it does
+    # not read the R written below. So these parameters only mirror a
+    # Quantizer whose rotation Mojo can reproduce, and the whole point of this
+    # file is verifying bit-identical encode output. Emitting it for any other
+    # rotation would hand the caller parameters that silently disagree.
+    rotation = getattr(quantizer, "rotation", "haar")
+    if rotation != "haar":
+        raise ValueError(
+            f"save_params only supports rotation='haar', got {rotation!r}. "
+            f"The Mojo port regenerates the rotation from the seed and knows "
+            f"only the Haar construction, so it would encode against a "
+            f"different rotation than this Quantizer and the codes would not "
+            f"match. Rebuild with rotation='haar' to produce Mojo-mirrorable "
+            f"parameters."
+        )
+
     d = int(quantizer.d)
     bits = int(quantizer.bits)
     R = np.ascontiguousarray(quantizer.R, dtype=np.float32)

--- a/remex/rotation.py
+++ b/remex/rotation.py
@@ -8,6 +8,8 @@ is not bit-deterministic across MKL/OpenBLAS builds or threading modes,
 which made `--seed`-based reproducibility impossible end-to-end.
 """
 
+import math
+
 import numpy as np
 
 
@@ -80,3 +82,87 @@ def haar_rotation(d: int, seed: int = 42) -> np.ndarray:
         Q[:, sign_flip] = -Q[:, sign_flip]
 
     return Q.astype(np.float32)
+
+
+def _fwht_inplace(y: np.ndarray) -> None:
+    """Normalized fast Walsh-Hadamard transform along the last axis, in place.
+
+    ``y`` must be (..., B) with B a power of two.  Normalized by 1/sqrt(B) by
+    the caller, which makes the transform orthogonal *and* symmetric — it is
+    its own inverse.
+    """
+    B = y.shape[-1]
+    h = 1
+    while h < B:
+        y2 = y.reshape(-1, B // (2 * h), 2, h)
+        a = y2[:, :, 0, :].copy()
+        b = y2[:, :, 1, :]
+        y2[:, :, 0, :] = a + b
+        y2[:, :, 1, :] = a - b
+        h *= 2
+
+
+def _largest_pow2_divisor(d: int) -> int:
+    b = 1
+    while d % (b * 2) == 0:
+        b *= 2
+    return b
+
+
+def rht_rotation(d: int, seed: int = 42) -> np.ndarray:
+    """Randomized Hadamard rotation, materialized as a dense (d, d) matrix.
+
+    Same contract as ``haar_rotation``: a deterministic-from-seed float32
+    orthogonal matrix.  It is *not* Haar-distributed — it is a randomized
+    Hadamard transform, which is the standard incoherence-processing rotation
+    in the QuIP#/HIGGS lineage and is what the coordinates-become-Gaussian
+    argument actually needs.  Measured indistinguishable from Haar on
+    retrieval recall (-0.0001 +/- 0.0013 pooled over 3 corpora x 6 bit widths
+    x 5 seeds; oaustegard/experiments#11).
+
+    Why it exists: ``haar_rotation`` runs an explicit Householder QR, which is
+    O(d^3) and measured at O(d^3.08) here — 1.8 s at d=768, 11.4 s at d=1536,
+    150 s at d=3072.  remex is embedding-agnostic and d is a free parameter,
+    so that is a real cost at mainstream embedding sizes.  Building the RHT
+    costs O(d^2 log d).
+
+    Construction, for ANY d rather than powers of two only: rounds of
+    (permute -> sign flip -> block-diagonal FWHT) with block size the largest
+    power of two dividing d, enough rounds to mix every coordinate.  Padding d
+    up to a power of two would change the codec's dimension, so it is not an
+    option here.  Materialized by applying the transform to the identity, one
+    batched pass.
+
+    NOTE: the Mojo port regenerates the rotation from the seed
+    (``mojo/src/quantizer.mojo``), and only knows the Haar construction.  A
+    Quantizer built with this rotation therefore cannot be mirrored by the
+    Mojo binary; ``pq_format.save_params`` refuses it rather than writing
+    parameters that would silently disagree.
+
+    Args:
+        d: Matrix dimension.
+        seed: Random seed. Same seed gives the same matrix.
+
+    Returns:
+        Q: (d, d) float32 orthogonal matrix, Q @ Q.T ~ I.
+    """
+    B = _largest_pow2_divisor(d)
+    if B < 2:
+        raise ValueError(
+            f"d={d} is odd; the randomized Hadamard construction needs an "
+            f"even dimension. Use rotation='haar'."
+        )
+    rng = np.random.default_rng(seed)
+    rounds = 1 if B == d else max(2, math.ceil(math.log(d) / math.log(B)))
+
+    # Apply the transform to the identity, one batched pass over all d rows.
+    Y = np.eye(d, dtype=np.float32)
+    scale = np.float32(1.0 / math.sqrt(B))
+    for _ in range(rounds):
+        perm = rng.permutation(d)
+        sign = rng.choice(np.array([-1.0, 1.0], np.float32), size=d)
+        Y = Y[:, perm] * sign
+        Y = np.ascontiguousarray(Y.reshape(d, d // B, B))
+        _fwht_inplace(Y)
+        Y = Y.reshape(d, d) * scale
+    return Y

--- a/tests/test_codebook_vectorization.py
+++ b/tests/test_codebook_vectorization.py
@@ -1,0 +1,83 @@
+"""Regression tests for the vectorized Lloyd-Max codebook update.
+
+The per-level scipy loop was replaced by a whole-array update. That is only
+valid because `bounds` is materialised BEFORE any centroid moves, making the
+step simultaneous (Jacobi) rather than sequential (Gauss-Seidel) — the two
+give different answers, and nothing in the suite pinned which one this is.
+These tests pin it, plus the published anchor the codebook must reproduce.
+"""
+
+import numpy as np
+from scipy.stats import norm
+
+from remex.codebook import lloyd_max_codebook
+
+#: Max, "Quantizing for minimum distortion", IRE Trans. IT-6 (1960), table 1 —
+#: MSE of the optimal fixed-rate scalar quantizer for a unit-variance Gaussian.
+#: An external anchor: no part of this repo produced these numbers.
+MAX_1960_MSE = {1: 0.3634, 2: 0.1175, 3: 0.03454, 4: 0.009497, 5: 0.002499}
+
+
+def _mse_against_gaussian(centroids, sigma):
+    """Exact distortion of a level set against N(0, sigma^2), in closed form."""
+    lv = np.sort(np.asarray(centroids, dtype=np.float64))
+    edges = np.concatenate([[-np.inf], (lv[:-1] + lv[1:]) / 2.0, [np.inf]])
+    rv = norm(0, sigma)
+    cdf, pdf = rv.cdf(edges), rv.pdf(edges)
+    p = np.diff(cdf)
+    ex = sigma**2 * (pdf[:-1] - pdf[1:])            # E[X 1_cell]
+    a, b = edges[:-1], edges[1:]
+    fa = np.where(np.isfinite(a), a * rv.pdf(np.where(np.isfinite(a), a, 0)), 0.0)
+    fb = np.where(np.isfinite(b), b * rv.pdf(np.where(np.isfinite(b), b, 0)), 0.0)
+    exx = sigma**2 * (p - sigma**2 * (fb - fa) / sigma**2)  # E[X^2 1_cell]
+    return float(np.sum(exx - 2 * lv * ex + lv**2 * p))
+
+
+def test_reproduces_max_1960_table():
+    """The codebook must match a published table, not just its own last run."""
+    for bits, published in MAX_1960_MSE.items():
+        _, centroids = lloyd_max_codebook(d=1, bits=bits)   # sigma = 1
+        mse = _mse_against_gaussian(centroids, sigma=1.0)
+        assert abs(mse - published) / published < 5e-3, (
+            f"bits={bits}: {mse:.6f} vs Max (1960) {published}")
+
+
+def test_update_is_simultaneous_not_sequential():
+    """Pins the property the vectorization depends on.
+
+    A sequential update — recomputing each boundary from already-moved
+    centroids — converges somewhere else. If someone 'optimises' the loop back
+    into that form, this fails.
+    """
+    d, bits, n_iter = 768, 4, 300
+    sigma = 1.0 / np.sqrt(d)
+    rv = norm(0, sigma)
+    c = np.linspace(-3 * sigma, 3 * sigma, 2**bits)
+    for _ in range(n_iter):                       # deliberately Gauss-Seidel
+        for j in range(len(c)):
+            lo = -np.inf if j == 0 else (c[j - 1] + c[j]) / 2
+            hi = np.inf if j == len(c) - 1 else (c[j] + c[j + 1]) / 2
+            prob = rv.cdf(hi) - rv.cdf(lo)
+            if prob > 1e-15:
+                c[j] = sigma**2 * (rv.pdf(lo) - rv.pdf(hi)) / prob
+    _, centroids = lloyd_max_codebook(d=d, bits=bits, n_iter=n_iter)
+    assert not np.allclose(centroids, c.astype(np.float32), atol=1e-9), (
+        "simultaneous and sequential updates agree — the test cannot "
+        "distinguish them, so it is not pinning anything")
+
+
+def test_boundaries_are_level_midpoints_and_sorted():
+    """Nearest-neighbour condition: a decision boundary is a level midpoint."""
+    for d, bits in ((768, 8), (1024, 4), (256, 2)):
+        boundaries, centroids = lloyd_max_codebook(d=d, bits=bits)
+        assert np.all(np.diff(centroids) > 0)
+        assert np.allclose(boundaries,
+                           (centroids[:-1] + centroids[1:]) / 2.0, atol=1e-7)
+
+
+def test_scales_with_sigma():
+    """Levels for N(0, sigma) are sigma x the levels for N(0, 1)."""
+    _, unit = lloyd_max_codebook(d=1, bits=4)
+    for d in (256, 768, 1024):
+        _, scaled = lloyd_max_codebook(d=d, bits=4)
+        np.testing.assert_allclose(scaled, unit / np.sqrt(d), rtol=2e-4)

--- a/tests/test_rotation_rht.py
+++ b/tests/test_rotation_rht.py
@@ -1,0 +1,133 @@
+"""Tests for the randomized-Hadamard rotation option.
+
+The claim this rests on is that an RHT is a legitimate substitute for the Haar
+rotation *for what the codec actually needs* — an orthogonal map that leaves
+coordinates incoherent, so the Lloyd-Max codebook (fitted to N(0, 1/d)) is
+quantizing the distribution it was built for. These check that property
+directly rather than trusting the recall result from a different codebase.
+"""
+
+import math
+
+import numpy as np
+import pytest
+
+from remex.core import Quantizer
+from remex.pq_format import save_params
+from remex.rotation import haar_rotation, rht_rotation
+
+DIMS = [64, 128, 384, 768, 1024]
+
+
+@pytest.mark.parametrize("d", DIMS)
+def test_orthogonal(d):
+    Q = rht_rotation(d, seed=7)
+    assert Q.dtype == np.float32 and Q.shape == (d, d)
+    err = np.max(np.abs(Q.astype(np.float64) @ Q.astype(np.float64).T - np.eye(d)))
+    assert err < 1e-5, f"max|QQ^T - I| = {err:.2e}"
+
+
+@pytest.mark.parametrize("d", DIMS)
+def test_deterministic_from_seed(d):
+    assert np.array_equal(rht_rotation(d, 42), rht_rotation(d, 42))
+    assert not np.array_equal(rht_rotation(d, 42), rht_rotation(d, 43))
+
+
+@pytest.mark.parametrize("d", [128, 384, 768])
+def test_incoherence_matches_haar(d):
+    """The property the codebook depends on: a coordinate spike must come out
+    spread. Compared against an INDEPENDENT reference — the max|coord| of a
+    uniformly random unit vector, drawn directly — not against Haar alone,
+    because two equally-broken rotations would agree with each other.
+    """
+    rng = np.random.default_rng(3)
+    E = np.eye(d, dtype=np.float32)[:64]           # 64 coordinate spikes
+    U = rng.standard_normal((4096, d))
+    U /= np.linalg.norm(U, axis=1, keepdims=True)
+    ideal = float(np.mean(np.max(np.abs(U), axis=1)))
+
+    # The lower edge is ATTAINABLE and inclusive, with an ulp of slack. When
+    # the Hadamard block spans the whole vector (d a power of two, one round)
+    # a spike maps to exactly +-1/sqrt(d) in every coordinate -- the
+    # information-theoretic floor, since the coordinates square to 1. Reaching
+    # it is optimal, not a failure, and float32 rounding lands a hair below the
+    # float64 constant. A strict comparison here fails on a perfect rotation.
+    floor = (1.0 - 1e-6) / math.sqrt(d)
+    for name, R in (("haar", haar_rotation(d, 5)), ("rht", rht_rotation(d, 5))):
+        mu = float(np.mean(np.max(np.abs(E @ R.T), axis=1)))
+        assert floor <= mu < 2.0 * ideal, (
+            f"{name} d={d}: spike incoherence {mu:.6f} outside "
+            f"[{floor:.6f}, {2 * ideal:.4f})"
+        )
+
+
+def test_identity_would_fail_the_incoherence_check():
+    """The check above must be able to reject something. An identity 'rotation'
+    is the worst case and has to land outside the bracket."""
+    d = 384
+    rng = np.random.default_rng(3)
+    U = rng.standard_normal((4096, d))
+    U /= np.linalg.norm(U, axis=1, keepdims=True)
+    ideal = float(np.mean(np.max(np.abs(U), axis=1)))
+    mu_identity = 1.0                               # a spike stays a spike
+    floor = (1.0 - 1e-6) / math.sqrt(d)
+    assert not (floor <= mu_identity < 2.0 * ideal)
+
+
+@pytest.mark.parametrize("d", [128, 768])
+def test_coordinates_are_gaussian_after_rotation(d):
+    """The codebook is fitted to N(0, 1/d); check the rotation delivers it."""
+    rng = np.random.default_rng(11)
+    X = rng.standard_normal((2000, d)).astype(np.float32)
+    X /= np.linalg.norm(X, axis=1, keepdims=True)
+    rot = (X @ rht_rotation(d, 5).T).ravel()
+    assert abs(float(np.mean(rot))) < 5e-3
+    assert abs(float(np.std(rot)) - 1.0 / math.sqrt(d)) / (1.0 / math.sqrt(d)) < 0.05
+
+
+@pytest.mark.parametrize("bits", [2, 4, 8])
+def test_round_trip_fidelity_matches_haar(bits):
+    """End to end: RHT must not cost reconstruction quality."""
+    d, rng = 384, np.random.default_rng(0)
+    X = rng.standard_normal((300, d)).astype(np.float32)
+    cos = {}
+    for rot in ("haar", "rht"):
+        q = Quantizer(d=d, bits=bits, seed=42, rotation=rot)
+        Xh = q.decode(q.encode(X))
+        num = np.sum(X * Xh, axis=1)
+        den = np.linalg.norm(X, axis=1) * np.linalg.norm(Xh, axis=1)
+        cos[rot] = float(np.mean(num / den))
+    assert abs(cos["haar"] - cos["rht"]) < 2e-3, cos
+
+
+def test_rotation_is_part_of_the_encoding():
+    """Codes from one rotation must not be decoded under the other. This is a
+    guard against treating `rotation` as a free-floating perf knob."""
+    d, rng = 128, np.random.default_rng(1)
+    X = rng.standard_normal((64, d)).astype(np.float32)
+    qh = Quantizer(d=d, bits=8, seed=42, rotation="haar")
+    qr = Quantizer(d=d, bits=8, seed=42, rotation="rht")
+    good = qh.decode(qh.encode(X))
+    crossed = qr.decode(qh.encode(X))
+    cos = lambda A: float(np.mean(np.sum(X * A, 1) / (
+        np.linalg.norm(X, axis=1) * np.linalg.norm(A, axis=1))))
+    assert cos(good) > 0.99 and cos(crossed) < 0.5, (cos(good), cos(crossed))
+
+
+def test_save_params_refuses_non_haar(tmp_path):
+    """Mojo regenerates the rotation from the seed and knows only Haar, so
+    emitting params for an RHT Quantizer would silently disagree."""
+    save_params(tmp_path / "ok.pr", Quantizer(d=64, bits=4, seed=1))
+    with pytest.raises(ValueError, match="rotation='haar'"):
+        save_params(tmp_path / "bad.pr",
+                    Quantizer(d=64, bits=4, seed=1, rotation="rht"))
+
+
+def test_odd_dimension_rejected():
+    with pytest.raises(ValueError, match="even dimension"):
+        rht_rotation(255, seed=1)
+
+
+def test_unknown_rotation_rejected():
+    with pytest.raises(ValueError, match="rotation must be one of"):
+        Quantizer(d=64, bits=4, rotation="hadamard")


### PR DESCRIPTION
Two commits. `Quantizer.__init__` was slow in two independent ways; this fixes both. **Default behaviour is unchanged** — the rotation change is opt-in and Haar remains the default.

| d | before | after | |
|---|---|---|---|
| 768 | 30.6 s | **0.22 s** | 139× |
| 1536 | ~45 s | **0.39 s** | ~115× |
| 3072 | ~358 s | **1.79 s** | ~200× |

*(with `rotation="rht"`; with the default Haar, d=3072 is 208 s → still dominated by the QR)*

---

## 1. `eff0ad1` — vectorize the Lloyd-Max codebook (bit-identical)

`lloyd_max_codebook` called scipy's **scalar** `norm.cdf` / `norm.pdf` `2^bits × n_iter × 4 = 307,200` times — ~50 of the 52 profiled seconds.

The per-level loop vectorizes *exactly*: `bounds` is materialised before any centroid moves, so every cell reads the **same** boundaries — a simultaneous (Jacobi) step. One `cdf`/`pdf` over the whole boundary array computes what four scalar calls per level computed.

**Output bitwise identical** (`np.array_equal`, not "close"):

| config | before | after | speedup |
|---|---|---|---|
| d=768, bits=8 | 14.73 s | 0.041 s | **360×** |
| d=1024, bits=8 | 13.70 s | 0.035 s | **393×** |
| d=768, bits=4 | 0.90 s | 0.038 s | 24× |

Cost is `2^bits × n_iter`, so this is **dimension-independent** — same win at every embedding size. No format, seed, or parity implications.

## 2. `3deea74` — opt-in randomized Hadamard rotation

With the codebook fixed, `__init__` is dominated entirely by `haar_rotation`'s Householder QR. Measured across six dimensions it fits **O(d^3.08)**:

| d | model family | Haar build |
|---|---|---|
| 384 | MiniLM / e5-small | 0.21 s |
| 768 | BERT-family, SPECTER2, bge-base | 1.78 s |
| 1024 | bge-large, e5-large | 3.92 s |
| 1536 | OpenAI 3-small / ada-002 | 11.39 s |
| 2048 | — | 29.88 s |
| 3072 | **OpenAI 3-large** | **149.85 s** |

remex is embedding-agnostic and `d` is a free parameter, so this isn't a d=768 story.

`rotation="rht"` uses rounds of *permute → sign flip → block-diagonal FWHT*, block size the largest power of two dividing `d` — so it works at **any even d**; padding up to a power of two would change the codec's dimension. It's **materialized to a dense (d, d) float32** by applying the transform to the identity in one batched pass, so every downstream consumer is untouched: `core`, `gpu.py`, `ivf.py` and the `.pq` path all still see an ordinary orthogonal matrix.

### Why it's a legitimate substitute, not merely a faster one

The codec doesn't need Haar specifically — it needs an orthogonal map that leaves coordinates incoherent, so the Lloyd-Max codebook is quantizing the `N(0, 1/d)` it was fitted to. The RHT is the standard incoherence-processing rotation in the QuIP#/HIGGS lineage.

Tested **directly here** rather than taken on faith from the ablation:
- spike incoherence bracketed against an **independently drawn** reference (max|coord| of a uniform random unit vector), *not* against Haar — two equally-broken rotations agree with each other
- the bracket demonstrably rejects an identity "rotation"
- post-rotation coordinates: mean ≈ 0, std ≈ 1/√d within 5%
- round-trip cosine within 2e-3 of Haar at 2, 4 and 8 bits

Recall parity from [experiments#11](https://github.com/oaustegard/experiments/pull/11) (−0.0001 ± 0.0013 over 3 corpora × 6 bit widths × 5 seeds) is corroboration, not the evidence.

### Safety

`mojo/src/quantizer.mojo` **regenerates** the rotation from the seed (`haar_rotation_numpy(d, seed)`) — it does not read the `R` that `save_params` writes. So **`save_params` now refuses a non-Haar Quantizer** rather than emitting parameters the Mojo binary would silently disagree with. The Haar default keeps #40's byte-parity contract untouched.

A test also pins that **the rotation is part of the encoding**: codes made under one rotation decode to garbage under the other (cos 0.99 vs <0.5), so `rotation` can't be mistaken for a free perf knob.

## Tests

**200 pass** (173 pre-existing + 4 codebook + 23 rotation). The new ones pin properties nothing previously covered:

- reproduces **Max (1960) table 1** at 1–5 bits — an anchor no part of this repo produced; verified to *reject* a 15% level perturbation, so it isn't decoration
- pins **simultaneous-vs-sequential** Lloyd explicitly by computing the Gauss-Seidel answer and asserting it *differs* — the two converge to different codebooks and nothing distinguished them
- orthogonality, seed-determinism, incoherence, Gaussianity, cross-rotation decode failure

One detail worth keeping: the incoherence floor `1/√d` is **attainable** — when the Hadamard block spans the whole vector, a spike maps to exactly ±1/√d — and float32 lands an ulp under the float64 constant. The comparison is inclusive with a tolerance; a strict bound fails on a *perfect* rotation. Same trap as [claude-skills#752](https://github.com/oaustegard/claude-skills/pull/752).