### PR TITLE
Mojo: implement the RHT rotation, byte-identical to Python

### DIFF
--- a/remex/core.py
+++ b/remex/core.py
@@ -470,10 +470,9 @@ class Quantizer:
                 d=768, 5.7 s at d=3072 (26x faster). Measured
                 indistinguishable from Haar on retrieval recall
                 (-0.0001 +/- 0.0013 pooled over 3 corpora x 6 bit widths x
-                5 seeds, oaustegard/experiments#11). The Mojo port cannot
-                reproduce it, so `save_params` refuses a Quantizer built this
-                way rather than emitting parameters that silently disagree.
-                Requires an even d.
+                5 seeds, oaustegard/experiments#11). Bit-reproducible against
+                the Mojo port via `polarquant --rotation rht`. Requires an
+                even d.
 
             Both are seed-deterministic and exactly orthogonal. The rotation
             is part of the encoding: vectors encoded under one CANNOT be

--- a/remex/mojo/README.md
+++ b/remex/mojo/README.md
@@ -17,7 +17,7 @@ remex/mojo/
 │   ├── mathx.mojo           # erf-based normal CDF / PDF
 │   ├── rng.mojo             # xoshiro256++ + Marsaglia polar normal
 │   ├── matrix.mojo          # Owning Float32 / Float64 matrices
-│   ├── rotation.mojo        # Householder QR → Haar orthogonal matrix
+│   ├── rotation.mojo        # Householder QR → Haar, and randomized Hadamard (RHT)
 │   ├── codebook.mojo        # Lloyd-Max iteration on N(0, 1/d) + Matryoshka nested tables
 │   ├── packing.mojo         # 1/2/3/4/8-bit pack and unpack
 │   ├── packed_vectors.mojo  # Bit-packed in-memory storage with on-demand unpack
@@ -33,6 +33,9 @@ remex/mojo/
 ├── tests/
 │   ├── test_rng.mojo
 │   ├── test_rotation.mojo
+│   ├── test_rht.mojo               # RHT byte parity vs Python + orthogonality
+│   ├── test_rht_encode.mojo        # RHT encode parity, --seed and --params routes
+│   ├── build_rht_fixture.py        # Python fixture builder for the two above
 │   ├── test_codebook.mojo
 │   ├── test_packing.mojo
 │   ├── test_packed_vectors.mojo    # PackedVectors round-trip + at_precision parity
@@ -79,6 +82,10 @@ mojo build -I . bench/bench_ivf.mojo       -o bench/bench_ivf
 # Encode an .npy of float32 vectors → .pq
 ./polarquant encode corpus.npy --bits 4 --seed 42 -o corpus.pq
 
+# Same, with the randomized Hadamard rotation (cheaper to build at large d).
+# --rotation is part of the encoding: pass the same value to search/decode.
+./polarquant encode corpus.npy --bits 4 --seed 42 --rotation rht -o corpus.pq
+
 # Search a single (1, d) query against a .pq, top-k
 ./polarquant search corpus.pq query.npy --k 10 --seed 42 --top 10
 
@@ -106,11 +113,12 @@ print(cv.n, cv.d, cv.bits, cv.compression_ratio)
 The encode/search path needs (R, boundaries, centroids). The CLI
 provides those two ways:
 
-| Flag | Source of (R, codebook) | Bit-identical to a Python `Quantizer(seed=S)`? |
+| Flag | Source of (R, codebook) | Bit-identical to the matching Python `Quantizer`? |
 |---|---|---|
-| `--seed S` *(default RNG: numpy)* | Computed in Mojo from S via PCG64 + SeedSequence + Ziggurat + Householder QR + Lloyd-Max | **Yes**, at 1–4 bits. **8-bit:** see caveat below. |
+| `--seed S` *(default RNG: numpy, rotation: haar)* | Computed in Mojo from S via PCG64 + SeedSequence + Ziggurat + Householder QR + Lloyd-Max | **Yes**, at 1–4 bits. **8-bit:** see caveat below. |
+| `--seed S --rotation rht` | Computed in Mojo from S via PCG64 + SeedSequence + permute/sign/FWHT + Lloyd-Max | **Yes**, vs `Quantizer(..., rotation="rht")`, same bit-width caveat. |
 | `--seed S --rng xoshiro` | Computed in Mojo from S via xoshiro256++ + Marsaglia + Householder QR + Lloyd-Max | **No.** Both Haar samples but from different Gaussian streams. Faster init, no Ziggurat tables. |
-| `--params P.bin` | Loaded from a file written by `remex.save_params(quantizer, P)` | **Yes**, at all bit widths. |
+| `--params P.bin` | Loaded from a file written by `remex.save_params(quantizer, P)` | **Yes**, at all bit widths and for either rotation. |
 
 `--seed` (numpy mode, the default) gives a self-contained Mojo workflow
 with end-to-end byte parity vs Python: `polarquant encode X.npy --bits 4
@@ -121,6 +129,15 @@ issue #40 and uses the new `src/rng_numpy.mojo` module.
 `--seed --rng xoshiro` is the legacy fast path. Use it when you don't
 need Python parity — startup is slightly faster (no 25 KB of Ziggurat
 tables to populate).
+
+`--rotation rht` builds the randomized Hadamard transform instead of the
+Haar matrix — `O(d^2 log d)` instead of the QR's `O(d^3)`, off the same
+NumPy PCG64 stream Python uses, so `polarquant encode --seed 42
+--rotation rht` and `Quantizer(d, bits, seed=42, rotation="rht")` agree
+byte for byte. It needs an even `d`, and it only combines with the numpy
+RNG (there is no xoshiro variant of the construction). The rotation is
+part of the encoding: an index encoded with `--rotation rht` must be
+searched and decoded with it too.
 
 `--params` remains the canonical bridge for any case where you want
 guaranteed bit parity regardless of bit width or potential drift.
@@ -146,6 +163,9 @@ cd remex/mojo
 mojo run -I . tests/test_rng.mojo
 mojo run -I . tests/test_rng_numpy.mojo   # NumPy-bit-identical RNG (issue #40)
 mojo run -I . tests/test_rotation.mojo
+python3 tests/build_rht_fixture.py    # fixtures for the two RHT tests
+mojo run -I . tests/test_rht.mojo         # RHT byte parity vs Python
+mojo run -I . tests/test_rht_encode.mojo  # RHT encode parity, both routes
 mojo run -I . tests/test_codebook.mojo
 mojo run -I . tests/test_packing.mojo
 

--- a/remex/mojo/polarquant.mojo
+++ b/remex/mojo/polarquant.mojo
@@ -1,14 +1,19 @@
 """polarquant CLI — Mojo port of the remex compress/search workflow.
 
 Usage:
-    polarquant encode <input.npy> --bits N [--seed S | --params P.bin] -o <out.pq>
+    polarquant encode <input.npy> --bits N [--seed S | --params P.bin]
+                       [--rotation haar|rht] -o <out.pq>
     polarquant search <index.pq> <query.npy> --k K [--seed S | --params P.bin]
-                       [--top <int>]
+                       [--rotation haar|rht] [--top <int>]
 
 `--seed S`   computes (R, codebook) from seed S in Mojo (not bit-identical to
              a Python Quantizer with the same seed; see README).
 `--params P` loads (R, codebook) from a `.params` file written by
              `remex.save_params(quantizer, path)` — bit-identical encoding.
+`--rotation` picks the orthogonal rotation the seed path builds: `haar`
+             (default, Householder QR, O(d^3)) or `rht` (randomized
+             Hadamard, O(d^2 log d)). Must match the Python Quantizer's
+             `rotation=` argument or the codes will not agree.
 
 Outputs `index.pq`, the binary container readable by `remex.load_pq()`.
 """
@@ -22,7 +27,7 @@ from src.params_format import load_params
 from src.pq_format import save_pq, load_pq
 from src.quantizer import Quantizer, encode_batch, adc_search, search_twostage, decode_batch
 from src.packing import pack, packed_nbytes
-from src.rotation import haar_rotation, haar_rotation_numpy
+from src.rotation import haar_rotation, haar_rotation_numpy, rht_rotation
 from src.gpu.device import is_apple_gpu, is_gpu_available
 from src.gpu.encode import gpu_encode_batch
 from src.gpu.adc import gpu_adc_search
@@ -43,16 +48,29 @@ def _arg_idx(args: List[String], flag: String) -> Int:
 
 def _build_quantizer(d: Int, bits: Int, seed: UInt64,
                      params_path: String,
-                     rng_choice: String) raises -> Quantizer:
+                     rng_choice: String,
+                     rotation_choice: String) raises -> Quantizer:
     """Build a Quantizer from either a .params file or a seed.
 
-    Seed-based modes (default `numpy`) match Python `Quantizer(seed=S)` byte-for-byte.
-    `xoshiro` is the legacy fast self-contained Mojo path (no Python parity).
+    Seed-based modes (default `numpy` RNG, `haar` rotation) match Python
+    `Quantizer(seed=S, rotation=...)` byte-for-byte. `xoshiro` is the
+    legacy fast self-contained Mojo path (no Python parity).
     """
     if len(params_path) > 0:
         var R = Matrix(d, d)
         var cb = Codebook(bits)
         load_params(params_path, R, cb)
+        return Quantizer(R^, cb^, d, bits, seed)
+    if rotation_choice == "rht":
+        # The RHT is built from NumPy's PCG64 stream, so there is no
+        # xoshiro variant of it to offer.
+        if rng_choice != "numpy":
+            raise Error(
+                String("--rotation rht requires --rng numpy (the default); got --rng ")
+                + rng_choice
+            )
+        var R = rht_rotation(d, seed)
+        var cb = lloyd_max_codebook(d, bits)
         return Quantizer(R^, cb^, d, bits, seed)
     if rng_choice == "xoshiro":
         var R = haar_rotation(d, seed)
@@ -66,10 +84,14 @@ def _build_quantizer(d: Int, bits: Int, seed: UInt64,
 
 def _print_usage():
     print("usage:")
-    print("  polarquant encode <input.npy> --bits N (--seed S | --params P) [--device auto|cpu|gpu] -o <out.pq>")
-    print("  polarquant search <index.pq> <query.npy> --k K (--seed S | --params P) [--device auto|cpu|gpu] [--top T]")
+    print("  polarquant encode <input.npy> --bits N (--seed S | --params P) [--rotation haar|rht] [--device auto|cpu|gpu] -o <out.pq>")
+    print("  polarquant search <index.pq> <query.npy> --k K (--seed S | --params P) [--rotation haar|rht] [--device auto|cpu|gpu] [--top T]")
     print("                   [--twostage --candidates N --coarse-precision K]")
-    print("  polarquant decode <index.pq> (--seed S | --params P) [--precision P] -o <out.npy>")
+    print("  polarquant decode <index.pq> (--seed S | --params P) [--rotation haar|rht] [--precision P] -o <out.npy>")
+    print("")
+    print("--rotation defaults to 'haar' (Householder QR, O(d^3)). 'rht' is the randomized")
+    print("Hadamard transform, O(d^2 log d) to build and byte-identical to Python's")
+    print("Quantizer(..., rotation='rht'). It must match how the index was encoded.")
     print("")
     print("--device defaults to 'auto', which picks the most efficient backend per stage:")
     print("  encode: always CPU (GPU encode is currently slower on every measured platform;")
@@ -77,6 +99,17 @@ def _print_usage():
     print("  search: GPU if an accelerator is present, else CPU (GPU search is faster on")
     print("          Apple Metal via the corpus cache; non-Apple GPUs are not yet measured).")
     print("Use --device cpu or --device gpu to force a backend (e.g. for benchmarking).")
+
+
+def _parse_rotation(args: List[String]) raises -> String:
+    """Parse --rotation flag. Returns 'haar' (default) or 'rht'."""
+    var idx = _arg_idx(args, String("--rotation"))
+    if idx < 0:
+        return String("haar")
+    var rot = _arg_str(args, idx + 1)
+    if rot != String("haar") and rot != String("rht"):
+        raise Error(String("--rotation must be 'haar' or 'rht', got: ") + rot)
+    return rot
 
 
 def _parse_device(args: List[String]) raises -> String:
@@ -183,17 +216,18 @@ def cmd_encode(args: List[String]) raises:
         rng_choice = _arg_str(args, rng_idx + 1)
         if rng_choice != "numpy" and rng_choice != "xoshiro":
             raise Error("encode: --rng must be 'numpy' (default) or 'xoshiro'")
+    var rotation_choice = _parse_rotation(args)
 
     var device_note = String("")
     if requested_device == String("auto"):
         device_note = String(" [auto]")
-    print("encode:", input_path, "→", out_path, "(bits =", bits, ", device =", device + device_note, ", rng =", rng_choice, ")")
+    print("encode:", input_path, "→", out_path, "(bits =", bits, ", device =", device + device_note, ", rng =", rng_choice, ", rotation =", rotation_choice, ")")
     var X = load_npy_2d_f32(input_path)
     var n = X.rows
     var d = X.cols
     print("  loaded", n, "vectors of dimension", d)
 
-    var q = _build_quantizer(d, bits, seed, params_path, rng_choice)
+    var q = _build_quantizer(d, bits, seed, params_path, rng_choice, rotation_choice)
 
     # Copy X into a fresh buffer (works around an UnsafePointer borrow oddity
     # observed when passing struct fields across function boundaries).
@@ -296,8 +330,9 @@ def cmd_search(args: List[String]) raises:
         rng_choice2 = _arg_str(args, rng_idx2 + 1)
         if rng_choice2 != "numpy" and rng_choice2 != "xoshiro":
             raise Error("search: --rng must be 'numpy' (default) or 'xoshiro'")
+    var rotation_choice2 = _parse_rotation(args)
 
-    var q_quant = _build_quantizer(pq.d, pq.bits, seed, params_path, rng_choice2)
+    var q_quant = _build_quantizer(pq.d, pq.bits, seed, params_path, rng_choice2, rotation_choice2)
 
     # Unpack indices into uint8 (n*d). Copy norms into a fresh buffer too —
     # see test_encode.mojo for the same workaround.
@@ -373,6 +408,7 @@ def cmd_decode(args: List[String]) raises:
         rng_choice = _arg_str(args, rng_idx + 1)
         if rng_choice != "numpy" and rng_choice != "xoshiro":
             raise Error("decode: --rng must be 'numpy' (default) or 'xoshiro'")
+    var rotation_choice = _parse_rotation(args)
 
     var out_idx = _arg_idx(args, String("-o"))
     if out_idx < 0:
@@ -384,7 +420,7 @@ def cmd_decode(args: List[String]) raises:
           "(n =", pq.n, ", d =", pq.d, ", bits =", pq.bits,
           ", precision =", precision if precision > 0 else pq.bits, ")")
 
-    var q_quant = _build_quantizer(pq.d, pq.bits, seed, params_path, rng_choice)
+    var q_quant = _build_quantizer(pq.d, pq.bits, seed, params_path, rng_choice, rotation_choice)
 
     # Build nested centroid tables from the loaded codebook so they match
     # what Python would compute for the same Quantizer (mirrors the

--- a/remex/mojo/src/quantizer.mojo
+++ b/remex/mojo/src/quantizer.mojo
@@ -11,7 +11,7 @@ from std.memory import alloc, UnsafePointer
 from std.sys.info import simd_width_of
 from src.codebook import Codebook, NestedCodebook, lloyd_max_codebook
 from src.matrix import Matrix
-from src.rotation import haar_rotation, haar_rotation_numpy
+from src.rotation import haar_rotation, haar_rotation_numpy, rht_rotation
 from src.packing import pack, packed_nbytes
 
 
@@ -287,6 +287,19 @@ struct Quantizer(Movable):
         self.seed = seed
         self.R = haar_rotation_numpy(d, seed)
         self.cb = lloyd_max_codebook(d, bits)
+
+    @staticmethod
+    def from_rht_seed(d: Int, bits: Int, seed: UInt64) raises -> Quantizer:
+        """Randomized Hadamard rotation instead of Haar.
+
+        Bit-identical to Python `remex.Quantizer(d, bits, seed,
+        rotation="rht")` at float32. Builds in O(d^2 log d) rather than
+        the QR's O(d^3), which is the whole point at mainstream embedding
+        dimensions. Requires an even `d`.
+        """
+        var R = rht_rotation(d, seed)
+        var cb = lloyd_max_codebook(d, bits)
+        return Quantizer(R^, cb^, d, bits, seed)
 
     @staticmethod
     def from_xoshiro_seed(d: Int, bits: Int, seed: UInt64) raises -> Quantizer:

--- a/remex/mojo/src/rng_numpy.mojo
+++ b/remex/mojo/src/rng_numpy.mojo
@@ -152,12 +152,22 @@ struct PCG64(Copyable, Movable):
 
     State / inc are 128-bit. Output is XSL-RR: rotate-right of (low^high)
     by (high >> 58) bits. One step per output uint64.
+
+    `has_uint32` / `uinteger` mirror the same fields in NumPy's
+    `pcg64_state`: a 32-bit request draws one uint64 and buffers its high
+    half for the next request. Consumers that draw 64-bit words
+    (`next_u64`, `next_double`, the Ziggurat) never touch that buffer, so
+    the two streams interleave exactly as they do in NumPy.
     """
     var state: UInt128
     var inc: UInt128
+    var has_uint32: Bool
+    var uinteger: UInt32
 
     fn __init__(out self, seed: UInt64):
         """Initialize from an integer seed via SeedSequence."""
+        self.has_uint32 = False
+        self.uinteger = UInt32(0)
         var pool = seedseq_pool_from_u64(seed)
         var sw = alloc[UInt64](4)
         seedseq_generate_state_u64(pool, 4, sw)
@@ -190,6 +200,60 @@ struct PCG64(Copyable, Movable):
         # Standard NumPy convention: top 53 bits / 2^53.
         var u = self.next_u64()
         return Float64(u >> UInt64(11)) * (Float64(1.0) / Float64(1 << 53))
+
+    fn next_u32(mut self) -> UInt32:
+        """`pcg64_next32`: low half now, high half buffered for next call."""
+        if self.has_uint32:
+            self.has_uint32 = False
+            return self.uinteger
+        var nxt = self.next_u64()
+        self.has_uint32 = True
+        self.uinteger = UInt32((nxt >> UInt64(32)) & UInt64(0xFFFFFFFF))
+        return UInt32(nxt & UInt64(0xFFFFFFFF))
+
+    fn random_interval(mut self, max_: UInt64) -> UInt64:
+        """`random_interval`: uniform on [0, max_] by masked rejection.
+
+        This is what `Generator.shuffle` draws with — NOT the Lemire path
+        `Generator.integers` uses. Getting the two mixed up desynchronizes
+        the stream, so keep them separate.
+        """
+        if max_ == UInt64(0):
+            return UInt64(0)
+        var mask = max_
+        mask |= mask >> UInt64(1)
+        mask |= mask >> UInt64(2)
+        mask |= mask >> UInt64(4)
+        mask |= mask >> UInt64(8)
+        mask |= mask >> UInt64(16)
+        mask |= mask >> UInt64(32)
+        if max_ <= UInt64(0xFFFFFFFF):
+            var mask32 = UInt32(mask & UInt64(0xFFFFFFFF))
+            while True:
+                var v32 = self.next_u32() & mask32
+                if UInt64(v32) <= max_:
+                    return UInt64(v32)
+        while True:
+            var v = self.next_u64() & mask
+            if v <= max_:
+                return v
+
+    fn bounded_lemire_u32(mut self, rng: UInt32) -> UInt32:
+        """`bounded_lemire_uint32`: uniform on [0, rng], Lemire's method.
+
+        This is what `Generator.integers(0, rng + 1)` draws with. `rng`
+        must not be 0xFFFFFFFF (`rng_excl` would wrap to zero) — the only
+        caller here passes 1.
+        """
+        var rng_excl = UInt64(rng) + UInt64(1)
+        var m = UInt64(self.next_u32()) * rng_excl
+        var leftover = m & UInt64(0xFFFFFFFF)
+        if leftover < rng_excl:
+            var threshold = (UInt64(0xFFFFFFFF) - UInt64(rng)) % rng_excl
+            while leftover < threshold:
+                m = UInt64(self.next_u32()) * rng_excl
+                leftover = m & UInt64(0xFFFFFFFF)
+        return UInt32(m >> UInt64(32))
 
 
 # ---------------------------------------------------------------------------

--- a/remex/mojo/src/rotation.mojo
+++ b/remex/mojo/src/rotation.mojo
@@ -1,17 +1,22 @@
-"""Haar-distributed random orthogonal matrix via Householder QR.
+"""Orthogonal rotations: Haar via Householder QR, and randomized Hadamard.
 
-Mirrors `remex.rotation.haar_rotation`:
+`haar_rotation*` mirrors `remex.rotation.haar_rotation`:
   1. Sample A ~ N(0, 1) of shape (d, d)
   2. QR decompose
   3. Sign-correct: Q[:, j] *= sign(R[j, j])
 
 The resulting Q is uniformly distributed on O(d) (Mezzadri 2007).
+
+`rht_rotation` mirrors `remex.rotation.rht_rotation` — a randomized
+Hadamard transform materialized as a dense (d, d) matrix. Not Haar, but
+it delivers the incoherence the Lloyd-Max codebook actually depends on,
+and it costs O(d^2 log d) to build instead of the QR's O(d^3).
 """
 
 from std.math import sqrt
 from std.memory import alloc, UnsafePointer
 from src.rng import Xoshiro256pp
-from src.rng_numpy import NumpyNormalRNG
+from src.rng_numpy import NumpyNormalRNG, PCG64
 from src.matrix import Matrix, MatrixF64
 
 
@@ -130,6 +135,120 @@ def haar_rotation_numpy(d: Int, seed: UInt64) -> Matrix:
                 Q.set(i, j, -Q.get(i, j))
 
     return Q.to_float32()
+
+
+def largest_pow2_divisor(d: Int) -> Int:
+    """Largest power of two dividing `d` — the FWHT block size."""
+    var b = 1
+    while d % (b * 2) == 0:
+        b *= 2
+    return b
+
+
+def rht_rounds(d: Int, B: Int) -> Int:
+    """Rounds of (permute -> sign flip -> FWHT): smallest k with B**k >= d.
+
+    Python spells this `max(2, ceil(log(d) / log(B)))`. The two agree for
+    every even d (checked exhaustively to 20000): `B**k == d` forces
+    `B == d`, which takes the k = 1 branch, so in the other branch the log
+    quotient never lands on an integer and no rounding boundary is in
+    play. The integer form is used here because it cannot drift with libm.
+    """
+    if B == d:
+        return 1
+    var k = 1
+    var p = B
+    while p < d:
+        p *= B
+        k += 1
+    return k
+
+
+def rht_rotation(d: Int, seed: UInt64) raises -> Matrix:
+    """Randomized Hadamard rotation, byte-identical to Python `rht_rotation`.
+
+    Applies `rounds` of (permute -> sign flip -> block-diagonal FWHT) to
+    the identity, with block size the largest power of two dividing `d`.
+    Every draw comes off the same NumPy PCG64 stream Python uses, in the
+    same order: `Generator.permutation` consumes `random_interval`
+    (masked rejection) and `Generator.choice` consumes
+    `bounded_lemire_uint32`. All arithmetic is float32, matching NumPy's
+    float32 `Y`.
+    """
+    var B = largest_pow2_divisor(d)
+    if B < 2:
+        raise Error(
+            String("d=") + String(d) + String(
+                " is odd; the randomized Hadamard construction needs an "
+                "even dimension. Use the Haar rotation."
+            )
+        )
+    var rounds = rht_rounds(d, B)
+    var n_blocks = d // B
+    var rng = PCG64(seed)
+
+    var Y = Matrix(d, d)
+    for i in range(d):
+        Y.set(i, i, Float32(1.0))
+    # float64 reciprocal-sqrt with a single rounding to float32 — matches
+    # NumPy's `np.float32(1.0 / math.sqrt(B))`. Rounding sqrt to float32
+    # first instead would be a real difference in general (it disagrees for
+    # 1349 of the integers in [2, 5000]) but not here, because B is always a
+    # power of two and the two forms agree on every one of those up to 2^30.
+    # No test can tell them apart; keep this spelling anyway, so the line
+    # reads the same as the Python it has to match.
+    var scale = Float32(Float64(1.0) / sqrt(Float64(B)))
+
+    var perm = alloc[Int32](d)
+    var sign = alloc[Float32](d)
+    var tmp = alloc[Float32](d)
+
+    for _round in range(rounds):
+        # rng.permutation(d): arange, then Fisher-Yates over random_interval.
+        for i in range(d):
+            perm[i] = Int32(i)
+        var i = d - 1
+        while i > 0:
+            var j = Int(rng.random_interval(UInt64(i)))
+            var swap = perm[i]
+            perm[i] = perm[j]
+            perm[j] = swap
+            i -= 1
+        # rng.choice([-1.0, 1.0], size=d) is rng.integers(0, 2, size=d) remapped.
+        for k in range(d):
+            if rng.bounded_lemire_u32(UInt32(1)) == UInt32(0):
+                sign[k] = Float32(-1.0)
+            else:
+                sign[k] = Float32(1.0)
+
+        for row in range(d):
+            var base = row * d
+            # Y = Y[:, perm] * sign
+            for j in range(d):
+                tmp[j] = Y.data[base + Int(perm[j])] * sign[j]
+            for j in range(d):
+                Y.data[base + j] = tmp[j]
+            # Unnormalized FWHT over each contiguous run of B.
+            for blk in range(n_blocks):
+                var off = base + blk * B
+                var h = 1
+                while h < B:
+                    var m = 0
+                    while m < B:
+                        for t in range(h):
+                            var a = Y.data[off + m + t]
+                            var b = Y.data[off + m + h + t]
+                            Y.data[off + m + t] = a + b
+                            Y.data[off + m + h + t] = a - b
+                        m += 2 * h
+                    h *= 2
+            for j in range(d):
+                Y.data[base + j] = Y.data[base + j] * scale
+
+    perm.free()
+    sign.free()
+    tmp.free()
+    return Y^
 
 
 def matvec(M: Matrix, x: UnsafePointer[Float32, MutExternalOrigin],

--- a/remex/mojo/tests/build_rht_fixture.py
+++ b/remex/mojo/tests/build_rht_fixture.py
@@ -1,0 +1,53 @@
+"""Fixture builder for tests/test_rht.mojo.
+
+Writes, for each (d, seed) case, the Python `rht_rotation(d, seed)` matrix
+plus an encode-parity bundle, so the Mojo side can assert byte equality
+rather than an approximate match.
+
+    python3 remex/mojo/tests/build_rht_fixture.py [outdir]
+
+Default outdir is /tmp. Run from the repo root with remex importable.
+"""
+
+import sys
+
+import numpy as np
+
+from remex import Quantizer, save_pq, save_params
+from remex.rotation import rht_rotation
+
+# (d, seed), chosen to span the shapes the construction can take:
+#   d=128  B=128, 1 round  — power of two, one block spanning the row
+#   d=384  B=128, 2 rounds — mainstream embedding size, 3 blocks per row
+#   d=768  B=256, 2 rounds — mainstream embedding size, 3 blocks per row
+#   d=36   B=4,   3 rounds — odd round count > 1, small block, 9 per row
+# The d=36 case is not decorative: with an even round count a globally
+# inverted sign draw cancels itself out, so nothing else here can tell a
+# sign-mapping bug from a correct one.
+CASES = [(128, 42), (384, 7), (768, 42), (36, 5)]
+
+# Encode-parity case, kept small so the Mojo test stays quick.
+ENC_N, ENC_D, ENC_BITS, ENC_SEED = 64, 384, 4, 7
+
+
+def main(outdir="/tmp"):
+    for d, seed in CASES:
+        R = rht_rotation(d, seed)
+        np.save(f"{outdir}/_rht_R_{d}_{seed}.npy", R)
+        print(f"wrote {outdir}/_rht_R_{d}_{seed}.npy  shape={R.shape}")
+
+    rng = np.random.default_rng(0)
+    X = rng.standard_normal((ENC_N, ENC_D)).astype(np.float32)
+    np.save(f"{outdir}/_rht_X.npy", X)
+    q = Quantizer(d=ENC_D, bits=ENC_BITS, seed=ENC_SEED, rotation="rht")
+    save_pq(f"{outdir}/_rht_ref.pq", q.encode(X))
+    # Same Quantizer dumped as params, so the Mojo test can check both routes
+    # into it: rebuilt from the seed, and read straight off disk.
+    save_params(f"{outdir}/_rht.params", q)
+    print(f"wrote {outdir}/_rht_X.npy, {outdir}/_rht_ref.pq and "
+          f"{outdir}/_rht.params "
+          f"(n={ENC_N}, d={ENC_D}, bits={ENC_BITS}, seed={ENC_SEED})")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1] if len(sys.argv) > 1 else "/tmp")

--- a/remex/mojo/tests/test_rht.mojo
+++ b/remex/mojo/tests/test_rht.mojo
@@ -1,0 +1,157 @@
+"""Randomized Hadamard rotation: byte parity with Python, plus orthogonality.
+
+Fixtures come from `tests/build_rht_fixture.py`:
+
+    python3 remex/mojo/tests/build_rht_fixture.py
+    mojo run -I . tests/test_rht.mojo
+
+The anchor is NumPy's `remex.rotation.rht_rotation` — an independent
+implementation this code did not produce. Byte equality, not tolerance:
+the whole claim is that the two constructions agree exactly.
+
+Known-bads this has been shown to reject (each applied to
+`src/rotation.mojo` / `src/rng_numpy.mojo`, gate confirmed red):
+permutation drawing Lemire instead of `random_interval`; `next_u32`
+dropping the `has_uint32` buffer; signs drawn before the permutation;
+a fixed round count; the FWHT butterfly halves swapped; the permutation
+applied as its inverse; the sign mapping inverted.
+
+What it cannot catch:
+  - A shared misreading of the construction. The anchor is remex's own
+    Python, so if `rht_rotation` there is wrong about what an RHT is,
+    both sides are wrong together and this stays green. `test_orthogonal`
+    and `test_incoherence` are the independent checks on that, and they
+    are properties, not byte comparisons.
+  - Anything at d values outside {36, 96, 128, 384, 768} — notably d where
+    the FWHT block is 2, and d above 768.
+  - The `polarquant` CLI wiring. This tests the function, not `--rotation`
+    argument parsing.
+"""
+
+from std.math import sqrt
+from std.testing import assert_true
+from std.memory import alloc
+from src.matrix import Matrix
+from src.npy import load_npy_2d_f32
+from src.rotation import (
+    largest_pow2_divisor, rht_rotation, rht_rounds, matvec,
+)
+
+
+def _abs(x: Float32) -> Float32:
+    return -x if x < Float32(0.0) else x
+
+
+def _assert_bit_identical(R: Matrix, path: String, label: String) raises:
+    var want = load_npy_2d_f32(path)
+    assert_true(want.rows == R.rows and want.cols == R.cols)
+    var mismatches = 0
+    var max_diff: Float32 = Float32(0.0)
+    for i in range(R.rows * R.cols):
+        if R.data[i] != want.data[i]:
+            mismatches += 1
+            var diff = _abs(R.data[i] - want.data[i])
+            if diff > max_diff:
+                max_diff = diff
+    print("  ", label, "mismatched elements:", mismatches,
+          " max |diff| =", max_diff)
+    assert_true(mismatches == 0)
+
+
+def test_block_size_and_rounds() raises:
+    assert_true(largest_pow2_divisor(128) == 128)
+    assert_true(largest_pow2_divisor(384) == 128)
+    assert_true(largest_pow2_divisor(768) == 256)
+    assert_true(largest_pow2_divisor(100) == 4)
+    # B == d is a single round; otherwise the smallest k with B**k >= d.
+    assert_true(rht_rounds(128, 128) == 1)
+    assert_true(rht_rounds(384, 128) == 2)
+    assert_true(rht_rounds(768, 256) == 2)
+    assert_true(rht_rounds(36, 4) == 3)
+    assert_true(rht_rounds(100, 4) == 4)
+    print("test_block_size_and_rounds: ok")
+
+
+def test_byte_parity_with_python() raises:
+    """Every element must match Python's rht_rotation exactly, not nearly."""
+    var R128 = rht_rotation(128, UInt64(42))
+    _assert_bit_identical(R128, String("/tmp/_rht_R_128_42.npy"), String("d=128 seed=42"))
+    var R384 = rht_rotation(384, UInt64(7))
+    _assert_bit_identical(R384, String("/tmp/_rht_R_384_7.npy"), String("d=384 seed=7"))
+    var R768 = rht_rotation(768, UInt64(42))
+    _assert_bit_identical(R768, String("/tmp/_rht_R_768_42.npy"), String("d=768 seed=42"))
+    # d=36 is B=4 over 3 rounds. An odd round count is the only shape in
+    # which a globally inverted sign draw survives to the output — at an
+    # even count it cancels, and every other case here is 1 or 2 rounds.
+    var R36 = rht_rotation(36, UInt64(5))
+    _assert_bit_identical(R36, String("/tmp/_rht_R_36_5.npy"), String("d=36 seed=5"))
+    print("test_byte_parity_with_python: ok")
+
+
+def test_orthogonal() raises:
+    var d = 96          # B = 32 < d, so this exercises the multi-round path
+    var R = rht_rotation(d, UInt64(3))
+    var max_err: Float32 = Float32(0.0)
+    for i in range(d):
+        for j in range(d):
+            var s: Float32 = Float32(0.0)
+            for k in range(d):
+                s += R.get(i, k) * R.get(j, k)
+            var target: Float32 = Float32(1.0) if i == j else Float32(0.0)
+            var err = _abs(s - target)
+            if err > max_err:
+                max_err = err
+    print("   orthogonality err (d=96) =", max_err)
+    assert_true(max_err < Float32(1e-5))
+    print("test_orthogonal: ok")
+
+
+def test_incoherence() raises:
+    """A coordinate spike must come out spread — the property the Lloyd-Max
+    codebook depends on. Mirrors tests/test_rotation_rht.py."""
+    var d = 128
+    var R = rht_rotation(d, UInt64(5))
+    var x = alloc[Float32](d)
+    var y = alloc[Float32](d)
+    var floor = Float32(1.0 - 1e-6) / Float32(sqrt(Float64(d)))
+    var worst: Float32 = Float32(0.0)
+    for spike in range(16):
+        for i in range(d):
+            x[i] = Float32(0.0)
+        x[spike] = Float32(1.0)
+        matvec(R, x, y)
+        var peak: Float32 = Float32(0.0)
+        for i in range(d):
+            var a = _abs(y[i])
+            if a > peak:
+                peak = a
+        assert_true(peak >= floor)
+        if peak > worst:
+            worst = peak
+    print("   worst spike peak (d=128) =", worst, " floor =", floor)
+    # d = 128 is a power of two: one round, one block spanning the row, so a
+    # spike maps to exactly +-1/sqrt(d) everywhere — the attainable floor.
+    assert_true(worst < Float32(2.0) * floor)
+    x.free()
+    y.free()
+    print("test_incoherence: ok")
+
+
+def test_odd_d_rejected() raises:
+    var raised = False
+    try:
+        var R = rht_rotation(63, UInt64(1))
+        _ = R.rows
+    except:
+        raised = True
+    assert_true(raised)
+    print("test_odd_d_rejected: ok")
+
+
+def main() raises:
+    test_block_size_and_rounds()
+    test_byte_parity_with_python()
+    test_orthogonal()
+    test_incoherence()
+    test_odd_d_rejected()
+    print("[test_rht] all passed")

--- a/remex/mojo/tests/test_rht_encode.mojo
+++ b/remex/mojo/tests/test_rht_encode.mojo
@@ -1,0 +1,94 @@
+"""Encode parity for the RHT rotation, through both routes into a Quantizer.
+
+`from_rht_seed` loads no `.params` file: the Quantizer is rebuilt in Mojo
+from (d, bits, seed) alone, so a byte-identical `.pq` proves the whole
+seed -> PCG64 -> permutation -> sign -> FWHT -> codebook -> encode chain
+agrees with Python. `load_params` is the other route, reading R off disk,
+and has to land on the same bytes.
+
+    python3 remex/mojo/tests/build_rht_fixture.py
+    mojo run -I . tests/test_rht_encode.mojo
+
+What this cannot catch, measured rather than guessed. It runs one case,
+n=64 d=384 bits=4, and two known-bads that `test_rht` rejects survive it:
+a hardcoded round count (d=384 already takes 2 rounds, so nothing moves)
+and an inverted sign mapping (at an even round count the inversion
+cancels and R is unchanged). Neither is a defect this file can see. The
+rotation gate is `test_rht`; do not treat a green run here as covering R.
+Also untested here: bit widths other than 4 — at 8 bits the codebook's
+erf drift makes ~0.1-0.2% of indices differ, as it does for Haar (see
+README), so this would go red for a reason that is not the rotation.
+"""
+
+from std.testing import assert_equal, assert_true
+from std.memory import alloc, UnsafePointer
+from src.codebook import Codebook
+from src.matrix import Matrix
+from src.npy import load_npy_2d_f32
+from src.params_format import load_params
+from src.pq_format import load_pq, PqVectors
+from src.quantizer import Quantizer, encode_batch
+from src.packing import pack
+
+
+def _check_encode(q: Quantizer, X_buf: UnsafePointer[Float32, MutExternalOrigin],
+                  n: Int, d: Int, bits: Int, expected: PqVectors,
+                  label: String) raises:
+    var indices = alloc[UInt8](n * d)
+    var norms = alloc[Float32](n)
+    encode_batch(q, X_buf, n, indices, norms)
+
+    var packed = alloc[UInt8](expected.packed_bytes)
+    pack(indices, n * d, bits, packed)
+
+    var max_norm_diff: Float32 = Float32(0.0)
+    for i in range(n):
+        var diff = norms[i] - expected.norms[i]
+        if diff < Float32(0.0):
+            diff = -diff
+        if diff > max_norm_diff:
+            max_norm_diff = diff
+
+    var n_diff: Int = 0
+    for i in range(expected.packed_bytes):
+        if packed[i] != expected.packed_indices[i]:
+            n_diff += 1
+
+    print("  ", label, "— max norm diff:", max_norm_diff,
+          " packed-byte differences:", n_diff, "of", expected.packed_bytes)
+    assert_true(max_norm_diff < Float32(1e-5))
+    assert_equal(n_diff, 0)
+
+    indices.free()
+    norms.free()
+    packed.free()
+
+
+def main() raises:
+    var X = load_npy_2d_f32(String("/tmp/_rht_X.npy"))
+    var expected = load_pq(String("/tmp/_rht_ref.pq"))
+    var d = X.cols
+    var n = X.rows
+    var bits = expected.bits
+    var seed = UInt64(7)        # must match build_rht_fixture.ENC_SEED
+
+    # Copy X into a fresh buffer to dodge borrow weirdness on Npy2D.data
+    # crossing a function boundary.
+    var X_buf = alloc[Float32](n * d)
+    for i in range(n):
+        for j in range(d):
+            X_buf[i * d + j] = X.get(i, j)
+
+    var q_seed = Quantizer.from_rht_seed(d, bits, seed)
+    _check_encode(q_seed, X_buf, n, d, bits, expected,
+                  String("--seed --rotation rht"))
+
+    var R = Matrix(d, d)
+    var cb = Codebook(bits)
+    load_params(String("/tmp/_rht.params"), R, cb)
+    var q_params = Quantizer(R^, cb^, d, bits, seed)
+    _check_encode(q_params, X_buf, n, d, bits, expected, String("--params"))
+
+    X_buf.free()
+    print("[test_rht_encode] parity ok — both --seed --rotation rht and "
+          "--params match Python")

--- a/remex/mojo/tests/test_rng_numpy.mojo
+++ b/remex/mojo/tests/test_rng_numpy.mojo
@@ -171,7 +171,7 @@ def _read_f64_bin(path: String, n: Int) raises -> UnsafePointer[Float64, MutExte
 def test_pcg64_first_1000() raises:
     """First 1000 raw uint64 outputs vs NumPy fixture."""
     var expected = _read_u64_bin(
-        "/home/user/claude-workspace/.spokes/remex/remex/mojo/tests/fixtures/raw_u64_seed42.bin",
+        "tests/fixtures/raw_u64_seed42.bin",
         1000,
     )
     var rng = PCG64(UInt64(42))
@@ -193,7 +193,7 @@ def test_pcg64_first_1000() raises:
 def test_standard_normal_first_1000() raises:
     """First 1000 standard_normal outputs vs NumPy fixture."""
     var expected_arr = _read_f64_bin(
-        "/home/user/claude-workspace/.spokes/remex/remex/mojo/tests/fixtures/normal_f64_seed42.bin",
+        "tests/fixtures/normal_f64_seed42.bin",
         1000,
     )
     var rng = NumpyNormalRNG(UInt64(42))

--- a/remex/pq_format.py
+++ b/remex/pq_format.py
@@ -38,26 +38,32 @@ PARAMS_VERSION = 1
 PARAMS_MAGIC = b"PR\x00\x01"
 
 
+# Rotations the Mojo port can rebuild from `(d, seed)` alone, mapped to the
+# `polarquant` flag that selects each one. `--params` reads R straight out of
+# the file and is rotation-agnostic, but a caller dumping params is usually
+# also exercising the seed path, and a rotation Mojo has never heard of would
+# fail there without saying why. Keep in step with
+# `remex/mojo/src/rotation.mojo`.
+MOJO_ROTATIONS = {"haar": "--rotation haar", "rht": "--rotation rht"}
+
+
 def save_params(path: str | Path, quantizer: "Quantizer") -> None:
     """Dump (R, boundaries, centroids) so a Mojo binary can mirror this Quantizer.
 
     Used to verify bit-identical encode output between Python and Mojo.
+
+    The Mojo CLI consumes this two ways. ``--params P`` loads R from the file
+    and works for any rotation. ``--seed S --rotation K`` rebuilds R in Mojo
+    from the seed instead; that path needs a construction Mojo actually
+    implements, which is what the check below is for.
     """
-    # The Mojo side REGENERATES the rotation from the seed
-    # (mojo/src/quantizer.mojo builds haar_rotation_numpy(d, seed)); it does
-    # not read the R written below. So these parameters only mirror a
-    # Quantizer whose rotation Mojo can reproduce, and the whole point of this
-    # file is verifying bit-identical encode output. Emitting it for any other
-    # rotation would hand the caller parameters that silently disagree.
     rotation = getattr(quantizer, "rotation", "haar")
-    if rotation != "haar":
+    if rotation not in MOJO_ROTATIONS:
         raise ValueError(
-            f"save_params only supports rotation='haar', got {rotation!r}. "
-            f"The Mojo port regenerates the rotation from the seed and knows "
-            f"only the Haar construction, so it would encode against a "
-            f"different rotation than this Quantizer and the codes would not "
-            f"match. Rebuild with rotation='haar' to produce Mojo-mirrorable "
-            f"parameters."
+            f"save_params supports rotation in {sorted(MOJO_ROTATIONS)}, got "
+            f"{rotation!r}. The Mojo port has no construction for it, so "
+            f"`polarquant --seed` would encode against a different rotation "
+            f"than this Quantizer and the codes would not match."
         )
 
     d = int(quantizer.d)

--- a/remex/rotation.py
+++ b/remex/rotation.py
@@ -133,11 +133,11 @@ def rht_rotation(d: int, seed: int = 42) -> np.ndarray:
     option here.  Materialized by applying the transform to the identity, one
     batched pass.
 
-    NOTE: the Mojo port regenerates the rotation from the seed
-    (``mojo/src/quantizer.mojo``), and only knows the Haar construction.  A
-    Quantizer built with this rotation therefore cannot be mirrored by the
-    Mojo binary; ``pq_format.save_params`` refuses it rather than writing
-    parameters that would silently disagree.
+    The Mojo port implements the same construction, off the same NumPy PCG64
+    stream (``mojo/src/rotation.mojo::rht_rotation``), so ``polarquant
+    --seed S --rotation rht`` rebuilds this matrix byte-for-byte and encodes
+    identically.  ``--params`` works too, and reads R straight out of the
+    file.
 
     Args:
         d: Matrix dimension.

--- a/tests/test_rotation_rht.py
+++ b/tests/test_rotation_rht.py
@@ -114,13 +114,28 @@ def test_rotation_is_part_of_the_encoding():
     assert cos(good) > 0.99 and cos(crossed) < 0.5, (cos(good), cos(crossed))
 
 
-def test_save_params_refuses_non_haar(tmp_path):
-    """Mojo regenerates the rotation from the seed and knows only Haar, so
-    emitting params for an RHT Quantizer would silently disagree."""
-    save_params(tmp_path / "ok.pr", Quantizer(d=64, bits=4, seed=1))
-    with pytest.raises(ValueError, match="rotation='haar'"):
-        save_params(tmp_path / "bad.pr",
-                    Quantizer(d=64, bits=4, seed=1, rotation="rht"))
+@pytest.mark.parametrize("rotation", ["haar", "rht"])
+def test_save_params_accepts_every_mojo_rotation(tmp_path, rotation):
+    """Mojo rebuilds both constructions from the seed, so params dump for
+    both. The R written is the Quantizer's own, whichever rotation built it."""
+    q = Quantizer(d=64, bits=4, seed=1, rotation=rotation)
+    path = tmp_path / f"{rotation}.pr"
+    save_params(path, q)
+
+    raw = path.read_bytes()
+    d, n_levels = 64, 1 << 4
+    assert len(raw) == 16 + d * d * 4 + (n_levels - 1) * 4 + n_levels * 4
+    R = np.frombuffer(raw, np.float32, count=d * d, offset=16).reshape(d, d)
+    assert np.array_equal(R, q.R)
+
+
+def test_save_params_refuses_a_rotation_mojo_lacks(tmp_path):
+    """The guard still has to bite for anything the Mojo port has no
+    construction for — it just no longer bites on 'rht'."""
+    q = Quantizer(d=64, bits=4, seed=1)
+    q.rotation = "hadamard-but-fancier"
+    with pytest.raises(ValueError, match="save_params supports rotation in"):
+        save_params(tmp_path / "bad.pr", q)
 
 
 def test_odd_dimension_rejected():


### PR DESCRIPTION
Makes the Mojo port compatible with `rotation="rht"`. Previously the Mojo side knew only the Haar construction, so an RHT `Quantizer` had no counterpart and `save_params` refused to emit parameters for one.

## What changed

**`src/rotation.mojo` — `rht_rotation(d, seed)`**, mirroring `remex.rotation.rht_rotation`: the same rounds of (permute → sign flip → block-diagonal FWHT) applied to the identity, all float32, off the same NumPy PCG64 stream.

Two RNG primitives were needed, and they are **not** interchangeable — this is the subtle part:

| NumPy call | draws through |
|---|---|
| `Generator.shuffle` (behind `permutation`) | `random_interval` — masked rejection |
| `Generator.choice` (behind the sign draw) | `bounded_lemire_uint32` — Lemire |

Using one where the other belongs desynchronizes the stream and silently yields a different, still-orthogonal matrix — no error, just codes that don't match. `PCG64` also gains NumPy's `has_uint32` / `uinteger` buffering, since a 32-bit request consumes one uint64 and keeps its high half for the next. The 64-bit consumers (`next_double`, the Ziggurat) never touch that buffer, so the existing Haar path is bit-for-bit unaffected — `test_rng_numpy` still matches its 1000-output fixtures exactly.

The round count is computed as *the smallest k with `B**k >= d`* rather than Python's `ceil(log(d)/log(B))`. The two agree for every even d up to 20000 — `B**k == d` forces `B == d`, which takes the `k = 1` branch, so the log quotient never lands on an integer elsewhere — and the integer form cannot drift with libm.

**`remex/pq_format.py`** — `save_params` now accepts any rotation the Mojo port can rebuild from a seed, and keeps the guard for one it cannot. The old refusal also rested on a claim that wasn't true: `--params` loads R from the file and never regenerated it, so that route already worked for RHT. Both routes are now asserted rather than assumed.

**Wiring** — `polarquant` grows `--rotation haar|rht` on encode/search/decode, plus `Quantizer.from_rht_seed`. The rotation is part of the encoding, so the flag must match across encode and search.

## Verification

`tests/test_rht.mojo` asserts **byte equality** (not tolerance) against Python-generated fixtures:

| d | B | rounds | shape covered |
|---|---|---|---|
| 128 | 128 | 1 | power of two, one block per row |
| 384 | 128 | 2 | mainstream embedding size |
| 768 | 256 | 2 | mainstream embedding size |
| 36 | 4 | 3 | odd round count, 9 small blocks per row |

`tests/test_rht_encode.mojo` checks encode parity through both `--seed --rotation rht` and `--params`. Both land on 0 differing bytes of 12288, norms exact.

Each gate was validated against deliberate known-bads rather than assumed to work — Lemire-instead-of-`random_interval`, dropping the u32 buffer, reordering the sign and permutation draws, a fixed round count, swapped FWHT butterfly halves, an inverted permutation, and an inverted sign mapping all drive it red.

Two results from that pass are worth flagging:

- **The d=36 case is load-bearing.** At an even round count a globally inverted sign draw cancels itself out, so with only the 1- and 2-round cases nothing distinguished a sign-mapping bug from correct code.
- **`test_rht_encode` alone cannot see two of those known-bads** (fixed round count, inverted signs) because d=384 already takes 2 rounds. `test_rht` is the rotation gate; that limit is written into the test docstring rather than left implicit.

Coverage limits are stated in both test docstrings, including the one this design cannot check: the anchor is remex's own Python, so a shared misreading of what an RHT *is* would leave both sides wrong together. `test_orthogonal` and `test_incoherence` are the property-based checks against that.

**Suites:** 191 passed / 11 skipped (pyarrow absent) for `pytest`; 13/13 Mojo tests.

## Notes

- `mojo build polarquant.mojo` does not complete in this environment — `src/gpu/` fails with *"Unknown GPU architecture detected"* on a host without a supported accelerator. This reproduces on a pristine checkout of `main`, so it is pre-existing and not from this change; it does mean the `--rotation` flag parsing itself is untested end-to-end, while the code paths behind it are covered by the two tests above.
- Also fixes two absolute paths in `test_rng_numpy.mojo` that pointed into another machine's checkout, which made that test — the regression guard for the very `PCG64` struct extended here — unrunnable anywhere. It passes now.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JhSTc7zpmhjSrC3r9GVEYz)_