### PR TITLE
Rotation provenance, plus the CI that makes its gate mean anything

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,116 @@
+name: tests
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Deliberately installs only `.[dev]` — never `.[bench]`, which pulls
+  # sentence-transformers and therefore torch: hundreds of megabytes that say
+  # nothing about whether the library works.
+  pytest:
+    name: pytest (py${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # 3.9 is the floor pyproject's requires-python claims; 3.13 is the
+        # ceiling. Both edges are load-bearing — the middle rarely breaks alone.
+        python-version: ["3.9", "3.11", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+
+      - name: pytest
+        run: python -m pytest tests/ -q
+
+  # The Arrow container is an optional extra, so the matrix above skips every
+  # test that touches it. Skipped tests are not passing tests: this job exists
+  # so the `b"rotation"` metadata path is actually executed somewhere. Split
+  # out rather than folded into the matrix because pyarrow's own support floor
+  # moves independently of ours, and a resolver failure there should not take
+  # down the 3.9 run of everything else.
+  pytest-arrow:
+    name: pytest (arrow extra)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev,arrow]"
+
+      - name: Confirm the Arrow tests actually ran
+        # Guards the point of this job. Two ways it could go green having
+        # tested nothing: pyarrow fails to install and every test skips, or
+        # the -k filter stops matching and selects zero tests. Both are
+        # checked, because a job that cannot fail is worse than no job.
+        run: |
+          set -o pipefail
+          python -c "import pyarrow; print('pyarrow', pyarrow.__version__)"
+          python -m pytest tests/ -q -k arrow --no-header -rA > arrow.txt 2>&1 || {
+            cat arrow.txt; exit 1; }
+          cat arrow.txt
+          if grep -qE '^SKIPPED' arrow.txt; then
+            echo "::error::Arrow tests skipped in the job that exists to run them"
+            exit 1
+          fi
+          if ! grep -qE '[0-9]+ passed' arrow.txt; then
+            echo "::error::the -k arrow filter selected no tests; it has gone stale"
+            exit 1
+          fi
+
+      - name: pytest
+        run: python -m pytest tests/ -q
+
+  gates:
+    name: gates
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+
+      - name: rotation identity gate (must pass)
+        run: python bench/gates/rotation_identity_gate.py
+
+      # A gate seen only green has not been shown to work. The gate ships a
+      # flag that reintroduces the defect it exists to catch; CI asserts it
+      # goes RED under that flag. If this step ever starts passing, the gate
+      # has gone toothless and the green run above means nothing.
+      - name: rotation identity gate (must go RED on the pre-fix reader)
+        run: |
+          if python bench/gates/rotation_identity_gate.py --simulate-prefix; then
+            echo "::error::gate PASSED with the pre-fix reader patched in; it can no longer fail"
+            exit 1
+          fi
+          echo "gate went red as required"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 **remex** (formerly polar-embed) is a Python library for retrieval-validated embedding compression. It implements random orthogonal rotation + Lloyd-Max scalar quantization (from TurboQuant, Zandieh et al. ICLR 2026) to compress embedding vectors 2-16x with measured recall, optimized for nearest-neighbor retrieval in RAG systems.
 
-Key differentiator: **data-oblivious** — no training required. The quantizer is fully determined by `(dimension, bits, seed)`.
+Key differentiator: **data-oblivious** — no training required. The quantizer is fully determined by `(dimension, bits, seed, rotation)`.
 
 ## Architecture
 
@@ -98,7 +98,11 @@ python bench/specter2_eval.py --cached  # then run the bench against the cache
 ## Code conventions
 
 - **NumPy-only core**: No PyTorch/CuPy dependency in `remex/core.py`. GPU support is opt-in via `remex/gpu.py`.
-- **No training**: Fully data-oblivious. The quantizer is determined by `(d, bits, seed)` alone.
+- **No training**: Fully data-oblivious. The quantizer is determined by `(d, bits, seed, rotation)` alone.
+- **The rotation is part of the encoding**: every persisted container (`.pq` byte 17, `.npz` `rotation` key,
+  Arrow `b"rotation"` metadata) records which rotation wrote it, and an absent record means `"haar"` — the
+  frozen historical value, never the live default. That rule is what makes the default safe to change; see
+  `bench/gates/rotation_identity_gate.py`.
 - **Honest compression**: `nbytes` property uses bit-packed sizes, not uint8. Benchmark tables report packed compression ratios.
 - **Deterministic**: Same `(d, bits, seed)` must produce identical results across runs.
 - **Test thresholds**: Recall tests use conservative bounds (e.g. 2-bit R@10 >= 0.3, not exact values) because recall depends on random data.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ from remex import CompressedVectors
 loaded = CompressedVectors.load("index.npz")
 ```
 
-The quantizer is fully determined by `(d, bits, seed)` — no training, no fitting, no index to ship.
+The quantizer is fully determined by `(d, bits, seed, rotation)` — no training, no fitting, no index to ship. `rotation` defaults to `"haar"` and is part of the encoding exactly as `seed` is; every container records it, and decoding against the wrong one raises rather than returning wrong-but-plausible vectors.
 
 ## How it works
 

--- a/bench/gates/gate.py
+++ b/bench/gates/gate.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""A tiny harness for gates that can actually fail.
+
+The whole point of a gate is to go red when it should.  The characteristic
+failure is not a wrong check — it is a check that *cannot* fail, which reports
+PASS forever and reads exactly like a working one.
+
+So this harness refuses to let a gate pass unless it registered at least one
+`known_bad` case that its own criteria rejected.  A gate with no known-bad is
+reported as INCONCLUSIVE and exits non-zero, because "nothing looked wrong" is
+not evidence when nothing could have looked wrong.
+
+    from gate import Gate
+
+    g = Gate("codebook calibration")
+
+    g.anchor("scalar quantizer, 2 bits", measured=0.117482, published=0.1175,
+             rel_tol=2e-3, source="Max (1960) table 1")
+
+    g.bracket("trained grid sits between scalar and the Shannon bound",
+              value=0.0887, lo=0.0625, hi=0.1175,
+              why="must beat scalar; cannot beat the rate-distortion bound")
+
+    g.known_bad("an under-trained grid is rejected",
+                rejected=under_trained_mse > threshold,
+                detail=f"{under_trained_mse:.5f} > {threshold:.5f}")
+
+    g.coverage("Max's table stops at 5 bits — rates above that are unanchored")
+
+    raise SystemExit(g.report())
+
+Stdlib only.  Import it, or copy the class into your gate script; it is small
+on purpose.
+"""
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass, field
+
+
+@dataclass
+class _Check:
+    ok: bool
+    label: str
+    detail: str
+    kind: str  # "anchor" | "bracket" | "check" | "known-bad"
+    covers: tuple[str, ...] = ()  # known-bad only: checks it exercises
+
+
+@dataclass
+class Gate:
+    """Collects checks, then reports and returns a process exit code."""
+
+    name: str = "gate"
+    checks: list[_Check] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+    limits: list[str] = field(default_factory=list)
+    stream = sys.stdout
+
+    # -- primitives --------------------------------------------------------
+
+    def check(self, ok: bool, label: str, detail: str = "", *,
+              kind: str = "check", covers: tuple[str, ...] = ()) -> bool:
+        """Record a plain boolean check."""
+        self.checks.append(_Check(bool(ok), label, detail, kind, covers))
+        return bool(ok)
+
+    def anchor(self, label: str, *, measured: float, published: float,
+               rel_tol: float, source: str) -> bool:
+        """Compare a measurement against a value from outside your own code.
+
+        `source` is required and is printed: an anchor whose provenance is not
+        written down decays into a golden value, and a golden value only ever
+        tells you the code still does what it did.
+        """
+        rel = abs(measured - published) / abs(published) if published else float("inf")
+        return self.check(
+            rel < rel_tol, f"{label} [anchor: {source}]",
+            f"measured={measured:.6g} published={published:.6g} "
+            f"rel={rel:.2e} tol={rel_tol:.0e}", kind="anchor")
+
+    def bracket(self, label: str, *, value: float, lo: float, hi: float,
+                why: str = "", lo_inclusive: bool = False,
+                hi_inclusive: bool = False) -> bool:
+        """Assert lo < value < hi, or <= at either edge.
+
+        Two-sided by construction.  A one-sided check passes for a value that
+        collapsed as readily as for one that is right, which is how an
+        implementation that silently does nothing gets certified.
+
+        **Use the inclusive flag when an edge is ATTAINABLE.**  A theoretical
+        bound is frequently reachable, and reaching it is optimal, not a
+        failure.  A strict bound then reports red on the best possible result:
+        a randomized-Hadamard rotation maps a coordinate spike to exactly
+        ±1/sqrt(d), the information-theoretic floor for max|coord|, so
+        `lo=1/sqrt(d)` rejected a perfect rotation and blocked a run.  Ask of
+        each edge: can the subject legitimately sit exactly here?  If yes, make
+        it inclusive.
+        """
+        lo_ok = (lo <= value) if lo_inclusive else (lo < value)
+        hi_ok = (value <= hi) if hi_inclusive else (value < hi)
+        lo_op = "<=" if lo_inclusive else "<"
+        hi_op = "<=" if hi_inclusive else "<"
+        suffix = f" — {why}" if why else ""
+        return self.check(lo_ok and hi_ok, label,
+                          f"{lo:.6g} {lo_op} {value:.6g} {hi_op} {hi:.6g}{suffix}",
+                          kind="bracket")
+
+    def known_bad(self, label: str, *, rejected: bool, detail: str = "",
+                  covers: tuple[str, ...] = ()) -> bool:
+        """Register a case the gate MUST reject, and whether it did.
+
+        Build the bad case out of the same machinery the real subject uses and
+        break it the way it would plausibly break — an under-trained model, a
+        dropped term, an off-by-one — not a nonsense input that anything would
+        catch.  A known-bad that is too obviously bad certifies nothing.
+
+        **Validate it at the configuration it will actually run in.**  A
+        known-bad tuned on a small/fast setting can stop being bad at full
+        size: an "untrained" grid built from one Lloyd iteration was genuinely
+        zero-gain at m=2/K=16 and earned a real +0.10 dB at m=8/K=65536, where
+        a single iteration relocates ~63,000 empty cells toward the mode.  It
+        passed the fast gate and certified nothing about the real one.
+
+        `covers` names the check labels (or substrings of them) this case
+        exercises.  Supplying it turns "we have a known-bad" into "we know
+        WHICH checks have been shown to fire", which is a different and much
+        stronger claim — see `report()`.
+        """
+        return self.check(rejected, label, detail, kind="known-bad",
+                          covers=tuple(covers))
+
+    def note(self, text: str) -> None:
+        """Record a number worth seeing that is not itself pass/fail."""
+        self.notes.append(text)
+
+    def coverage(self, text: str) -> None:
+        """Record something this gate CANNOT catch.
+
+        Coverage holes are invisible from inside a green run, so they have to
+        be asserted by the author.  Anchors that stop short of the range you
+        operate in belong here.
+        """
+        self.limits.append(text)
+
+    # -- reporting ---------------------------------------------------------
+
+    @property
+    def failures(self) -> list[_Check]:
+        return [c for c in self.checks if not c.ok]
+
+    @property
+    def known_bads(self) -> list[_Check]:
+        return [c for c in self.checks if c.kind == "known-bad"]
+
+    def report(self) -> int:
+        """Print the result; return 0 to pass, 1 to fail, 2 if inconclusive."""
+        w = self.stream
+        line = "=" * 74
+        print(f"{line}\nGATE — {self.name}\n{line}", file=w)
+        for c in self.checks:
+            tag = "PASS" if c.ok else "FAIL"
+            print(f"  [{tag}] ({c.kind}) {c.label}"
+                  + (f": {c.detail}" if c.detail else ""), file=w)
+        for n in self.notes:
+            print(f"  [note] {n}", file=w)
+        for lim in self.limits:
+            print(f"  [cannot catch] {lim}", file=w)
+
+        if self.failures:
+            print(f"\nFAILED — {len(self.failures)} check(s):", file=w)
+            for c in self.failures:
+                print(f"  * {c.label}: {c.detail}", file=w)
+            return 1
+        if not self.known_bads:
+            print("\nINCONCLUSIVE — every check passed and no known-bad case was "
+                  "registered.\nA gate that was never shown to reject anything has "
+                  "not been shown to work.\nAdd g.known_bad(...) with a case its "
+                  "own criteria must catch.", file=w)
+            return 2
+        if not self.limits:
+            print("\nINCONCLUSIVE — no coverage limit recorded. State at least one "
+                  "thing\nthis gate cannot catch (g.coverage(...)); if you truly "
+                  "believe there is\nnothing, say that explicitly.", file=w)
+            return 2
+        # Known-bad REACH.  "We have a known-bad" and "we know which checks
+        # have been shown to fire" are different claims, and only the second
+        # is worth much.  An audit of a real gate found its single known-bad
+        # exercised 1 of 8 checks -- and the check the whole result rested on
+        # ACCEPTED the same bad case.  That gate reported PASS.
+        substantive = [c for c in self.checks if c.kind != "known-bad"]
+        if any(kb.covers for kb in self.known_bads):
+            claimed = [t for kb in self.known_bads for t in kb.covers]
+            reached = {c.label for c in substantive
+                       if any(t in c.label for t in claimed)}
+            unreached = [c.label for c in substantive if c.label not in reached]
+            print(f"\n  known-bad reach: {len(reached)}/{len(substantive)} "
+                  f"checks exercised by a known-bad", file=w)
+            for lab in unreached[:12]:
+                print(f"    [unreached] {lab}", file=w)
+            if len(unreached) > 12:
+                print(f"    ... and {len(unreached) - 12} more", file=w)
+        else:
+            print(f"\n  known-bad reach: UNDECLARED — {len(self.known_bads)} "
+                  f"known-bad(s), none naming the checks they exercise.\n"
+                  f"  Pass covers=(...) to known_bad() to turn 'we have one' "
+                  f"into 'we know which checks fire'.", file=w)
+
+        print(f"\nPASSED — {len(self.checks)} checks, "
+              f"{len(self.known_bads)} known-bad rejected, "
+              f"{len(self.limits)} coverage limit(s) stated.", file=w)
+        return 0
+
+
+__all__ = ["Gate"]

--- a/bench/gates/rotation_identity_gate.py
+++ b/bench/gates/rotation_identity_gate.py
@@ -55,6 +55,9 @@ _CANDIDATES = [
     os.environ.get("GATING_SKILL_DIR"),
     "/tmp/gating-skill/scripts",
     "/mnt/skills/user/gating/scripts",
+    # Vendored fallback (bench/gates/gate.py) so the gate runs in CI, where
+    # no skill directory is mounted. A real skill checkout still wins.
+    str(Path(__file__).resolve().parent),
 ]
 for _c in _CANDIDATES:
     if _c and (Path(_c) / "gate.py").is_file():
@@ -335,7 +338,9 @@ def main() -> int:
     g.coverage(
         "Does NOT cover the Arrow container. save_arrow/load_arrow carry a "
         "b'rotation' metadata key with the same absent-means-haar rule, but "
-        "pyarrow is an optional dependency and is skipped when absent."
+        "pyarrow is an optional dependency. The pytest-arrow CI job installs "
+        "it and fails if those tests skip, so the path is covered there — not "
+        "here, and not in a local run without the extra."
     )
     g.coverage(
         "Does NOT protect a pre-field READER from a future rht file. An old "

--- a/bench/gates/rotation_identity_gate.py
+++ b/bench/gates/rotation_identity_gate.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""Gate: a stored index decodes the same way after the library default flips.
+
+The hazard this guards
+----------------------
+``Quantizer`` can rotate with either the Haar QR construction or a randomized
+Hadamard transform. The two give *different codes* from the same
+``(d, bits, seed)``, and until the rotation was recorded nothing on disk said
+which one wrote an index. The reader therefore fell back on the library's
+current default — and the day somebody flips that default, every already-stored
+index starts decoding queries in a rotation frame its codes were never written
+in. Nothing raises. ``search()`` still returns k neighbours; they are the wrong
+k. ``tests/test_rotation_rht.py::test_rotation_is_part_of_the_encoding``
+measures the damage: mean cosine falls from >0.99 to <0.5.
+
+The hazard runs in the direction of the *default*, not of the writer. This gate
+is what makes the default safe to change: it asserts that changing it is a
+no-op for decode of an already-written index.
+
+What is checked
+---------------
+An index is written with the real library, then its rotation byte is zeroed to
+manufacture a pre-field (legacy) file — the exact artifact whose
+reinterpretation is the hazard. The library default is then flipped to ``rht``
+and the legacy index reopened. Indices, norms and decoded vectors must be
+**byte-identical** across that flip, and identical to a Haar reference computed
+straight from ``remex.rotation.haar_rotation`` + ``remex.codebook`` without
+going through ``core.py`` or ``pq_format.py`` at all.
+
+Running it red
+--------------
+``--simulate-prefix`` patches the readers to resolve the rotation from the live
+module default instead of from the file, which is precisely the pre-fix reader.
+The gate must FAIL under that flag. A gate that has only ever been seen green
+has not been shown to work.
+
+    python3 bench/gates/rotation_identity_gate.py                    # expect 0
+    python3 bench/gates/rotation_identity_gate.py --simulate-prefix  # expect 1
+
+The harness lives in the ``gating`` skill; point ``GATING_SKILL_DIR`` at its
+``scripts/`` directory if it is not staged at ``/tmp/gating-skill/scripts``.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import numpy as np
+
+_CANDIDATES = [
+    os.environ.get("GATING_SKILL_DIR"),
+    "/tmp/gating-skill/scripts",
+    "/mnt/skills/user/gating/scripts",
+]
+for _c in _CANDIDATES:
+    if _c and (Path(_c) / "gate.py").is_file():
+        sys.path.insert(0, _c)
+        break
+else:  # pragma: no cover - environment problem, not a gate failure
+    sys.exit(
+        "gate.py harness not found. Set GATING_SKILL_DIR to the gating "
+        f"skill's scripts/ directory. Tried: {_CANDIDATES}"
+    )
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from gate import Gate  # noqa: E402
+
+from remex import CompressedVectors, PackedVectors, Quantizer  # noqa: E402
+from remex.codebook import lloyd_max_codebook  # noqa: E402
+from remex.packing import pack  # noqa: E402
+from remex.pq_format import load_pq, save_pq  # noqa: E402
+from remex.rotation import LEGACY_ROTATION, haar_rotation, rht_rotation  # noqa: E402
+
+N, D, BITS, SEED = 96, 64, 4, 11
+
+
+def _digest(*arrays: np.ndarray) -> str:
+    h = hashlib.sha256()
+    for a in arrays:
+        h.update(np.ascontiguousarray(a).tobytes())
+    return h.hexdigest()[:16]
+
+
+def _reference_codes(X: np.ndarray, kind: str) -> np.ndarray:
+    """Encode without touching core.py or pq_format.py.
+
+    This is the anchor: rotation and codebook straight from their own
+    modules, quantization spelled out here. If this agreed with the library
+    only because both call the same persistence helper, it would not be an
+    anchor at all.
+    """
+    R = (haar_rotation if kind == "haar" else rht_rotation)(D, SEED)
+    boundaries, _ = lloyd_max_codebook(D, BITS)
+    norms = np.linalg.norm(X, axis=1, keepdims=True)
+    unit = X / np.where(norms == 0, 1.0, norms)
+    rotated = unit @ R.T
+    return np.searchsorted(boundaries, rotated).astype(np.uint8)
+
+
+def _flip_library_default(kind: str) -> str:
+    """Rebind Quantizer.__init__'s `rotation` default and return the old one."""
+    defaults = Quantizer.__init__.__defaults__
+    old = defaults[-1]
+    Quantizer.__init__.__defaults__ = defaults[:-1] + (kind,)
+    return old
+
+
+def _zero_rotation_byte(path: Path) -> None:
+    """Rewrite a .pq so byte 17 is zero — a file from before the field."""
+    raw = bytearray(path.read_bytes())
+    raw[17] = 0
+    path.write_bytes(bytes(raw))
+
+
+def _bit_agreement(a: np.ndarray, b: np.ndarray) -> float:
+    """Fraction of agreeing bits in the *packed* codes — the bytes on disk.
+
+    Compare the uint8 index arrays directly and you measure the padding: at
+    4 bits the high nibble of every byte is always zero and always agrees,
+    which floors the statistic near 0.75 and hides what the real codes do.
+    The first version of this gate did exactly that and the bracket caught
+    it, which is the bracket earning its place.
+    """
+    ab = np.unpackbits(pack(np.ascontiguousarray(a).ravel(), BITS))
+    bb = np.unpackbits(pack(np.ascontiguousarray(b).ravel(), BITS))
+    return float((ab == bb).mean())
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--simulate-prefix", action="store_true",
+        help="patch the readers back to the pre-fix behaviour; gate must go red",
+    )
+    args = ap.parse_args()
+
+    g = Gate(name="rotation-identity")
+    rng = np.random.default_rng(3)
+    X = rng.standard_normal((N, D)).astype(np.float32)
+
+    if args.simulate_prefix:
+        # The pre-fix reader: resolve the rotation from whatever the library
+        # default happens to be at read time, ignoring what the file says.
+        import remex.pq_format as pqf
+
+        _real_load = pqf.load_pq
+
+        def _prefix_load(path):
+            cv = _real_load(path)
+            live_default = Quantizer.__init__.__defaults__[-1]
+            return CompressedVectors(
+                cv.indices, cv.norms, cv.d, cv.bits, live_default
+            )
+
+        pqf.load_pq = _prefix_load
+        globals()["load_pq"] = _prefix_load
+        g.note("--simulate-prefix active: readers trust the module default")
+
+    tmp = Path(tempfile.mkdtemp())
+
+    # ---- 1. anchors: the library agrees with an independent encode -------
+    for kind in ("haar", "rht"):
+        q = Quantizer(d=D, bits=BITS, seed=SEED, rotation=kind)
+        lib = q.encode(X).indices
+        ref = _reference_codes(X, kind)
+        g.check(
+            np.array_equal(lib, ref),
+            f"{kind}: library codes match an independent encode",
+            f"digest lib={_digest(lib)} ref={_digest(ref)}",
+            kind="anchor",
+            covers=(),
+        )
+
+    # ---- 2. the two rotations are far apart, so identity is non-trivial --
+    haar_codes = _reference_codes(X, "haar")
+    rht_codes = _reference_codes(X, "rht")
+    agreement = _bit_agreement(haar_codes, rht_codes)
+    g.bracket(
+        "haar and rht codes are near-independent",
+        value=agreement, lo=0.40, hi=0.60,
+        why=(
+            "a misread is a coin flip, not a rounding difference — this is "
+            "what makes the byte-identity assertions below non-tautological"
+        ),
+    )
+
+    # ---- 3. a legacy file survives a default flip ------------------------
+    q_haar = Quantizer(d=D, bits=BITS, seed=SEED, rotation="haar")
+    cv = q_haar.encode(X)
+    pq_path = tmp / "legacy.pq"
+    save_pq(pq_path, cv)
+    _zero_rotation_byte(pq_path)
+
+    before = load_pq(pq_path)
+    g.check(
+        before.rotation == LEGACY_ROTATION,
+        "legacy .pq (rotation byte zeroed) resolves to haar",
+        f"got {before.rotation!r}",
+        covers=(),
+    )
+
+    old_default = _flip_library_default("rht")
+    try:
+        after = load_pq(pq_path)
+        g.check(
+            Quantizer.__init__.__defaults__[-1] == "rht",
+            "library default really was flipped for this run",
+            "guards against the flip silently not taking",
+        )
+        g.check(
+            after.rotation == LEGACY_ROTATION,
+            "legacy .pq still resolves to haar after the default flips",
+            f"got {after.rotation!r}",
+            covers=(),
+        )
+        g.check(
+            np.array_equal(before.indices, after.indices)
+            and np.array_equal(before.norms, after.norms),
+            "legacy .pq bytes decode identically across the flip",
+            f"digest before={_digest(before.indices, before.norms)} "
+            f"after={_digest(after.indices, after.norms)}",
+            covers=(),
+        )
+        g.check(
+            np.array_equal(after.indices, haar_codes),
+            "legacy .pq codes still match the independent haar reference",
+            f"digest after={_digest(after.indices)} ref={_digest(haar_codes)}",
+            kind="anchor",
+            covers=(),
+        )
+
+        # ---- 4. an rht index round-trips under a flipped default too -----
+        q_rht = Quantizer(d=D, bits=BITS, seed=SEED, rotation="rht")
+        rht_path = tmp / "rht.pq"
+        save_pq(rht_path, q_rht.encode(X))
+        rt = load_pq(rht_path)
+        g.check(
+            rt.rotation == "rht" and np.array_equal(rt.indices, rht_codes),
+            "an rht-written .pq reads back as rht",
+            f"rotation={rt.rotation!r} digest={_digest(rt.indices)}",
+            covers=(),
+        )
+
+        # ---- the recorded value has to be load-bearing, not advisory -----
+        # This is the pair of checks the pre-fix reader actually breaks:
+        # under it the legacy index claims 'rht', so the correct Haar
+        # quantizer is refused and the wrong one is accepted. Recording the
+        # rotation without consuming it would leave both of these green.
+        decoded = None
+        try:
+            decoded = q_haar.decode(after)
+            refused = False
+        except ValueError:
+            refused = True
+        g.check(
+            not refused and decoded is not None,
+            "the correct haar Quantizer still decodes the legacy index",
+            "a reader that mislabels the index refuses the right quantizer",
+            covers=(),
+        )
+
+        try:
+            Quantizer(d=D, bits=BITS, seed=SEED, rotation="rht").decode(after)
+            wrong_refused = False
+        except ValueError:
+            wrong_refused = True
+        g.check(
+            wrong_refused,
+            "the wrong (rht) Quantizer is refused on the legacy index",
+            "enforcement, not just metadata",
+            covers=(),
+        )
+
+        # ---- 5. the other two containers agree ---------------------------
+        npz_path = tmp / "legacy.npz"
+        cv.save(npz_path)
+        g.check(
+            CompressedVectors.load(npz_path).rotation == "haar",
+            ".npz round-trips the rotation",
+            covers=(),
+        )
+        pv = PackedVectors.from_compressed(q_rht.encode(X))
+        pv_path = tmp / "rht_packed.npz"
+        pv.save(pv_path)
+        g.check(
+            PackedVectors.load(pv_path).rotation == "rht",
+            "PackedVectors .npz round-trips the rotation",
+            covers=(),
+        )
+    finally:
+        _flip_library_default(old_default)
+
+    # ---- known-bad -------------------------------------------------------
+    # Decode the haar index against the rht quantizer: the misread this whole
+    # mechanism exists to prevent. It must land far from the truth.
+    q_rht = Quantizer(d=D, bits=BITS, seed=SEED, rotation="rht")
+    good = q_haar.decode(q_haar.encode(X))
+    # Override the recorded value to get past the enforcement — this is
+    # exactly the state a mislabelling reader puts the object in, so the
+    # damage measured here is the damage the enforcement prevents.
+    mislabelled = q_haar.encode(X)
+    mislabelled.rotation = "rht"
+    crossed = q_rht.decode(mislabelled)
+
+    def _cos(A):
+        num = np.sum(X * A, axis=1)
+        den = np.linalg.norm(X, axis=1) * np.linalg.norm(A, axis=1)
+        return float(np.mean(num / den))
+
+    cos_good, cos_crossed = _cos(good), _cos(crossed)
+    g.known_bad(
+        "decoding a haar index under an rht quantizer is caught as wrong",
+        rejected=(cos_good > 0.9 and cos_crossed < 0.5),
+        detail=f"cos(correct)={cos_good:.4f} cos(crossed)={cos_crossed:.4f}",
+        covers=(
+            "legacy .pq still resolves to haar after the default flips",
+            "the correct haar Quantizer still decodes the legacy index",
+            "the wrong (rht) Quantizer is refused on the legacy index",
+        ),
+    )
+    g.note(f"haar/rht bit agreement = {agreement:.4f}")
+
+    # ---- coverage limits -------------------------------------------------
+    g.coverage(
+        "Does NOT cover the Mojo readers. src/pq_format.mojo parses the same "
+        "byte 17 and polarquant refuses a mismatch, but neither is exercised "
+        "here — that needs a built binary, and the CLI does not build on a "
+        "host without a supported GPU."
+    )
+    g.coverage(
+        "Does NOT cover the Arrow container. save_arrow/load_arrow carry a "
+        "b'rotation' metadata key with the same absent-means-haar rule, but "
+        "pyarrow is an optional dependency and is skipped when absent."
+    )
+    g.coverage(
+        "Does NOT protect a pre-field READER from a future rht file. An old "
+        "remex ignores byte 17 and will decode an rht index as haar, silently. "
+        "This protects existing indexes from a future default flip, not the "
+        "reverse — that direction is unfixable from this side of the wire."
+    )
+    g.coverage(
+        "Does NOT cover .params. That file embeds R explicitly, so a reader "
+        "cannot misread it; its byte 9 is recorded for the --seed path's "
+        "benefit only and is not asserted here."
+    )
+    g.coverage(
+        f"One shape only: n={N}, d={D}, bits={BITS}, seed={SEED}. Bit widths "
+        "other than 4, and d where the RHT block size is small, are untested "
+        "by this gate (tests/ and the Mojo test_rht cover those separately)."
+    )
+    g.coverage(
+        "Does NOT cover LAPACK/BLAS drift across machines. haar_rotation uses "
+        "an explicit Householder QR precisely to avoid that, but this gate "
+        "runs on one host and cannot see cross-host divergence."
+    )
+    return g.report()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/remex/core.py
+++ b/remex/core.py
@@ -4,7 +4,9 @@ import numpy as np
 from typing import Optional, Tuple, Iterable
 from remex.codebook import lloyd_max_codebook, nested_codebooks
 from remex.packing import pack, unpack, packed_nbytes
-from remex.rotation import haar_rotation, rht_rotation
+from remex.rotation import (
+    LEGACY_ROTATION, haar_rotation, rht_rotation, validate_rotation,
+)
 
 
 class CompressedVectors:
@@ -15,20 +17,22 @@ class CompressedVectors:
     computing the true compressed size (nbytes).
     """
 
-    __slots__ = ("indices", "norms", "d", "bits", "n", "_x_hat_rot")
+    __slots__ = ("indices", "norms", "d", "bits", "n", "rotation", "_x_hat_rot")
 
-    def __init__(self, indices: np.ndarray, norms: np.ndarray, d: int, bits: int):
+    def __init__(self, indices: np.ndarray, norms: np.ndarray, d: int, bits: int,
+                 rotation: str = LEGACY_ROTATION):
         self.indices = indices  # (n, d) uint8 — unpacked for fast access
         self.norms = norms
         self.d = d
         self.bits = bits
         self.n = indices.shape[0]
+        self.rotation = validate_rotation(rotation)
         self._x_hat_rot = None  # cached dequantized rotated vectors (full precision)
 
     def subset(self, idx: np.ndarray) -> "CompressedVectors":
         """Return a CompressedVectors containing only the given row indices."""
         sub = CompressedVectors(
-            self.indices[idx], self.norms[idx], self.d, self.bits
+            self.indices[idx], self.norms[idx], self.d, self.bits, self.rotation
         )
         if self._x_hat_rot is not None:
             sub._x_hat_rot = self._x_hat_rot[idx]
@@ -71,15 +75,22 @@ class CompressedVectors:
             d=np.int32(self.d),
             bits=np.int32(self.bits),
             n=np.int32(self.n),
+            rotation=np.str_(self.rotation),
         )
 
     @classmethod
     def load(cls, path: str) -> "CompressedVectors":
-        """Load from .npz file, unpacking bit-packed indices."""
+        """Load from .npz file, unpacking bit-packed indices.
+
+        A file with no ``rotation`` entry predates the field and is Haar —
+        see ``remex.rotation.LEGACY_ROTATION`` for why that is a frozen
+        constant rather than the current default.
+        """
         data = np.load(path)
         d = int(data["d"])
         bits = int(data["bits"])
         n = int(data["n"])
+        rotation = str(data["rotation"]) if "rotation" in data else LEGACY_ROTATION
 
         if "packed_indices" in data:
             flat = unpack(data["packed_indices"], bits, n * d)
@@ -88,7 +99,7 @@ class CompressedVectors:
             # Backward compat: old format stored unpacked indices
             indices = data["indices"]
 
-        return cls(indices, data["norms"], d, bits)
+        return cls(indices, data["norms"], d, bits, rotation)
 
     def save_arrow(self, path: str, seed: Optional[int] = None, **extra_metadata):
         """Save to Arrow IPC (Feather v2) format, packing indices for storage.
@@ -132,7 +143,8 @@ class PackedVectors:
     supported — use ``to_compressed()`` to convert back if needed.
     """
 
-    __slots__ = ("_packed", "norms", "d", "bits", "n", "_row_bytes", "_row_aligned")
+    __slots__ = ("_packed", "norms", "d", "bits", "n", "rotation",
+                 "_row_bytes", "_row_aligned")
 
     def __init__(
         self,
@@ -141,6 +153,7 @@ class PackedVectors:
         n: int,
         d: int,
         bits: int,
+        rotation: str = LEGACY_ROTATION,
     ):
         """
         Args:
@@ -149,12 +162,15 @@ class PackedVectors:
             n: Number of vectors.
             d: Vector dimension.
             bits: Bits per coordinate.
+            rotation: Which rotation encoded these codes. Defaults to
+                the frozen historical value, not the library default.
         """
         self._packed = packed  # (n, row_bytes) uint8
         self.norms = norms
         self.n = n
         self.d = d
         self.bits = bits
+        self.rotation = validate_rotation(rotation)
         self._row_bytes = packed_nbytes(1, d, bits)
         self._row_aligned = (d * bits) % 8 == 0
 
@@ -220,7 +236,8 @@ class PackedVectors:
             packed = np.empty((n, row_bytes), dtype=np.uint8)
             for i in range(n):
                 packed[i] = pack(compressed.indices[i], bits)
-        return cls(packed, compressed.norms.copy(), n, d, bits)
+        return cls(packed, compressed.norms.copy(), n, d, bits,
+                   compressed.rotation)
 
     @classmethod
     def from_rows(
@@ -229,6 +246,7 @@ class PackedVectors:
         norms: np.ndarray,
         d: int,
         bits: int,
+        rotation: str = LEGACY_ROTATION,
     ) -> "PackedVectors":
         """Reconstruct from database packed byte rows.
 
@@ -237,6 +255,10 @@ class PackedVectors:
             norms: (n,) float32 array of vector norms.
             d: Vector dimension.
             bits: Bits per coordinate.
+            rotation: Which rotation encoded these codes. The database
+                schema has no column for it, so the caller must supply it
+                for anything other than Haar — this default is the frozen
+                historical value, not the library default.
 
         Returns:
             PackedVectors instance.
@@ -249,7 +271,8 @@ class PackedVectors:
                 row_list.append(np.asarray(r, dtype=np.uint8))
         packed = np.stack(row_list)
         n = len(row_list)
-        return cls(packed, np.asarray(norms, dtype=np.float32), n, d, bits)
+        return cls(packed, np.asarray(norms, dtype=np.float32), n, d, bits,
+                   rotation)
 
     def at_precision(self, target_bits: int) -> "PackedVectors":
         """Derive a lower-bit representation via Matryoshka right-shift.
@@ -289,13 +312,16 @@ class PackedVectors:
                     packed_target[start + i] = pack(shifted[i], target_bits)
 
         return PackedVectors(
-            packed_target, self.norms.copy(), self.n, self.d, target_bits
+            packed_target, self.norms.copy(), self.n, self.d, target_bits,
+            self.rotation,
         )
 
     def to_compressed(self) -> CompressedVectors:
         """Convert to CompressedVectors by unpacking all indices."""
         indices = self.unpack_rows(0, self.n)
-        return CompressedVectors(indices, self.norms.copy(), self.d, self.bits)
+        return CompressedVectors(
+            indices, self.norms.copy(), self.d, self.bits, self.rotation
+        )
 
     def subset(self, idx: np.ndarray) -> "PackedVectors":
         """Return a PackedVectors containing only the given row indices."""
@@ -306,6 +332,7 @@ class PackedVectors:
             len(idx),
             self.d,
             self.bits,
+            self.rotation,
         )
 
     @property
@@ -332,19 +359,24 @@ class PackedVectors:
             d=np.int32(self.d),
             bits=np.int32(self.bits),
             n=np.int32(self.n),
+            rotation=np.str_(self.rotation),
         )
 
     @classmethod
     def load(cls, path: str) -> "PackedVectors":
-        """Load from .npz file, keeping indices packed."""
+        """Load from .npz file, keeping indices packed.
+
+        A file with no ``rotation`` entry predates the field and is Haar.
+        """
         data = np.load(path)
         d = int(data["d"])
         bits = int(data["bits"])
         n = int(data["n"])
+        rotation = str(data["rotation"]) if "rotation" in data else LEGACY_ROTATION
         row_bytes = packed_nbytes(1, d, bits)
         packed_flat = data["packed_indices"]
         packed = packed_flat.reshape(n, row_bytes)
-        return cls(packed, data["norms"], n, d, bits)
+        return cls(packed, data["norms"], n, d, bits, rotation)
 
     def save_arrow(self, path: str, seed: Optional[int] = None, **extra_metadata):
         """Save to Arrow IPC (Feather v2) format.
@@ -373,6 +405,7 @@ class PackedVectors:
             b"d": str(self.d).encode(),
             b"bits": str(self.bits).encode(),
             b"n": str(self.n).encode(),
+            b"rotation": self.rotation.encode(),
         }
         if seed is not None:
             metadata[b"seed"] = str(seed).encode()
@@ -424,6 +457,11 @@ class PackedVectors:
         d = int(metadata[b"d"])
         bits = int(metadata[b"bits"])
         n = int(metadata[b"n"])
+        rotation = (
+            metadata[b"rotation"].decode()
+            if b"rotation" in metadata
+            else LEGACY_ROTATION
+        )
         row_bytes = packed_nbytes(1, d, bits)
 
         norms = table.column("norms").to_numpy().astype(np.float32)
@@ -436,7 +474,7 @@ class PackedVectors:
         packed_flat = np.frombuffer(data_buf, dtype=np.uint8)[: n * row_bytes]
         packed = packed_flat.reshape(n, row_bytes).copy()
 
-        return cls(packed, norms, n, d, bits)
+        return cls(packed, norms, n, d, bits, rotation)
 
 
 class Quantizer:
@@ -536,7 +574,29 @@ class Quantizer:
 
         indices = np.searchsorted(self.boundaries, X_rot).astype(np.uint8)
 
-        return CompressedVectors(indices, norms, self.d, self.bits)
+        return CompressedVectors(indices, norms, self.d, self.bits, self.rotation)
+
+    def _check_rotation(self, compressed) -> None:
+        """Refuse to interpret codes a different rotation encoded.
+
+        The rotation is part of the encoding exactly as `seed` is, and the
+        two constructions disagree on ~50% of stored bits — so a mismatch
+        is not a small error, it is noise that still looks like an answer.
+        Recording the rotation on disk is what makes this check possible;
+        this is what makes it protective. If you are knowingly reading a
+        legacy container whose recorded value is wrong, set
+        ``compressed.rotation`` before calling.
+        """
+        stored = getattr(compressed, "rotation", LEGACY_ROTATION)
+        if stored != self.rotation:
+            raise ValueError(
+                f"rotation mismatch: these codes were encoded with "
+                f"{stored!r} but this Quantizer uses {self.rotation!r}. "
+                f"Rebuild the Quantizer with rotation={stored!r}. "
+                f"(Decoding across rotations returns plausible-looking "
+                f"vectors that are wrong — the two disagree on about half "
+                f"of all stored bits.)"
+            )
 
     def decode(
         self, compressed: CompressedVectors, precision: Optional[int] = None
@@ -594,6 +654,7 @@ class Quantizer:
                 "Use search_adc() or search_twostage(), or convert "
                 "with packed.to_compressed() first."
             )
+        self._check_rotation(compressed)
         query = np.asarray(query, dtype=np.float32)
         q_rot = self.R @ query
 
@@ -910,7 +971,12 @@ class Quantizer:
     def _resolve_centroids(
         self, compressed: CompressedVectors, precision: Optional[int]
     ) -> np.ndarray:
-        """Get centroid table for the requested precision level."""
+        """Get centroid table for the requested precision level.
+
+        Every decode/search path passes through here, which makes it the
+        one place the rotation invariant has to hold.
+        """
+        self._check_rotation(compressed)
         if precision is None:
             return self.centroids
         if precision < 1 or precision > self.bits:

--- a/remex/mojo/README.md
+++ b/remex/mojo/README.md
@@ -142,6 +142,19 @@ searched and decoded with it too.
 `--params` remains the canonical bridge for any case where you want
 guaranteed bit parity regardless of bit width or potential drift.
 
+### The index records its rotation
+
+`.pq` byte 17 holds the rotation code (`0` = haar, `1` = rht) and
+`.params` byte 9 mirrors it. Both were reserved-and-zero before the field
+existed, and haar is `0`, so every previously written file reads back as
+haar with no compatibility branch — which is the correct answer for all
+of them. `search` and `decode` refuse a `--rotation` that disagrees with
+what the index records, instead of silently decoding against the wrong
+rotation; the two constructions differ on roughly half their stored bits,
+so the results would look plausible and be wrong. `--params` skips the
+check, since the matrix comes from the file and there is nothing to
+disagree with.
+
 ### 8-bit byte-parity caveat
 
 At `--bits 8`, the Lloyd-Max codebook uses 256 levels and runs 300

--- a/remex/mojo/polarquant.mojo
+++ b/remex/mojo/polarquant.mojo
@@ -101,6 +101,39 @@ def _print_usage():
     print("Use --device cpu or --device gpu to force a backend (e.g. for benchmarking).")
 
 
+def _rotation_code(name: String) -> Int:
+    """Rotation name to its .pq / .params header code. Haar is 0 because
+    that byte was reserved-and-zero in every file written before the field
+    existed, so those files read back as haar without a presence check."""
+    if name == "rht":
+        return 1
+    return 0
+
+
+def _check_rotation_matches(stored: Int, requested: String,
+                            params_path: String) raises:
+    """Refuse to decode an index under a rotation that did not encode it.
+
+    Only meaningful on the --seed path: with --params the matrix comes out
+    of the file, so there is nothing to disagree with. Without this check a
+    mismatch is silent — the codes decode to plausible-looking vectors that
+    are simply wrong, because the two rotations differ in roughly half
+    their bits rather than slightly.
+    """
+    if len(params_path) > 0:
+        return
+    var want = _rotation_code(requested)
+    if stored != want:
+        var stored_name = String("rht") if stored == 1 else String("haar")
+        raise Error(
+            String("rotation mismatch: this index was encoded with '")
+            + stored_name + String("' but --rotation is '") + requested
+            + String("'. Re-run with --rotation ") + stored_name
+            + String(" (the codes would otherwise decode against the wrong ")
+            + String("rotation and the results would be silently wrong).")
+        )
+
+
 def _parse_rotation(args: List[String]) raises -> String:
     """Parse --rotation flag. Returns 'haar' (default) or 'rht'."""
     var idx = _arg_idx(args, String("--rotation"))
@@ -247,7 +280,8 @@ def cmd_encode(args: List[String]) raises:
     var nb = packed_nbytes(n * d, bits)
     var packed = alloc[UInt8](nb)
     pack(indices, n * d, bits, packed)
-    save_pq(out_path, packed, nb, norms, n, d, bits)
+    save_pq(out_path, packed, nb, norms, n, d, bits,
+            _rotation_code(rotation_choice))
     var total_bytes = nb + n * 4 + 32
     var ratio = Float64(n * d * 4) / Float64(nb + n * 4)
     print("  wrote", total_bytes, "bytes (compression ratio:", ratio, "x)")
@@ -332,6 +366,7 @@ def cmd_search(args: List[String]) raises:
             raise Error("search: --rng must be 'numpy' (default) or 'xoshiro'")
     var rotation_choice2 = _parse_rotation(args)
 
+    _check_rotation_matches(pq.rotation, rotation_choice2, params_path)
     var q_quant = _build_quantizer(pq.d, pq.bits, seed, params_path, rng_choice2, rotation_choice2)
 
     # Unpack indices into uint8 (n*d). Copy norms into a fresh buffer too —
@@ -420,6 +455,7 @@ def cmd_decode(args: List[String]) raises:
           "(n =", pq.n, ", d =", pq.d, ", bits =", pq.bits,
           ", precision =", precision if precision > 0 else pq.bits, ")")
 
+    _check_rotation_matches(pq.rotation, rotation_choice, params_path)
     var q_quant = _build_quantizer(pq.d, pq.bits, seed, params_path, rng_choice, rotation_choice)
 
     # Build nested centroid tables from the loaded codebook so they match

--- a/remex/mojo/src/params_format.mojo
+++ b/remex/mojo/src/params_format.mojo
@@ -6,7 +6,8 @@ Layout (little-endian):
   bytes 0-3   : magic 'PR\x00\x01'
   bytes 4-7   : d (u32)
   byte 8      : bits (u8)
-  bytes 9-15  : reserved (zero)
+  byte 9      : rotation code (u8) — 0 = haar, 1 = rht
+  bytes 10-15 : reserved (zero)
   bytes 16+   : R              (d * d float32 row-major)
   then        : boundaries     ((n_levels - 1) float32)
   then        : centroids      (n_levels float32)
@@ -88,7 +89,8 @@ def load_params(path: String, mut R_out: Matrix, mut cb_out: Codebook) raises:
     owned.free()
 
 
-def save_params(path: String, R: Matrix, cb: Codebook) raises:
+def save_params(path: String, R: Matrix, cb: Codebook,
+                rotation: Int = 0) raises:
     """Write (R, boundaries, centroids) to a .params file."""
     var d = R.rows
     var bits = cb.bits
@@ -109,6 +111,7 @@ def save_params(path: String, R: Matrix, cb: Codebook) raises:
     buf[6] = UInt8((d >> 16) & 0xFF)
     buf[7] = UInt8((d >> 24) & 0xFF)
     buf[8] = UInt8(bits)
+    buf[9] = UInt8(rotation)
 
     var R_src = R.data.bitcast[UInt8]()
     for i in range(R_bytes):

--- a/remex/mojo/src/pq_format.mojo
+++ b/remex/mojo/src/pq_format.mojo
@@ -7,7 +7,8 @@ Layout (all little-endian):
   bytes 4-7   : d (u32)
   bytes 8-15  : n (u64)
   byte 16     : bits (u8)
-  bytes 17-31 : reserved (15 zero bytes) — header padded to 32 bytes
+  byte 17     : rotation code (u8) — 0 = haar, 1 = rht
+  bytes 18-31 : reserved (14 zero bytes) — header padded to 32 bytes
   bytes 32+   : packed_indices (length = packed_nbytes(n*d, bits))
   then        : norms (n × float32)
 
@@ -30,12 +31,21 @@ struct PqVectors(Movable):
     var n: Int
     var d: Int
     var bits: Int
+    var rotation: Int
+    """Rotation code the file records: 0 = haar, 1 = rht.
+
+    Byte 17 was reserved-and-zero before this field existed and haar is
+    0, so a file written by an older remex reads back as haar with no
+    presence check — which is the correct answer for every such file.
+    """
     var packed_bytes: Int
 
-    def __init__(out self, n: Int, d: Int, bits: Int) raises:
+    def __init__(out self, n: Int, d: Int, bits: Int,
+                 rotation: Int = 0) raises:
         self.n = n
         self.d = d
         self.bits = bits
+        self.rotation = rotation
         self.packed_bytes = packed_nbytes(n * d, bits)
         self.packed_indices = alloc[UInt8](self.packed_bytes)
         self.norms = alloc[Float32](n)
@@ -64,7 +74,7 @@ def _u64_le(buf: UnsafePointer[UInt8, MutExternalOrigin], off: Int) -> Int:
 def save_pq(path: String,
             packed_indices: UnsafePointer[UInt8, MutExternalOrigin], packed_bytes: Int,
             norms: UnsafePointer[Float32, MutExternalOrigin], n: Int,
-            d: Int, bits: Int) raises:
+            d: Int, bits: Int, rotation: Int = 0) raises:
     """Write a .pq file."""
     var total = PQ_HEADER_BYTES + packed_bytes + n * 4
     var buf = alloc[UInt8](total)
@@ -83,8 +93,9 @@ def save_pq(path: String,
     # n (u64 LE) at offset 8
     for k in range(8):
         buf[8 + k] = UInt8((n >> (8 * k)) & 0xFF)
-    # bits at offset 16
+    # bits at offset 16, rotation code at 17
     buf[16] = UInt8(bits)
+    buf[17] = UInt8(rotation)
 
     # packed indices
     for i in range(packed_bytes):
@@ -120,8 +131,15 @@ def load_pq(path: String) raises -> PqVectors:
     var d = _u32_le(owned, 4)
     var n = _u64_le(owned, 8)
     var bits = Int(owned[16])
+    var rotation = Int(owned[17])
+    if rotation > 1:
+        owned.free()
+        raise Error(
+            String("unknown rotation code ") + String(rotation)
+            + String(" in .pq header; this file was written by a newer remex")
+        )
 
-    var pq = PqVectors(n, d, bits)
+    var pq = PqVectors(n, d, bits, rotation)
     var expected = PQ_HEADER_BYTES + pq.packed_bytes + n * 4
     if len(raw) < expected:
         owned.free()

--- a/remex/pq_format.py
+++ b/remex/pq_format.py
@@ -7,7 +7,8 @@ Layout (little-endian):
     bytes 4-7   : d (u32)
     bytes 8-15  : n (u64)
     byte 16     : bits (u8)
-    bytes 17-31 : reserved (15 zero bytes)
+    byte 17     : rotation code (u8) — 0 = haar, 1 = rht
+    bytes 18-31 : reserved (14 zero bytes)
     bytes 32+   : packed_indices (length = packed_nbytes(n*d, bits))
     then        : norms (n × float32, little-endian)
 
@@ -25,6 +26,9 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from remex.packing import pack, unpack, packed_nbytes
+from remex.rotation import (
+    ROTATION_CODES, rotation_from_code, validate_rotation,
+)
 
 if TYPE_CHECKING:
     from remex.core import CompressedVectors, Quantizer
@@ -82,6 +86,7 @@ def save_params(path: str | Path, quantizer: "Quantizer") -> None:
     header[0:4] = PARAMS_MAGIC
     header[4:8] = struct.pack("<I", d)
     header[8] = bits & 0xFF
+    header[9] = ROTATION_CODES[rotation]
     with open(path, "wb") as f:
         f.write(bytes(header))
         f.write(R.tobytes())
@@ -105,6 +110,7 @@ def save_pq(path: str | Path, compressed: "CompressedVectors") -> None:
     header[4:8] = struct.pack("<I", d)
     header[8:16] = struct.pack("<Q", n)
     header[16] = bits & 0xFF
+    header[17] = ROTATION_CODES[validate_rotation(compressed.rotation)]
 
     norms = np.ascontiguousarray(compressed.norms, dtype=np.float32)
 
@@ -129,6 +135,9 @@ def load_pq(path: str | Path) -> "CompressedVectors":
     (d,) = struct.unpack("<I", raw[4:8])
     (n,) = struct.unpack("<Q", raw[8:16])
     bits = raw[16]
+    # Byte 17 was reserved-and-zero before this field existed, and 0 is
+    # haar, so a pre-field file resolves to LEGACY_ROTATION for free.
+    rotation = rotation_from_code(raw[17])
     if bits in (5, 6, 7):
         raise ValueError(
             f"bits={bits} is not supported. Use 1-4 or 8 bits."
@@ -151,4 +160,4 @@ def load_pq(path: str | Path) -> "CompressedVectors":
     )
 
     indices = unpack(packed, bits, n * d).reshape(n, d)
-    return CompressedVectors(indices.copy(), norms.copy(), d, bits)
+    return CompressedVectors(indices.copy(), norms.copy(), d, bits, rotation)

--- a/remex/rotation.py
+++ b/remex/rotation.py
@@ -12,6 +12,45 @@ import math
 
 import numpy as np
 
+#: What an *absent* rotation record on disk means.
+#:
+#: A frozen historical constant, deliberately NOT tied to ``Quantizer``'s
+#: live ``rotation`` default. Every index written before this field existed
+#: was built with Haar, and must keep decoding as Haar no matter what the
+#: default becomes later. Binding this to the default would mean flipping
+#: the default silently re-decodes every stored index under a rotation that
+#: did not encode it — and the codes are 50%-different, not slightly off,
+#: so the failure is total and silent rather than noisy.
+LEGACY_ROTATION = "haar"
+
+#: Rotation name to its on-disk code, for the byte-oriented ``.pq`` and
+#: ``.params`` headers. Haar is 0 because the reserved header bytes this
+#: lives in were already zero-filled in every file written before the field
+#: existed — so an old file decodes to ``LEGACY_ROTATION`` for free, with no
+#: "is the field present?" branch.
+ROTATION_CODES = {"haar": 0, "rht": 1}
+ROTATION_BY_CODE = {code: name for name, code in ROTATION_CODES.items()}
+
+
+def validate_rotation(kind: str) -> str:
+    """Return ``kind`` if it names a rotation this library can build."""
+    if kind not in ROTATION_CODES:
+        raise ValueError(
+            f"unknown rotation {kind!r}; expected one of "
+            f"{sorted(ROTATION_CODES)}."
+        )
+    return kind
+
+
+def rotation_from_code(code: int) -> str:
+    """Map an on-disk rotation byte back to its name."""
+    if code not in ROTATION_BY_CODE:
+        raise ValueError(
+            f"unknown rotation code {code} in header; this file was written "
+            f"by a newer remex. Known codes: {sorted(ROTATION_BY_CODE)}."
+        )
+    return ROTATION_BY_CODE[code]
+
 
 def _householder_qr(A: np.ndarray) -> np.ndarray:
     """In-place Householder QR; returns Q. After the call A holds R.

--- a/tests/test_docs_links.py
+++ b/tests/test_docs_links.py
@@ -1,0 +1,77 @@
+"""Relative links in the docs must point at files that exist.
+
+remax#63 found two markdown files cited that had never existed. remex is
+currently clean, which is exactly when this check is cheap to add and
+worth having: the failure mode is a link that rots silently, long after
+whoever wrote it has stopped looking.
+
+No allowlist. remax's version needed one and reported that the allowlist
+was itself the fragile part — three of its six known-bads were about the
+allowlist going stale. With nothing to exempt here, the simplest thing
+that can still fail is the right one; add exemptions only when a real
+case demands it, and give each one a test.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Markdown inline links: ](target). Skip anchors, URLs and mailto.
+_LINK = re.compile(r"\]\((?!https?://|mailto:|#)([^)\s]+)\)")
+
+DOC_FILES = sorted(
+    p for p in [
+        *ROOT.glob("*.md"),
+        *ROOT.glob("docs/**/*.md"),
+        *ROOT.glob("bench/**/*.md"),
+        *ROOT.glob("remex/mojo/*.md"),
+    ]
+    if p.is_file()
+)
+
+
+def _links(path: Path) -> list[str]:
+    return _LINK.findall(path.read_text(encoding="utf-8"))
+
+
+def test_there_are_docs_to_check():
+    """Self-guard: a glob that matches nothing makes every check below
+    pass while checking nothing."""
+    assert len(DOC_FILES) >= 3, f"found only {len(DOC_FILES)} markdown files"
+    assert any(_links(p) for p in DOC_FILES), "no relative links extracted"
+
+
+@pytest.mark.parametrize("doc", DOC_FILES, ids=lambda p: str(p.relative_to(ROOT)))
+def test_relative_links_resolve(doc):
+    missing = []
+    for target in _links(doc):
+        clean = target.split("#", 1)[0]
+        if not clean:
+            continue
+        if not (doc.parent / clean).resolve().exists():
+            missing.append(target)
+    assert not missing, (
+        f"{doc.relative_to(ROOT)} links to files that do not exist: {missing}"
+    )
+
+
+def test_the_scanner_would_notice_a_dead_link(tmp_path):
+    """Negative control — the regex has to actually match a link, and a
+    dead target has to fail. A scanner whose pattern stops matching reports
+    zero dead links forever, which is indistinguishable from success."""
+    doc = tmp_path / "x.md"
+    doc.write_text("see [gone](does/not/exist.md) and [ok](x.md)\n")
+    found = _LINK.findall(doc.read_text())
+    assert found == ["does/not/exist.md", "x.md"], found
+    dead = [t for t in found if not (doc.parent / t).exists()]
+    assert dead == ["does/not/exist.md"]
+
+
+def test_the_scanner_ignores_urls_and_anchors(tmp_path):
+    doc = tmp_path / "y.md"
+    doc.write_text("[a](https://example.com/x.md) [b](#section) [c](y.md)\n")
+    assert _LINK.findall(doc.read_text()) == ["y.md"]

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -1,0 +1,104 @@
+"""Execute every ```python block in README.md against the real API.
+
+The bug class this catches is API drift in the docs: a method that moved to
+module level, a constructor that no longer exists, arguments in the wrong
+order. Those read fine and are wrong, and nothing else in the suite looks at
+them. (remax found three such defects in its own README this way —
+oaustegard/remax#63.)
+
+remex's README blocks are illustrative rather than self-contained: they use
+`embeddings`, `corpus`, `query` and friends without defining them. Rather
+than rewrite the README into something less readable, the fixtures are
+supplied here and the blocks run in document order in one shared namespace,
+so names a block defines (`pq`, `compressed`) are visible to later blocks —
+which is how a reader would build them up.
+
+Fixtures are re-seeded at whatever `d` a block's own `Quantizer(d=...)`
+declares, because the README legitimately switches dimension between
+sections.
+"""
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+README = Path(__file__).resolve().parents[1] / "README.md"
+_BLOCK = re.compile(r"^```python\n(.*?)^```", re.S | re.M)
+
+
+def _blocks() -> list[str]:
+    return _BLOCK.findall(README.read_text(encoding="utf-8"))
+
+
+def test_readme_has_python_blocks():
+    """Self-guard: if the extractor silently matches nothing, every other
+    assertion in this file passes vacuously."""
+    assert len(_blocks()) >= 5, (
+        "extracted too few ```python blocks from README.md — the fence "
+        "convention probably changed and this file is now testing nothing"
+    )
+
+
+def _seed_fixtures(ns: dict, d: int) -> None:
+    rng = np.random.default_rng(0)
+    ns.update(
+        embeddings=rng.standard_normal((50, d)).astype(np.float32),
+        corpus=rng.standard_normal((50, d)).astype(np.float32),
+        query=rng.standard_normal(d).astype(np.float32),
+        d=d,
+    )
+
+
+def test_readme_examples_execute(tmp_path, monkeypatch):
+    """Every block runs. Blocks that write files do so in a tmp dir."""
+    from remex import PackedVectors, Quantizer
+
+    monkeypatch.chdir(tmp_path)
+    ns: dict = {}
+    _seed_fixtures(ns, 384)
+
+    for i, block in enumerate(_blocks()):
+        m = re.search(r"Quantizer\(\s*d=(\d+)", block)
+        if m:
+            _seed_fixtures(ns, int(m.group(1)))
+        if "from_rows" in block:
+            # from_rows models reading packed bytes back out of a database.
+            pv = PackedVectors.from_compressed(
+                Quantizer(d=ns["d"], bits=4).encode(ns["corpus"])
+            )
+            ns["rows"] = [bytes(r) for r in pv._packed]
+            ns["norms"] = pv.norms
+        try:
+            exec(compile(block, f"README.md[block {i}]", "exec"), ns)
+        except Exception as exc:  # noqa: BLE001 - re-raised with context
+            pytest.fail(
+                f"README.md python block {i} failed to execute: "
+                f"{type(exc).__name__}: {exc}\n\n{block}"
+            )
+
+
+def test_the_executor_would_notice_a_broken_block(tmp_path, monkeypatch):
+    """Negative control. The check above must be able to reject something —
+    otherwise it is decoration that happens to be green."""
+    monkeypatch.chdir(tmp_path)
+    ns: dict = {}
+    _seed_fixtures(ns, 64)
+    bad = "from remex import Quantizer\nQuantizer(d=64).no_such_method()\n"
+    with pytest.raises(AttributeError):
+        exec(compile(bad, "<synthetic>", "exec"), ns)
+
+
+def test_readme_quantizer_signature_claims_hold():
+    """The README's headline claim names the tuple that determines a
+    quantizer. If a determinant is added and the sentence is not updated,
+    that sentence becomes the kind of confident-and-wrong prose this file
+    exists to catch."""
+    text = README.read_text(encoding="utf-8")
+    assert "(d, bits, seed, rotation)" in text, (
+        "README no longer states the full determining tuple; if a determinant "
+        "was added or removed, update the sentence and this assertion together"
+    )

--- a/tests/test_rotation_rht.py
+++ b/tests/test_rotation_rht.py
@@ -100,18 +100,48 @@ def test_round_trip_fidelity_matches_haar(bits):
     assert abs(cos["haar"] - cos["rht"]) < 2e-3, cos
 
 
+def _mean_cos(X, A):
+    return float(np.mean(np.sum(X * A, 1) / (
+        np.linalg.norm(X, axis=1) * np.linalg.norm(A, axis=1))))
+
+
 def test_rotation_is_part_of_the_encoding():
-    """Codes from one rotation must not be decoded under the other. This is a
-    guard against treating `rotation` as a free-floating perf knob."""
+    """Crossing rotations is refused, not merely bad.
+
+    The codes carry the rotation that wrote them, and every decode/search
+    path checks it. This used to return wrong-but-plausible vectors.
+    """
     d, rng = 128, np.random.default_rng(1)
     X = rng.standard_normal((64, d)).astype(np.float32)
     qh = Quantizer(d=d, bits=8, seed=42, rotation="haar")
     qr = Quantizer(d=d, bits=8, seed=42, rotation="rht")
-    good = qh.decode(qh.encode(X))
-    crossed = qr.decode(qh.encode(X))
-    cos = lambda A: float(np.mean(np.sum(X * A, 1) / (
-        np.linalg.norm(X, axis=1) * np.linalg.norm(A, axis=1))))
-    assert cos(good) > 0.99 and cos(crossed) < 0.5, (cos(good), cos(crossed))
+    cv = qh.encode(X)
+
+    assert _mean_cos(X, qh.decode(cv)) > 0.99
+
+    for call in (lambda: qr.decode(cv),
+                 lambda: qr.search(cv, X[0], k=5),
+                 lambda: qr.search_adc(cv, X[0], k=5)):
+        with pytest.raises(ValueError, match="rotation mismatch"):
+            call()
+
+
+def test_crossing_rotations_is_worth_refusing():
+    """The refusal above has to be load-bearing, not fussiness.
+
+    Override the recorded rotation to bypass the check — the escape hatch a
+    caller with genuinely mislabelled legacy data would use — and measure
+    what the check is preventing.
+    """
+    d, rng = 128, np.random.default_rng(1)
+    X = rng.standard_normal((64, d)).astype(np.float32)
+    qh = Quantizer(d=d, bits=8, seed=42, rotation="haar")
+    qr = Quantizer(d=d, bits=8, seed=42, rotation="rht")
+
+    cv = qh.encode(X)
+    cv.rotation = "rht"          # lie about it, the way a bad default would
+    crossed = qr.decode(cv)
+    assert _mean_cos(X, crossed) < 0.5, _mean_cos(X, crossed)
 
 
 @pytest.mark.parametrize("rotation", ["haar", "rht"])
@@ -146,3 +176,92 @@ def test_odd_dimension_rejected():
 def test_unknown_rotation_rejected():
     with pytest.raises(ValueError, match="rotation must be one of"):
         Quantizer(d=64, bits=4, rotation="hadamard")
+
+
+# --- rotation is recorded wherever an index is persisted -------------------
+# The gate at bench/gates/rotation_identity_gate.py covers .pq and .npz under
+# a flipped library default. These cover the surfaces it states it does not:
+# Arrow metadata, the .params byte, and the from_rows entry point.
+
+@pytest.mark.parametrize("rotation", ["haar", "rht"])
+def test_pq_and_npz_round_trip_rotation(tmp_path, rotation):
+    from remex import load_pq, save_pq, CompressedVectors, PackedVectors
+
+    X = np.random.default_rng(0).standard_normal((24, 64)).astype(np.float32)
+    cv = Quantizer(d=64, bits=4, seed=1, rotation=rotation).encode(X)
+    assert cv.rotation == rotation
+
+    pq = tmp_path / "i.pq"
+    save_pq(pq, cv)
+    assert load_pq(pq).rotation == rotation
+
+    npz = tmp_path / "i.npz"
+    cv.save(npz)
+    assert CompressedVectors.load(npz).rotation == rotation
+
+    pv_path = tmp_path / "p.npz"
+    PackedVectors.from_compressed(cv).save(pv_path)
+    assert PackedVectors.load(pv_path).rotation == rotation
+
+
+def test_pq_rotation_byte_is_where_the_spec_says(tmp_path):
+    """Byte 17, and 0 must mean haar so pre-field files read correctly."""
+    from remex import save_pq
+
+    X = np.random.default_rng(0).standard_normal((8, 64)).astype(np.float32)
+    for rotation, expected in (("haar", 0), ("rht", 1)):
+        p = tmp_path / f"{rotation}.pq"
+        save_pq(p, Quantizer(d=64, bits=4, seed=1, rotation=rotation).encode(X))
+        assert p.read_bytes()[17] == expected
+
+
+def test_params_records_the_rotation_byte(tmp_path):
+    """.params byte 9 mirrors .pq byte 17, same 0-means-haar convention."""
+    for rotation, expected in (("haar", 0), ("rht", 1)):
+        p = tmp_path / f"{rotation}.pr"
+        save_params(p, Quantizer(d=32, bits=4, seed=1, rotation=rotation))
+        assert p.read_bytes()[9] == expected
+
+
+def test_from_rows_defaults_to_legacy_not_library_default():
+    """The DB schema has no rotation column, so the default must be the
+    frozen historical value — never whatever the library default is now."""
+    from remex import PackedVectors
+    from remex.rotation import LEGACY_ROTATION
+
+    X = np.random.default_rng(0).standard_normal((6, 64)).astype(np.float32)
+    pv = PackedVectors.from_compressed(
+        Quantizer(d=64, bits=4, seed=1, rotation="rht").encode(X)
+    )
+    rows = [bytes(r) for r in pv._packed]
+    rebuilt = PackedVectors.from_rows(rows, pv.norms, 64, 4)
+    assert rebuilt.rotation == LEGACY_ROTATION == "haar"
+    assert PackedVectors.from_rows(
+        rows, pv.norms, 64, 4, rotation="rht"
+    ).rotation == "rht"
+
+
+@pytest.mark.parametrize("rotation", ["haar", "rht"])
+def test_arrow_round_trips_rotation(tmp_path, rotation):
+    pytest.importorskip("pyarrow")
+    from remex import CompressedVectors, PackedVectors
+
+    X = np.random.default_rng(0).standard_normal((16, 64)).astype(np.float32)
+    cv = Quantizer(d=64, bits=4, seed=1, rotation=rotation).encode(X)
+    p = tmp_path / "i.arrow"
+    cv.save_arrow(p, seed=1)
+    assert CompressedVectors.load_arrow(p).rotation == rotation
+    assert PackedVectors.load_arrow(p).rotation == rotation
+
+
+def test_unknown_rotation_code_in_pq_is_rejected(tmp_path):
+    from remex import load_pq, save_pq
+
+    X = np.random.default_rng(0).standard_normal((8, 64)).astype(np.float32)
+    p = tmp_path / "i.pq"
+    save_pq(p, Quantizer(d=64, bits=4, seed=1).encode(X))
+    raw = bytearray(p.read_bytes())
+    raw[17] = 7                      # a rotation a future remex might add
+    p.write_bytes(bytes(raw))
+    with pytest.raises(ValueError, match="unknown rotation code"):
+        load_pq(p)


### PR DESCRIPTION
Two commits. The first mirrors [remax#62](https://github.com/oaustegard/remax/pull/62); the second follows [remax#63](https://github.com/oaustegard/remax/pull/63) far enough to make the first one's gate load-bearing.

---

## 1. Record the rotation in every container, and enforce it on read

remex had remax#62's hazard — and #73 made it live: `--rotation rht` means rht-encoded indexes can now actually exist.

Every container recorded `(d, bits, n)` and sometimes `seed`, but never the rotation, so the reader fell back on whatever `Quantizer`'s default happened to be at read time. Flip that default and every stored index silently decodes in a frame its codes were never written in. Nothing raises; `search()` still returns k neighbours, and they are the wrong k.

Load-bearing rule, straight from remax#62: **an absent record resolves to `"haar"`, never to the live default.** `LEGACY_ROTATION` is a frozen historical constant for exactly that reason.

**Not a format-version bump.** `.pq` byte 17 and `.params` byte 9 were reserved-and-zero, and haar is code `0` — so every previously written file reads back as haar with no presence check, which is the correct answer for all of them. Old readers ignore the byte. Two-way door.

| Container | Where | Absent means |
|---|---|---|
| `.pq` | byte 17 (`0`=haar, `1`=rht) | haar |
| `.params` | byte 9 | haar |
| `.npz` | `rotation` key | haar |
| Arrow | `b"rotation"` metadata | haar |

**Recording alone would have been metadata, not protection** — nothing consumed the value, since `Quantizer` is built independently of the codes it reads. So `_check_rotation` now runs on every decode/search path, and `polarquant` refuses a `--rotation` that disagrees with what the `.pq` records. Crossing rotations raises instead of returning plausible garbage (mean cosine 0.996 → −0.031).

### Gate

`bench/gates/rotation_identity_gate.py` — anchor (reference codes built without `core.py`/`pq_format.py` in the path), two-sided bracket (haar vs rht agree on **0.497** of packed bits, so a misread is a coin flip), and a `--simulate-prefix` known-bad that restores the pre-fix reader and drives it red.

Two findings from building it, both recorded in the source:

1. The bracket first read **0.749** — I was comparing 4-bit codes in `uint8` and measuring the always-zero high nibble. The bracket caught a flaw in *the gate itself*.
2. The first known-bad reached only **1 of 13** checks. Chasing that is what exposed the unconsumed-value gap above. Reach is now 3/13; the rest are anchors the pre-fix reader structurally cannot perturb.

---

## 2. Add CI, and tests for the doc claims it would otherwise not check

Only the parts of remax#63 that transfer. Most of it is remax-internal (query-path bugs, `characterize()`, the Nemotron harness). **Two of its items are non-issues here — checked, not assumed:** remex has no dangling doc references (both relative links resolve), and scipy is a genuine runtime dependency (`codebook.py` imports `scipy.stats.norm`), so it stays pinned rather than moving to extras.

**CI is the real gap.** This repo had only `publish.yml` — nothing ran the tests, and nothing ran the gate from commit 1. pytest on 3.9 / 3.11 / 3.13, `.[dev]` only, never `.[bench]` (torch, for no signal about whether the library works).

The `gates` job runs the gate **and asserts it goes red** under `--simulate-prefix`. `gate.py` is vendored to `bench/gates/` so this works with no skill directory mounted; a real checkout still wins the candidate order. Verified by hiding the skill dir and re-running both ways.

A separate `pytest-arrow` job installs the arrow extra, because the matrix skips every Arrow test and **skipped tests are not passing tests** — this closes a coverage limit the gate itself declares. Split out rather than folded into the matrix because pyarrow's support floor moves independently of ours. Its guard checks both ways it could go green having tested nothing (pyarrow fails to install → everything skips; `-k` filter goes stale → nothing selected). Both confirmed to fail in the states they exist to catch.

**`tests/test_readme.py`** execs every python fence in document order. All six already pass — unlike remax, remex's examples had not drifted — so this is a guard, not a fix. Self-guarded: too few extracted blocks fails, and a synthetic broken block must raise.

**`tests/test_docs_links.py`** checks relative links resolve, deliberately **without an allowlist**. remax reported the allowlist as the fragile part of its own version, with three of six known-bads about it going stale; with nothing to exempt here, the simplest thing that can still fail is the right one. Two negative controls cover the scanner regex, since a pattern that stops matching reports zero dead links forever.

---

## Tests

| | |
|---|---|
| before this PR | 191 passed, 11 skipped |
| after, no arrow extra | **214 passed, 13 skipped** |
| after, with arrow extra | **227 passed, 0 skipped** |
| Mojo | 13/13 |
| gate | exit 0 green, exit 1 under `--simulate-prefix` |

## Note

`README.md` and `CLAUDE.md` both claimed the quantizer is "fully determined by `(d, bits, seed)`" — false since the rotation option landed. Corrected to `(d, bits, seed, rotation)`, and `test_readme.py` now asserts the sentence stays in step.