### PR TITLE
Add no-normalization scalar mode for hash-key use cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,50 @@
 
 ## Unreleased
 
-Nothing yet.
+### Added
+
+- **Scalar mode — `Quantizer(d, bits, normalize=False, scale=1.0)`**
+  ([#77](https://github.com/oaustegard/remex/issues/77)). Quantizes the
+  (optionally rotated) coordinates directly with the Lloyd-Max codebook:
+  no unit-sphere factorization, no norms computed or stored, codes are the
+  whole output. For use cases where the codes *are* the product — exact-match
+  hash keys for a join, bucketing, dedup — the default pipeline works against
+  you twice: unit-norm factorization maps every constant-direction family onto
+  a single direction code, and the float32 cast that buys `.pq` parity with
+  the Mojo port turns large values into `inf`. Scalar mode drops the first and
+  works in float64, saturating at the outermost cell instead. Lloyd-Max cell
+  shaping, Matryoshka nesting and determinism are unchanged.
+
+- **`rotation="none"`** — the identity, on-disk code 2. Intended for scalar
+  mode, where it makes a code a bare `searchsorted` of the input value: no
+  matmul, so identical inputs give identical codes across BLAS builds and
+  thread counts, and coordinate *j* of the code depends only on coordinate
+  *j* of the input.
+
+- **`sigma` on `lloyd_max_codebook` / `nested_codebooks`**, plus
+  `coordinate_sigma(d, sigma)` — the coordinate spread the cells are cut for.
+  `None` remains the unit-sphere `1/sqrt(d)`, bit-for-bit as before.
+
+- **`has_norms`** on `CompressedVectors` / `PackedVectors`.
+
+### Changed
+
+- `norms` is now optional on `CompressedVectors` and `PackedVectors`, and its
+  absence is how every serializer records scalar mode: no `norms` entry in
+  `.npz`, no `norms` column in Arrow, and a no-norms flag at `.pq` byte 18
+  bit 0 (previously reserved-and-zero, so existing files are unaffected).
+  A scalar-mode `.pq` is *shorter* than an old reader's arithmetic expects, so
+  such a reader — the Mojo port included — fails it as truncated rather than
+  reading indices as norms. `save_params` rejects a scalar quantizer for the
+  same reason.
+
+- Decoding or searching codes with a quantizer in the other mode now raises
+  `mode mismatch`, alongside the existing `rotation mismatch` check. The two
+  codebooks differ by a factor of `scale * sqrt(d)`, so crossing them would
+  otherwise rescale every reconstructed coordinate.
+
+The default path is untouched: same codes, same files, same
+`(d, bits, seed, rotation)` determinism.
 
 ## v0.6.0 — 2026-08-04
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 **remex** (formerly polar-embed) is a Python library for retrieval-validated embedding compression. It implements random orthogonal rotation + Lloyd-Max scalar quantization (from TurboQuant, Zandieh et al. ICLR 2026) to compress embedding vectors 2-16x with measured recall, optimized for nearest-neighbor retrieval in RAG systems.
 
-Key differentiator: **data-oblivious** — no training required. The quantizer is fully determined by `(dimension, bits, seed, rotation)`.
+Key differentiator: **data-oblivious** — no training required. The quantizer is fully determined by `(dimension, bits, seed, rotation, normalize, scale)`.
 
 ## Architecture
 
@@ -15,7 +15,7 @@ remex/
 ├── codebook.py       # Lloyd-Max codebooks + Matryoshka nested tables
 ├── ivf.py            # IVFCoarseIndex — coarse-tier IVF, data-oblivious
 ├── packing.py        # Bit-packing for sub-byte storage (1-8 bit)
-├── rotation.py       # Haar random orthogonal rotation via QR
+├── rotation.py       # Haar (QR), randomized Hadamard, and the identity
 └── gpu.py            # Optional GPU backend (CuPy/PyTorch/NumPy)
 
 tests/
@@ -24,7 +24,8 @@ tests/
 ├── test_adc_gpu.py       # ADC search, memory accounting, GPUSearcher (numpy fallback)
 ├── test_ivf.py           # IVFCoarseIndex: cell ID, multi-probe, recall, packed interop
 ├── test_packed_vectors.py # PackedVectors creation, unpacking, ADC, serialization
-└── test_coverage_gaps.py  # Edge cases, save/load all bits, subset search
+├── test_coverage_gaps.py  # Edge cases, save/load all bits, subset search
+└── test_scalar_mode.py   # normalize=False: hash-key properties, rotation="none", mode guard
 
 bench/
 ├── benchmark.py          # Self-contained benchmark (no external deps)
@@ -46,6 +47,15 @@ Search:
     → score via matmul (cached dequant) or ADC (lookup table over indices)
     → top-k selection
 ```
+
+**Scalar mode** (`Quantizer(normalize=False)`) drops the first step and the
+norms with it — codes are Lloyd-Max indices of the raw coordinates, cut for
+a caller-declared `scale` instead of the unit sphere's `1/sqrt(d)`, in
+float64 rather than float32. It exists for use cases where the codes *are*
+the product (exact-match hash keys, joins, bucketing) rather than an
+approximation of a direction; `rotation="none"` pairs with it to make a code
+a bare `searchsorted`. `norms is None` is what every container and
+serializer uses to record the mode, and mixing modes raises.
 
 ### Three search strategies
 
@@ -98,13 +108,16 @@ python bench/specter2_eval.py --cached  # then run the bench against the cache
 ## Code conventions
 
 - **NumPy-only core**: No PyTorch/CuPy dependency in `remex/core.py`. GPU support is opt-in via `remex/gpu.py`.
-- **No training**: Fully data-oblivious. The quantizer is determined by `(d, bits, seed, rotation)` alone.
+- **No training**: Fully data-oblivious. The quantizer is determined by `(d, bits, seed, rotation, normalize, scale)` alone. Scalar mode keeps this: `scale` is a value the caller *declares*, never one remex measures off the data.
 - **The rotation is part of the encoding**: every persisted container (`.pq` byte 17, `.npz` `rotation` key,
   Arrow `b"rotation"` metadata) records which rotation wrote it, and an absent record means `"haar"` — the
   frozen historical value, never the live default. That rule is what makes the default safe to change; see
   `bench/gates/rotation_identity_gate.py`.
+- **So is the mode**: a scalar-mode container (`normalize=False`) has `norms is None`, and every serializer
+  records that by *omitting* the norms column (`.npz`/Arrow) or setting the no-norms flag (`.pq` byte 18,
+  bit 0). Decoding or searching across the two modes raises, like a rotation mismatch.
 - **Honest compression**: `nbytes` property uses bit-packed sizes, not uint8. Benchmark tables report packed compression ratios.
-- **Deterministic**: Same `(d, bits, seed)` must produce identical results across runs.
+- **Deterministic**: Same `(d, bits, seed)` must produce identical results across runs. `rotation="none"` strengthens this to bit-identical across BLAS builds, because no matmul enters the encoding.
 - **Test thresholds**: Recall tests use conservative bounds (e.g. 2-bit R@10 >= 0.3, not exact values) because recall depends on random data.
 
 ## Key design decisions

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ from remex import CompressedVectors
 loaded = CompressedVectors.load("index.npz")
 ```
 
-The quantizer is fully determined by `(d, bits, seed, rotation)` — no training, no fitting, no index to ship. `rotation` defaults to `"haar"` and is part of the encoding exactly as `seed` is; every container records it, and decoding against the wrong one raises rather than returning wrong-but-plausible vectors.
+The quantizer is fully determined by `(d, bits, seed, rotation, normalize, scale)` — no training, no fitting, no index to ship. `rotation` defaults to `"haar"` and is part of the encoding exactly as `seed` is; every container records it, and decoding against the wrong one raises rather than returning wrong-but-plausible vectors. `normalize` and `scale` select the pipeline described below versus [scalar mode](#scalar-mode-codes-as-hash-keys), and default to the former.
 
 ## How it works
 
@@ -152,14 +152,16 @@ In-memory, indices are stored as uint8 for fast search. The `PackedVectors` clas
 
 ## API reference
 
-### `Quantizer(d, bits=4, seed=42, rotation="haar")`
+### `Quantizer(d, bits=4, seed=42, rotation="haar", normalize=True, scale=None)`
 
 Main quantizer class (formerly `PolarQuantizer`, which remains available as a deprecated alias).
 
 - **`d`** — Vector dimension (must match your embeddings).
 - **`bits`** — Bits per coordinate: 1-4 or 8. Sweet spot is 3-4. Use 8 for near-lossless.
 - **`seed`** — Random seed for the rotation matrix. Same seed = same quantizer.
-- **`rotation`** — `"haar"` (default) or `"rht"`. Part of the encoding exactly as `seed` is: every container records it, a file written before rotations were recorded resolves to `"haar"`, and decoding against the wrong one raises.
+- **`rotation`** — `"haar"` (default), `"rht"`, or `"none"` (the identity — see [scalar mode](#scalar-mode-codes-as-hash-keys)). Part of the encoding exactly as `seed` is: every container records it, a file written before rotations were recorded resolves to `"haar"`, and decoding against the wrong one raises.
+- **`normalize`** — `True` (default) factors each vector into unit direction plus a stored norm, as described above. `False` selects [scalar mode](#scalar-mode-codes-as-hash-keys): quantize the coordinates directly, store no norms. Also part of the encoding — a mismatch raises.
+- **`scale`** — Scalar mode only (default `1.0`): the coordinate standard deviation the Lloyd-Max cells are cut for. The normalizing path derives it from the unit sphere as `1/sqrt(d)` and rejects an explicit value.
 
 #### Methods
 
@@ -188,6 +190,7 @@ Container for quantized data. Created by `Quantizer.encode()`. Stores indices as
 - **`nbytes_unpacked`** — In-memory size (uint8 indices + float32 norms).
 - **`compression_ratio`** — `(n * d * 4) / nbytes`.
 - **`resident_bytes`** — Actual RAM including any active caches.
+- **`has_norms`** — `False` for scalar-mode containers, whose `norms` is `None`. Both size properties account for the absent column.
 
 #### Methods
 
@@ -333,8 +336,38 @@ from remex import lloyd_max_codebook, nested_codebooks
 
 - **`pack(indices, bits)`** / **`unpack(packed, bits, n_values)`** — Bit-pack/unpack uint8 arrays.
 - **`packed_nbytes(n_values, d, bits)`** — Compute packed byte count.
-- **`lloyd_max_codebook(d, bits)`** — Generate optimal boundaries and centroids for N(0, 1/d).
-- **`nested_codebooks(d, max_bits)`** — Build Matryoshka centroid tables for all bit levels 1..max_bits.
+- **`lloyd_max_codebook(d, bits, sigma=None)`** — Generate optimal boundaries and centroids for N(0, sigma); `sigma=None` is the unit-sphere value `1/sqrt(d)`.
+- **`nested_codebooks(d, max_bits, sigma=None)`** — Build Matryoshka centroid tables for all bit levels 1..max_bits.
+
+## Scalar mode: codes as hash keys
+
+`Quantizer(normalize=False)` skips the unit-sphere factorization and quantizes the (optionally rotated) coordinates directly. No norms are computed, none are stored, and the codes are the whole output.
+
+```python
+import numpy as np
+from remex import Quantizer
+
+# Enumerated algebraic values, not embeddings: heavy-tailed, and full of
+# near-parallel families that a unit-norm factorization would collapse.
+values = np.array([[c, c, 2 * c, -c] for c in (0.1, 0.7, 1.3, 2.0)])
+
+pq = Quantizer(d=4, bits=4, normalize=False, rotation="none", scale=1.0)
+codes = pq.encode(values).indices          # (n, 4) uint8, and no norms array
+keys = [bytes(row) for row in codes]       # exact-match hash keys
+
+coarse = codes >> 2                        # 2-bit keys: coarser, more collisions
+```
+
+Use it when the codes themselves are the product — hash keys for a join, bucketing, dedup — rather than an approximation of a direction. Two properties of the default pipeline work against that:
+
+- **Unit-norm factorization collapses constant-direction families.** Every `c * ones(d)` shares one direction code, differing only in the norm that scalar mode does not store. On roughly isotropic embeddings that is harmless; on enumerated values those families are enormous, and the shared code is a mega-bucket rather than a key.
+- **float32 range.** The normalizing path casts input to float32 and stores float32 norms (for byte-identical [`.pq` parity with the Mojo port](#mojo-port-polarquant)). Values past ~3.4e38 become `inf` there. Scalar mode works in float64 and saturates at the outermost cell instead.
+
+What is unchanged: Lloyd-Max cell shaping, Matryoshka nesting (right-shift a code for a coarser one — a per-query collision/recall dial), and determinism, which is what makes a code usable as an exact-match key at all. `rotation="none"` strengthens that last point: with no rotation matmul in the way, a code is a bare `searchsorted` of the input value, identical across BLAS builds and thread counts, and coordinate *j* of the code depends only on coordinate *j* of the input.
+
+**You own the range conditioning.** remex stays data-oblivious and will not measure your data to pick cells. Bound your inputs or push heavy tails through `arcsinh`/`log`, then set `scale` to the spread you conditioned them to; anything past `±3 * scale` lands in an outermost cell.
+
+Scalar-mode containers carry `norms is None`, which is how every serializer marks them: no `norms` entry in `.npz`, no `norms` column in Arrow, and the no-norms flag (byte 18, bit 0) in `.pq`. Mixing the two modes raises rather than silently rescaling every coordinate. The Mojo port always normalizes, so it does not read scalar-mode `.pq` files and `save_params` rejects a scalar quantizer.
 
 ## vs TurboQuant
 

--- a/bench/gates/rotation_identity_gate.py
+++ b/bench/gates/rotation_identity_gate.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import inspect
 import os
 import sys
 import tempfile
@@ -105,11 +106,31 @@ def _reference_codes(X: np.ndarray, kind: str) -> np.ndarray:
     return np.searchsorted(boundaries, rotated).astype(np.uint8)
 
 
+def _rotation_default_slot() -> int:
+    """Index of `rotation` within Quantizer.__init__.__defaults__.
+
+    Looked up by name rather than assumed to be last: `normalize` and
+    `scale` were added after it (#77), and a positional guess here would
+    have silently rebound one of those instead — leaving this gate green
+    while testing nothing.
+    """
+    spec = inspect.getfullargspec(Quantizer.__init__)
+    n_defaults = len(spec.defaults)
+    with_defaults = spec.args[-n_defaults:]
+    return with_defaults.index("rotation")
+
+
+def _library_default_rotation() -> str:
+    return Quantizer.__init__.__defaults__[_rotation_default_slot()]
+
+
 def _flip_library_default(kind: str) -> str:
     """Rebind Quantizer.__init__'s `rotation` default and return the old one."""
-    defaults = Quantizer.__init__.__defaults__
-    old = defaults[-1]
-    Quantizer.__init__.__defaults__ = defaults[:-1] + (kind,)
+    slot = _rotation_default_slot()
+    defaults = list(Quantizer.__init__.__defaults__)
+    old = defaults[slot]
+    defaults[slot] = kind
+    Quantizer.__init__.__defaults__ = tuple(defaults)
     return old
 
 
@@ -155,7 +176,7 @@ def main() -> int:
 
         def _prefix_load(path):
             cv = _real_load(path)
-            live_default = Quantizer.__init__.__defaults__[-1]
+            live_default = _library_default_rotation()
             return CompressedVectors(
                 cv.indices, cv.norms, cv.d, cv.bits, live_default
             )
@@ -211,7 +232,7 @@ def main() -> int:
     try:
         after = load_pq(pq_path)
         g.check(
-            Quantizer.__init__.__defaults__[-1] == "rht",
+            _library_default_rotation() == "rht",
             "library default really was flipped for this run",
             "guards against the flip silently not taking",
         )

--- a/remex/__init__.py
+++ b/remex/__init__.py
@@ -15,7 +15,9 @@ Formerly known as polar-embed.
 import warnings
 
 from remex.core import Quantizer, CompressedVectors, PackedVectors
-from remex.codebook import lloyd_max_codebook, nested_codebooks
+from remex.codebook import (
+    coordinate_sigma, lloyd_max_codebook, nested_codebooks,
+)
 from remex.ivf import IVFCoarseIndex
 from remex.packing import pack, unpack, packed_nbytes
 from remex.pq_format import save_pq, load_pq, save_params
@@ -30,7 +32,7 @@ __all__ = [
     "Quantizer", "CompressedVectors", "PackedVectors",
     "PolarQuantizer",  # deprecated alias
     "IVFCoarseIndex",
-    "lloyd_max_codebook", "nested_codebooks",
+    "coordinate_sigma", "lloyd_max_codebook", "nested_codebooks",
     "pack", "unpack", "packed_nbytes",
     "save_pq", "load_pq", "save_params",
 ]

--- a/remex/codebook.py
+++ b/remex/codebook.py
@@ -2,30 +2,51 @@
 
 import numpy as np
 from scipy.stats import norm
-from typing import Dict, Tuple
+from typing import Dict, Optional, Tuple
+
+
+def coordinate_sigma(d: int, sigma: Optional[float] = None) -> float:
+    """Resolve the coordinate standard deviation a codebook is built for.
+
+    ``None`` means the unit-sphere default, ``1/sqrt(d)``: after a random
+    orthogonal rotation of a *unit* vector in R^d each coordinate
+    concentrates to N(0, 1/d). Scalar mode (``Quantizer(normalize=False)``)
+    skips the normalization, so its coordinate scale is the caller's to
+    declare and is passed in explicitly.
+    """
+    if sigma is None:
+        return 1.0 / float(np.sqrt(d))
+    sigma = float(sigma)
+    if not np.isfinite(sigma) or sigma <= 0.0:
+        raise ValueError(f"sigma must be finite and positive, got {sigma!r}")
+    return sigma
 
 
 def lloyd_max_codebook(
-    d: int, bits: int, n_iter: int = 300
+    d: int, bits: int, n_iter: int = 300, sigma: Optional[float] = None
 ) -> Tuple[np.ndarray, np.ndarray]:
     """
-    Build optimal Lloyd-Max codebook for N(0, 1/d) distributed coordinates.
+    Build optimal Lloyd-Max codebook for N(0, sigma) distributed coordinates.
 
     After random orthogonal rotation of unit vectors in R^d, each coordinate
     follows a distribution that concentrates to N(0, 1/d) as d grows.
     The Lloyd-Max quantizer minimizes MSE for this known distribution.
 
     Args:
-        d: Vector dimension (determines coordinate variance = 1/d).
+        d: Vector dimension (determines the default coordinate variance = 1/d).
         bits: Quantization bit-width (produces 2^bits levels).
         n_iter: Lloyd-Max iteration count.
+        sigma: Coordinate standard deviation to optimize for. ``None``
+            (default) is ``1/sqrt(d)``, the unit-sphere value — pass an
+            explicit sigma only when the coordinates were not unit-normalized
+            first (see ``Quantizer(normalize=False)``).
 
     Returns:
         boundaries: (2^bits - 1,) decision boundaries for np.searchsorted.
         centroids: (2^bits,) reconstruction values.
     """
     n_levels = 2**bits
-    sigma = 1.0 / np.sqrt(d)
+    sigma = coordinate_sigma(d, sigma)
     rv = norm(0, sigma)
 
     centroids = np.linspace(-3 * sigma, 3 * sigma, n_levels)
@@ -57,7 +78,7 @@ def lloyd_max_codebook(
 
 
 def nested_codebooks(
-    d: int, max_bits: int
+    d: int, max_bits: int, sigma: Optional[float] = None
 ) -> Dict[int, np.ndarray]:
     """
     Build nested centroid tables for Matryoshka-style bit precision.
@@ -74,14 +95,16 @@ def nested_codebooks(
     Args:
         d: Vector dimension.
         max_bits: Maximum quantization bit-width.
+        sigma: Coordinate standard deviation, as in ``lloyd_max_codebook``.
+            ``None`` (default) is the unit-sphere value ``1/sqrt(d)``.
 
     Returns:
         Dict mapping bit-width to centroid array:
         {max_bits: (2^max_bits,), max_bits-1: (2^(max_bits-1),), ..., 1: (2,)}
     """
-    _, centroids_max = lloyd_max_codebook(d, max_bits)
+    sigma = coordinate_sigma(d, sigma)
+    _, centroids_max = lloyd_max_codebook(d, max_bits, sigma=sigma)
     n_max = len(centroids_max)
-    sigma = 1.0 / np.sqrt(d)
     rv = norm(0, sigma)
 
     # Probability mass for each max_bits bin

--- a/remex/core.py
+++ b/remex/core.py
@@ -2,11 +2,31 @@
 
 import numpy as np
 from typing import Optional, Tuple, Iterable
-from remex.codebook import lloyd_max_codebook, nested_codebooks
+from remex.codebook import (
+    coordinate_sigma, lloyd_max_codebook, nested_codebooks,
+)
 from remex.packing import pack, unpack, packed_nbytes
 from remex.rotation import (
-    LEGACY_ROTATION, haar_rotation, rht_rotation, validate_rotation,
+    LEGACY_ROTATION, haar_rotation, identity_rotation, rht_rotation,
+    validate_rotation,
 )
+
+
+def _norms_nbytes(norms: Optional[np.ndarray]) -> int:
+    """Bytes the norms column costs — zero in scalar mode, where it is absent."""
+    return 0 if norms is None else norms.nbytes
+
+
+def _apply_norms(
+    scores: np.ndarray, norms: Optional[np.ndarray]
+) -> np.ndarray:
+    """Rescale unit-sphere scores by the stored norms.
+
+    ``norms is None`` is scalar mode: the codes quantize the coordinates
+    themselves, so the lookup already is the approximate inner product and
+    there is nothing to rescale.
+    """
+    return scores if norms is None else scores * norms
 
 
 class CompressedVectors:
@@ -15,11 +35,16 @@ class CompressedVectors:
     Indices are stored as uint8 in memory for fast search/decode.
     Bit-packing is used for serialization (save/load) and for
     computing the true compressed size (nbytes).
+
+    ``norms`` is ``None`` for containers produced by a scalar-mode
+    quantizer (``Quantizer(normalize=False)``), which quantizes raw
+    coordinates and keeps no per-vector norm.
     """
 
     __slots__ = ("indices", "norms", "d", "bits", "n", "rotation", "_x_hat_rot")
 
-    def __init__(self, indices: np.ndarray, norms: np.ndarray, d: int, bits: int,
+    def __init__(self, indices: np.ndarray, norms: Optional[np.ndarray],
+                 d: int, bits: int,
                  rotation: str = LEGACY_ROTATION):
         self.indices = indices  # (n, d) uint8 — unpacked for fast access
         self.norms = norms
@@ -29,10 +54,17 @@ class CompressedVectors:
         self.rotation = validate_rotation(rotation)
         self._x_hat_rot = None  # cached dequantized rotated vectors (full precision)
 
+    @property
+    def has_norms(self) -> bool:
+        """False for scalar-mode codes, which store no per-vector norm."""
+        return self.norms is not None
+
     def subset(self, idx: np.ndarray) -> "CompressedVectors":
         """Return a CompressedVectors containing only the given row indices."""
         sub = CompressedVectors(
-            self.indices[idx], self.norms[idx], self.d, self.bits, self.rotation
+            self.indices[idx],
+            None if self.norms is None else self.norms[idx],
+            self.d, self.bits, self.rotation,
         )
         if self._x_hat_rot is not None:
             sub._x_hat_rot = self._x_hat_rot[idx]
@@ -41,12 +73,12 @@ class CompressedVectors:
     @property
     def nbytes(self) -> int:
         """Packed memory footprint in bytes (honest compression)."""
-        return packed_nbytes(self.n, self.d, self.bits) + self.norms.nbytes
+        return packed_nbytes(self.n, self.d, self.bits) + _norms_nbytes(self.norms)
 
     @property
     def nbytes_unpacked(self) -> int:
         """Unpacked memory footprint (what's actually in RAM)."""
-        return self.indices.nbytes + self.norms.nbytes
+        return self.indices.nbytes + _norms_nbytes(self.norms)
 
     @property
     def compression_ratio(self) -> float:
@@ -56,7 +88,7 @@ class CompressedVectors:
     @property
     def resident_bytes(self) -> int:
         """Actual RAM footprint including any active caches."""
-        total = self.indices.nbytes + self.norms.nbytes
+        total = self.indices.nbytes + _norms_nbytes(self.norms)
         if self._x_hat_rot is not None:
             total += self._x_hat_rot.nbytes
         return total
@@ -66,16 +98,23 @@ class CompressedVectors:
         self._x_hat_rot = None
 
     def save(self, path: str):
-        """Save to compressed .npz file with bit-packed indices."""
+        """Save to compressed .npz file with bit-packed indices.
+
+        Scalar-mode containers write no ``norms`` entry at all; its absence
+        is what marks the file as scalar mode on load. Every file written
+        by the normalizing path has one, so there is no ambiguity with
+        older files.
+        """
         packed_idx = pack(self.indices.ravel(), self.bits)
+        optional = {} if self.norms is None else {"norms": self.norms}
         np.savez_compressed(
             path,
             packed_indices=packed_idx,
-            norms=self.norms,
             d=np.int32(self.d),
             bits=np.int32(self.bits),
             n=np.int32(self.n),
             rotation=np.str_(self.rotation),
+            **optional,
         )
 
     @classmethod
@@ -85,6 +124,8 @@ class CompressedVectors:
         A file with no ``rotation`` entry predates the field and is Haar —
         see ``remex.rotation.LEGACY_ROTATION`` for why that is a frozen
         constant rather than the current default.
+
+        A file with no ``norms`` entry is scalar mode (``normalize=False``).
         """
         data = np.load(path)
         d = int(data["d"])
@@ -99,7 +140,8 @@ class CompressedVectors:
             # Backward compat: old format stored unpacked indices
             indices = data["indices"]
 
-        return cls(indices, data["norms"], d, bits, rotation)
+        norms = data["norms"] if "norms" in data else None
+        return cls(indices, norms, d, bits, rotation)
 
     def save_arrow(self, path: str, seed: Optional[int] = None, **extra_metadata):
         """Save to Arrow IPC (Feather v2) format, packing indices for storage.
@@ -149,7 +191,7 @@ class PackedVectors:
     def __init__(
         self,
         packed: np.ndarray,
-        norms: np.ndarray,
+        norms: Optional[np.ndarray],
         n: int,
         d: int,
         bits: int,
@@ -158,7 +200,8 @@ class PackedVectors:
         """
         Args:
             packed: (n, row_bytes) uint8 array of bit-packed indices.
-            norms: (n,) float32 array of vector norms.
+            norms: (n,) float32 array of vector norms, or ``None`` for
+                scalar-mode codes (``Quantizer(normalize=False)``).
             n: Number of vectors.
             d: Vector dimension.
             bits: Bits per coordinate.
@@ -173,6 +216,11 @@ class PackedVectors:
         self.rotation = validate_rotation(rotation)
         self._row_bytes = packed_nbytes(1, d, bits)
         self._row_aligned = (d * bits) % 8 == 0
+
+    @property
+    def has_norms(self) -> bool:
+        """False for scalar-mode codes, which store no per-vector norm."""
+        return self.norms is not None
 
     def unpack_rows(self, start: int, end: int) -> np.ndarray:
         """Decompress a contiguous row slice to uint8 indices.
@@ -236,14 +284,14 @@ class PackedVectors:
             packed = np.empty((n, row_bytes), dtype=np.uint8)
             for i in range(n):
                 packed[i] = pack(compressed.indices[i], bits)
-        return cls(packed, compressed.norms.copy(), n, d, bits,
-                   compressed.rotation)
+        norms = None if compressed.norms is None else compressed.norms.copy()
+        return cls(packed, norms, n, d, bits, compressed.rotation)
 
     @classmethod
     def from_rows(
         cls,
         rows: Iterable,
-        norms: np.ndarray,
+        norms: Optional[np.ndarray],
         d: int,
         bits: int,
         rotation: str = LEGACY_ROTATION,
@@ -252,7 +300,8 @@ class PackedVectors:
 
         Args:
             rows: Iterable of bytes/bytearray/ndarray, one per vector.
-            norms: (n,) float32 array of vector norms.
+            norms: (n,) float32 array of vector norms, or ``None`` for
+                scalar-mode codes.
             d: Vector dimension.
             bits: Bits per coordinate.
             rotation: Which rotation encoded these codes. The database
@@ -271,8 +320,9 @@ class PackedVectors:
                 row_list.append(np.asarray(r, dtype=np.uint8))
         packed = np.stack(row_list)
         n = len(row_list)
-        return cls(packed, np.asarray(norms, dtype=np.float32), n, d, bits,
-                   rotation)
+        if norms is not None:
+            norms = np.asarray(norms, dtype=np.float32)
+        return cls(packed, norms, n, d, bits, rotation)
 
     def at_precision(self, target_bits: int) -> "PackedVectors":
         """Derive a lower-bit representation via Matryoshka right-shift.
@@ -312,7 +362,7 @@ class PackedVectors:
                     packed_target[start + i] = pack(shifted[i], target_bits)
 
         return PackedVectors(
-            packed_target, self.norms.copy(), self.n, self.d, target_bits,
+            packed_target, self._copy_norms(), self.n, self.d, target_bits,
             self.rotation,
         )
 
@@ -320,7 +370,7 @@ class PackedVectors:
         """Convert to CompressedVectors by unpacking all indices."""
         indices = self.unpack_rows(0, self.n)
         return CompressedVectors(
-            indices, self.norms.copy(), self.d, self.bits, self.rotation
+            indices, self._copy_norms(), self.d, self.bits, self.rotation
         )
 
     def subset(self, idx: np.ndarray) -> "PackedVectors":
@@ -328,22 +378,25 @@ class PackedVectors:
         idx = np.asarray(idx)
         return PackedVectors(
             self._packed[idx].copy(),
-            self.norms[idx].copy(),
+            None if self.norms is None else self.norms[idx].copy(),
             len(idx),
             self.d,
             self.bits,
             self.rotation,
         )
 
+    def _copy_norms(self) -> Optional[np.ndarray]:
+        return None if self.norms is None else self.norms.copy()
+
     @property
     def nbytes(self) -> int:
         """Packed memory footprint in bytes."""
-        return self._packed.nbytes + self.norms.nbytes
+        return self._packed.nbytes + _norms_nbytes(self.norms)
 
     @property
     def resident_bytes(self) -> int:
         """Actual RAM footprint (same as nbytes — no caches)."""
-        return self._packed.nbytes + self.norms.nbytes
+        return self._packed.nbytes + _norms_nbytes(self.norms)
 
     @property
     def compression_ratio(self) -> float:
@@ -351,15 +404,20 @@ class PackedVectors:
         return (self.n * self.d * 4) / self.nbytes
 
     def save(self, path: str):
-        """Save to compressed .npz file."""
+        """Save to compressed .npz file.
+
+        As with ``CompressedVectors.save``, a scalar-mode container writes
+        no ``norms`` entry.
+        """
+        optional = {} if self.norms is None else {"norms": self.norms}
         np.savez_compressed(
             path,
             packed_indices=self._packed.ravel(),
-            norms=self.norms,
             d=np.int32(self.d),
             bits=np.int32(self.bits),
             n=np.int32(self.n),
             rotation=np.str_(self.rotation),
+            **optional,
         )
 
     @classmethod
@@ -367,6 +425,7 @@ class PackedVectors:
         """Load from .npz file, keeping indices packed.
 
         A file with no ``rotation`` entry predates the field and is Haar.
+        A file with no ``norms`` entry is scalar mode.
         """
         data = np.load(path)
         d = int(data["d"])
@@ -376,13 +435,15 @@ class PackedVectors:
         row_bytes = packed_nbytes(1, d, bits)
         packed_flat = data["packed_indices"]
         packed = packed_flat.reshape(n, row_bytes)
-        return cls(packed, data["norms"], n, d, bits, rotation)
+        norms = data["norms"] if "norms" in data else None
+        return cls(packed, norms, n, d, bits, rotation)
 
     def save_arrow(self, path: str, seed: Optional[int] = None, **extra_metadata):
         """Save to Arrow IPC (Feather v2) format.
 
         Stores packed indices as FixedSizeBinary and norms as Float32,
-        with quantizer parameters in schema-level metadata.
+        with quantizer parameters in schema-level metadata. A scalar-mode
+        container has no norms, so the file has no ``norms`` column.
 
         Requires pyarrow (optional dependency).
 
@@ -413,23 +474,20 @@ class PackedVectors:
             key = k.encode() if isinstance(k, str) else k
             metadata[key] = str(v).encode()
 
-        schema = pa.schema(
-            [
-                pa.field("norms", pa.float32()),
-                pa.field("packed_indices", pa.binary(row_bytes)),
-            ],
-            metadata=metadata,
-        )
-
-        # Build arrays from flat buffers for efficiency
-        norms_arr = pa.array(self.norms.tolist(), type=pa.float32())
+        fields = [pa.field("packed_indices", pa.binary(row_bytes))]
         packed_buf = pa.py_buffer(self._packed.tobytes())
-        packed_arr = pa.FixedSizeBinaryArray.from_buffers(
-            pa.binary(row_bytes), self.n, [None, packed_buf]
-        )
+        columns = {
+            "packed_indices": pa.FixedSizeBinaryArray.from_buffers(
+                pa.binary(row_bytes), self.n, [None, packed_buf]
+            )
+        }
+        if self.norms is not None:
+            fields.insert(0, pa.field("norms", pa.float32()))
+            columns["norms"] = pa.array(self.norms.tolist(), type=pa.float32())
 
+        schema = pa.schema(fields, metadata=metadata)
         table = pa.table(
-            {"norms": norms_arr, "packed_indices": packed_arr}, schema=schema
+            {f.name: columns[f.name] for f in fields}, schema=schema
         )
         feather.write_feather(table, path)
 
@@ -464,7 +522,10 @@ class PackedVectors:
         )
         row_bytes = packed_nbytes(1, d, bits)
 
-        norms = table.column("norms").to_numpy().astype(np.float32)
+        if "norms" in table.schema.names:
+            norms = table.column("norms").to_numpy().astype(np.float32)
+        else:
+            norms = None  # scalar mode — the column was never written
 
         # Extract packed data from contiguous Arrow buffer
         packed_col = table.column("packed_indices")
@@ -489,6 +550,9 @@ class Quantizer:
     Data-oblivious: Uses a theoretical Lloyd-Max codebook for N(0, 1/d).
     No training data needed. Based on TurboQuant (Zandieh et al., ICLR 2026).
 
+    ``normalize=False`` drops step 1 and quantizes the coordinates
+    themselves — see the ``normalize`` argument below.
+
     Supports **nested bit precision**: encode once at full bit-width,
     then search at any lower precision by right-shifting indices.
     The top k bits of an n-bit code are a valid k-bit code, with
@@ -512,16 +576,65 @@ class Quantizer:
                 the Mojo port via `polarquant --rotation rht`. Requires an
                 even d.
 
-            Both are seed-deterministic and exactly orthogonal. The rotation
-            is part of the encoding: vectors encoded under one CANNOT be
-            decoded under the other, so it must match across encode/decode
-            exactly as `seed` must.
+            "none" — no rotation (the identity). Only sensible together with
+                `normalize=False`, where the caller has already conditioned
+                the coordinates; it makes the code for coordinate *j* an
+                exact, matmul-free function of input coordinate *j*, which
+                is what a hash key wants. See
+                `remex.rotation.identity_rotation`.
+
+            All three are seed-deterministic and exactly orthogonal. The
+            rotation is part of the encoding: vectors encoded under one
+            CANNOT be decoded under another, so it must match across
+            encode/decode exactly as `seed` must.
+
+        normalize: Whether to factor each vector into (unit direction, norm)
+            before quantizing. Default True — the behavior described above,
+            and the only mode that existing `.pq`/`.npz` files use.
+
+            False selects **scalar mode**: quantize the (optionally rotated)
+            coordinates directly with the Lloyd-Max codebook, store no norms
+            at all, and let `scale` declare the coordinate spread. Use it
+            when the codes are the product — exact-match hash keys, joins,
+            bucketing — rather than an approximation of a direction:
+
+            - Unit-norm factorization collapses every constant-direction
+              family (`c * 1_vec` and near-parallel neighbourhoods) onto a
+              single direction code. On isotropic embeddings that is
+              harmless; on enumerated algebraic values it builds
+              mega-buckets, and a join that should take minutes turns into
+              a collision storm.
+            - Scalar mode never casts input to float32 (it works in
+              float64) and stores no float32 norms, so values that would
+              overflow either — `exp(700)` and friends — quantize to the
+              extreme cell instead of to `inf`/`nan`.
+
+            Everything else is unchanged: same Lloyd-Max cell shaping, same
+            Matryoshka nesting (right-shift a code for a coarser one, which
+            is a per-query collision/recall dial), same
+            `(d, bits, seed, rotation)` determinism.
+
+        scale: Coordinate standard deviation the Lloyd-Max codebook is built
+            for. Scalar mode only; the normalizing path derives it from the
+            unit sphere as `1/sqrt(d)` and rejects an explicit value.
+            Defaults to 1.0, i.e. inputs assumed roughly N(0, 1).
+
+            remex stays data-oblivious here: it will not measure your data
+            to pick a scale. Condition the input yourself — bound it, or
+            push heavy tails through `arcsinh`/`log` — and set `scale` to
+            the spread you conditioned it to. Coordinates far outside
+            `±3*scale` all land in the outermost cell.
     """
 
-    ROTATIONS = {"haar": haar_rotation, "rht": rht_rotation}
+    ROTATIONS = {
+        "haar": haar_rotation,
+        "rht": rht_rotation,
+        "none": identity_rotation,
+    }
 
     def __init__(self, d: int, bits: int = 4, seed: int = 42,
-                 rotation: str = "haar"):
+                 rotation: str = "haar", normalize: bool = True,
+                 scale: Optional[float] = None):
         if bits < 1 or bits > 8:
             raise ValueError(f"bits must be 1-4 or 8, got {bits}")
         if bits in (5, 6, 7):
@@ -536,16 +649,30 @@ class Quantizer:
                 f"got {rotation!r}"
             )
 
+        normalize = bool(normalize)
+        if normalize and scale is not None:
+            raise ValueError(
+                "scale is only meaningful with normalize=False. The "
+                "normalizing path quantizes unit vectors, whose rotated "
+                "coordinates have a known spread of 1/sqrt(d) — passing a "
+                "scale there would be silently ignored."
+            )
+        # None here means "unit sphere, 1/sqrt(d)"; scalar mode has no such
+        # default to fall back on, so it names one.
+        sigma = None if normalize else (1.0 if scale is None else scale)
+
         self.d = d
         self.bits = bits
         self.seed = seed
         self.rotation = rotation
+        self.normalize = normalize
+        self.scale = coordinate_sigma(d, sigma)
 
         self.R = self.ROTATIONS[rotation](d, seed)
-        self.boundaries, self.centroids = lloyd_max_codebook(d, bits)
+        self.boundaries, self.centroids = lloyd_max_codebook(d, bits, sigma=sigma)
 
         # Precompute nested centroid tables for all bit levels <= bits
-        self._nested = nested_codebooks(d, bits)
+        self._nested = nested_codebooks(d, bits, sigma=sigma)
 
     def encode(self, X: np.ndarray) -> CompressedVectors:
         """
@@ -555,8 +682,12 @@ class Quantizer:
             X: (n, d) float array. Need not be unit-normalized.
 
         Returns:
-            CompressedVectors container with indices and norms.
+            CompressedVectors container with indices, and norms unless this
+            is a scalar-mode (``normalize=False``) quantizer.
         """
+        if not self.normalize:
+            return self._encode_scalar(X)
+
         X = np.asarray(X, dtype=np.float32)
         if X.ndim == 1:
             X = X[np.newaxis]
@@ -570,11 +701,59 @@ class Quantizer:
         norms64 = np.sqrt(np.sum(X.astype(np.float64) ** 2, axis=1))
         norms = norms64.astype(np.float32)
         X_unit = X / np.maximum(norms, 1e-8)[:, None]
-        X_rot = X_unit @ self.R.T
+        X_rot = self._rotate_rows(X_unit)
 
         indices = np.searchsorted(self.boundaries, X_rot).astype(np.uint8)
 
         return CompressedVectors(indices, norms, self.d, self.bits, self.rotation)
+
+    def _encode_scalar(self, X: np.ndarray) -> CompressedVectors:
+        """Quantize coordinates directly — no normalization, no norms.
+
+        Stays in float64 throughout. The float32 cast on the normalizing
+        path is there for Mojo `.pq` parity, and it is exactly what
+        overflows on the heavy-tailed inputs this mode exists for; nothing
+        downstream of a scalar-mode code needs that parity.
+        """
+        X = np.asarray(X, dtype=np.float64)
+        if X.ndim == 1:
+            X = X[np.newaxis]
+        if X.shape[1] != self.d:
+            raise ValueError(f"Expected d={self.d}, got {X.shape[1]}")
+
+        X_rot = self._rotate_rows(X)
+        # searchsorted promotes the float32 boundaries to float64, so an
+        # out-of-range magnitude saturates at the outermost cell instead of
+        # overflowing to inf. NaN sorts above every boundary; it lands in
+        # the top cell rather than raising, which keeps a code well-defined
+        # for every input.
+        indices = np.searchsorted(self.boundaries, X_rot).astype(np.uint8)
+
+        return CompressedVectors(indices, None, self.d, self.bits, self.rotation)
+
+    def _rotate_rows(self, X: np.ndarray) -> np.ndarray:
+        """Apply R to a row-major batch: ``X @ R.T``, identity short-circuited.
+
+        Skipping the multiply is not just a speed-up. With `rotation="none"`
+        a code becomes a pure `searchsorted` of the input value, with no
+        floating-point summation in between, so identical inputs give
+        identical codes across BLAS builds and thread counts.
+        """
+        if self.rotation == "none":
+            return X
+        return X @ self.R.T
+
+    def _rotate_query(self, q: np.ndarray) -> np.ndarray:
+        """Apply R to a single query vector: ``R @ q``, identity short-circuited."""
+        if self.rotation == "none":
+            return q
+        return self.R @ q
+
+    def _unrotate_rows(self, X_rot: np.ndarray) -> np.ndarray:
+        """Undo ``_rotate_rows``: ``X_rot @ R`` (R orthogonal, so R.T is R^-1)."""
+        if self.rotation == "none":
+            return X_rot
+        return X_rot @ self.R
 
     def _check_rotation(self, compressed) -> None:
         """Refuse to interpret codes a different rotation encoded.
@@ -597,6 +776,31 @@ class Quantizer:
                 f"vectors that are wrong — the two disagree on about half "
                 f"of all stored bits.)"
             )
+        self._check_mode(compressed)
+
+    def _check_mode(self, compressed) -> None:
+        """Refuse to interpret codes the other mode wrote.
+
+        Whether a container carries norms says which mode encoded it, and
+        the codebooks differ by a factor of ``scale * sqrt(d)`` — so
+        crossing the two rescales every reconstructed coordinate. Caught
+        here rather than at the first ``None`` dereference, which would
+        only fire on the paths that happen to touch norms.
+        """
+        has_norms = getattr(compressed, "norms", None) is not None
+        if has_norms == self.normalize:
+            return
+        stored, wanted = (
+            ("normalize=True", "normalize=False") if has_norms
+            else ("normalize=False (scalar)", "normalize=True")
+        )
+        raise ValueError(
+            f"mode mismatch: these codes were encoded with {stored} but "
+            f"this Quantizer uses {wanted}. Rebuild the Quantizer with the "
+            f"mode that wrote them — the two use codebooks scaled "
+            f"differently, so the reconstruction would be off by a constant "
+            f"factor across every coordinate."
+        )
 
     def decode(
         self, compressed: CompressedVectors, precision: Optional[int] = None
@@ -616,8 +820,10 @@ class Quantizer:
         indices = self._resolve_indices(compressed, precision)
         X_hat_rot = centroids[indices]
 
-        X_hat_unit = X_hat_rot @ self.R
-        return X_hat_unit * compressed.norms[:, None]
+        X_hat = self._unrotate_rows(X_hat_rot)
+        if compressed.norms is None:  # scalar mode — coordinates are the code
+            return X_hat
+        return X_hat * compressed.norms[:, None]
 
     def search(
         self,
@@ -656,10 +862,10 @@ class Quantizer:
             )
         self._check_rotation(compressed)
         query = np.asarray(query, dtype=np.float32)
-        q_rot = self.R @ query
+        q_rot = self._rotate_query(query)
 
         X_hat_rot = self._get_x_hat_rot(compressed, precision)
-        scores = (X_hat_rot @ q_rot) * compressed.norms
+        scores = _apply_norms(X_hat_rot @ q_rot, compressed.norms)
 
         if k >= compressed.n:
             topk_idx = np.argsort(-scores)
@@ -701,7 +907,7 @@ class Quantizer:
             (indices, scores): top-k corpus indices and approximate scores.
         """
         query = np.asarray(query, dtype=np.float32)
-        q_rot = self.R @ query
+        q_rot = self._rotate_query(query)
 
         centroids = self._resolve_centroids(compressed, precision)
         table = np.outer(q_rot, centroids).astype(np.float32)
@@ -768,7 +974,7 @@ class Quantizer:
             coarse_precision = max(1, self.bits - 2)
 
         query = np.asarray(query, dtype=np.float32)
-        q_rot = self.R @ query
+        q_rot = self._rotate_query(query)
         coarse_k = min(candidates, compressed.n)
         is_packed = isinstance(compressed, PackedVectors)
 
@@ -801,7 +1007,10 @@ class Quantizer:
 
         X_hat_cand = fine_centroids[fine_indices]  # (candidates, d)
 
-        fine_scores = (X_hat_cand @ q_rot) * compressed.norms[coarse_idx]
+        cand_norms = (
+            None if compressed.norms is None else compressed.norms[coarse_idx]
+        )
+        fine_scores = _apply_norms(X_hat_cand @ q_rot, cand_norms)
         rerank_order = np.argsort(-fine_scores)[:k]
 
         original_idx = coarse_idx[rerank_order]
@@ -845,11 +1054,15 @@ class Quantizer:
             queries = queries[np.newaxis]
 
         n_queries = queries.shape[0]
-        Q_rot = queries @ self.R.T  # (n_queries, d)
+        Q_rot = self._rotate_rows(queries)  # (n_queries, d)
 
         X_hat_rot = self._get_x_hat_rot(compressed, precision)
         # (n_queries, n) = (n_queries, d) @ (d, n)
-        all_scores = (Q_rot @ X_hat_rot.T) * compressed.norms[np.newaxis, :]
+        batch_norms = (
+            None if compressed.norms is None
+            else compressed.norms[np.newaxis, :]
+        )
+        all_scores = _apply_norms(Q_rot @ X_hat_rot.T, batch_norms)
 
         all_indices = np.empty((n_queries, min(k, compressed.n)), dtype=np.intp)
         all_topk_scores = np.empty((n_queries, min(k, compressed.n)), dtype=np.float32)
@@ -870,9 +1083,11 @@ class Quantizer:
         """Compute mean per-vector reconstruction MSE (L2 squared)."""
         compressed = self.encode(X)
         X_hat = self.decode(compressed, precision=precision)
-        return float(
-            np.mean(np.sum((np.asarray(X, np.float32) - X_hat) ** 2, axis=1))
-        )
+        dtype = np.float32 if self.normalize else np.float64
+        X_ref = np.asarray(X, dtype)
+        if X_ref.ndim == 1:
+            X_ref = X_ref[np.newaxis]
+        return float(np.mean(np.sum((X_ref - X_hat) ** 2, axis=1)))
 
     # ------------------------------------------------------------------
     # Private helpers
@@ -882,7 +1097,7 @@ class Quantizer:
     def _adc_score_chunked(
         table: np.ndarray,
         indices: np.ndarray,
-        norms: np.ndarray,
+        norms: Optional[np.ndarray],
         chunk_size: int,
     ) -> np.ndarray:
         """Score vectors via ADC lookup table, processing in chunks.
@@ -890,7 +1105,7 @@ class Quantizer:
         Args:
             table: (d, n_levels) float32 lookup table.
             indices: (n, d) uint8 quantization indices.
-            norms: (n,) float32 vector norms.
+            norms: (n,) float32 vector norms, or None in scalar mode.
             chunk_size: Rows per chunk (controls peak memory).
 
         Returns:
@@ -899,7 +1114,7 @@ class Quantizer:
         Memory: peak allocation is chunk_size * d * 4 bytes.
         At chunk_size=4096, d=384: ~6 MB temporary.
         """
-        n = len(norms)
+        n = indices.shape[0]
         d = table.shape[0]
         dim_idx = np.arange(d)
         scores = np.empty(n, dtype=np.float32)
@@ -910,7 +1125,8 @@ class Quantizer:
             # Gather: table[j, chunk_idx[i, j]] → (chunk, d) float32
             # Then sum over d → (chunk,) inner-product contribution
             chunk_scores = table[dim_idx, chunk_idx].sum(axis=1)
-            scores[start:end] = chunk_scores * norms[start:end]
+            chunk_norms = None if norms is None else norms[start:end]
+            scores[start:end] = _apply_norms(chunk_scores, chunk_norms)
 
         return scores
 
@@ -943,7 +1159,10 @@ class Quantizer:
             if shift > 0:
                 chunk_idx = chunk_idx >> shift
             chunk_scores = table[dim_idx, chunk_idx].sum(axis=1)
-            scores[start:end] = chunk_scores * packed.norms[start:end]
+            chunk_norms = (
+                None if packed.norms is None else packed.norms[start:end]
+            )
+            scores[start:end] = _apply_norms(chunk_scores, chunk_norms)
 
         return scores
 

--- a/remex/gpu.py
+++ b/remex/gpu.py
@@ -290,7 +290,12 @@ class GPUSearcher:
 
         # Move static data to device
         self._R = self.ops.to_device(quantizer.R.astype(np.float32))
-        self._norms = self.ops.to_device(compressed.norms)
+        # None in scalar mode (Quantizer(normalize=False)) — there are no
+        # norms to move, and scoring skips the rescale entirely.
+        self._norms = (
+            None if compressed.norms is None
+            else self.ops.to_device(compressed.norms)
+        )
 
         # Indices: keep as int type appropriate for backend
         if self.backend_name == "torch":
@@ -325,7 +330,7 @@ class GPUSearcher:
         idx_bytes = self._n * self._d  # uint8 or int64
         if self.backend_name == "torch":
             idx_bytes *= 8  # int64
-        norm_bytes = self._n * 4
+        norm_bytes = 0 if self._norms is None else self._n * 4
         R_bytes = self._d * self._d * 4
         cent_bytes = sum(
             len(c) * 4 if hasattr(c, '__len__') else 0
@@ -353,7 +358,7 @@ class GPUSearcher:
         if self._x_hat_rot_gpu is None:
             self._x_hat_rot_gpu = self._build_x_hat_rot()
 
-        scores = ops.matvec(self._x_hat_rot_gpu, q_rot) * self._norms
+        scores = self._scale(ops.matvec(self._x_hat_rot_gpu, q_rot))
         idx, vals = ops.topk(scores, k)
         return ops.to_numpy(idx), ops.to_numpy(vals)
 
@@ -380,7 +385,9 @@ class GPUSearcher:
         # Build ADC table: (d, n_levels)
         table = ops.xp.outer(q_rot, centroids)
 
-        scores = ops.gather_sum(table, indices, chunk_size=chunk_size) * self._norms
+        scores = self._scale(
+            ops.gather_sum(table, indices, chunk_size=chunk_size)
+        )
         idx, vals = ops.topk(scores, k)
         return ops.to_numpy(idx), ops.to_numpy(vals)
 
@@ -412,9 +419,11 @@ class GPUSearcher:
         coarse_centroids, coarse_indices = self._resolve_gpu(coarse_precision)
         coarse_table = ops.xp.outer(q_rot, coarse_centroids)
 
-        coarse_scores = ops.gather_sum(
-            coarse_table, coarse_indices, chunk_size=coarse_chunk_size
-        ) * self._norms
+        coarse_scores = self._scale(
+            ops.gather_sum(
+                coarse_table, coarse_indices, chunk_size=coarse_chunk_size
+            )
+        )
 
         # Top candidates (no sort needed, just partition)
         coarse_idx, _ = ops.topk(coarse_scores, coarse_k)
@@ -423,7 +432,9 @@ class GPUSearcher:
         fine_indices = self._indices[coarse_idx]  # (candidates, d)
         X_hat_cand = self._centroids[fine_indices]
 
-        fine_scores = ops.matvec(X_hat_cand, q_rot) * self._norms[coarse_idx]
+        fine_scores = self._scale(
+            ops.matvec(X_hat_cand, q_rot), rows=coarse_idx
+        )
         rerank_idx, rerank_scores = ops.topk(fine_scores, k)
 
         original_idx = coarse_idx[rerank_idx]
@@ -454,10 +465,7 @@ class GPUSearcher:
             self._x_hat_rot_gpu = self._build_x_hat_rot()
 
         # (n_queries, n) = (n_queries, d) @ (n, d).T
-        if self.backend_name == "torch":
-            all_scores = ops.matmul(Q_rot, self._x_hat_rot_gpu.T) * self._norms
-        else:
-            all_scores = ops.matmul(Q_rot, self._x_hat_rot_gpu.T) * self._norms
+        all_scores = self._scale(ops.matmul(Q_rot, self._x_hat_rot_gpu.T))
 
         n_queries = Q.shape[0]
         actual_k = min(k, self._n)
@@ -478,6 +486,17 @@ class GPUSearcher:
     # ------------------------------------------------------------------
     # Private helpers
     # ------------------------------------------------------------------
+
+    def _scale(self, scores, rows=None):
+        """Rescale raw quantized scores by the stored norms, if any.
+
+        Scalar-mode codes quantize the coordinates themselves, so the
+        lookup already is the approximate inner product.
+        """
+        if self._norms is None:
+            return scores
+        norms = self._norms if rows is None else self._norms[rows]
+        return scores * norms
 
     def _build_x_hat_rot(self):
         """Dequantize indices to float32 on GPU."""

--- a/remex/ivf.py
+++ b/remex/ivf.py
@@ -46,7 +46,9 @@ from __future__ import annotations
 import numpy as np
 from typing import Optional, Tuple
 
-from remex.core import CompressedVectors, PackedVectors, Quantizer
+from remex.core import (
+    CompressedVectors, PackedVectors, Quantizer, _apply_norms,
+)
 
 
 _VALID_MODES = ("lsh", "rotated_prefix")
@@ -246,7 +248,7 @@ class IVFCoarseIndex:
         hashing so it lives in the same frame as the corpus hash.
         """
         q = np.asarray(query, dtype=np.float32)
-        q_rot = self.quantizer.R @ q
+        q_rot = self.quantizer._rotate_query(q)
         return self._query_cell_from_rot(q_rot)
 
     def probe_cells(self, query_cell: int, nprobe: int) -> np.ndarray:
@@ -328,7 +330,7 @@ class IVFCoarseIndex:
             total candidate count across the visited cells.
         """
         q = np.asarray(query, dtype=np.float32)
-        q_rot = self.quantizer.R @ q
+        q_rot = self.quantizer._rotate_query(q)
 
         q_cell = self._query_cell_from_rot(q_rot)
         cand = self.candidate_indices(q_cell, nprobe)
@@ -353,7 +355,8 @@ class IVFCoarseIndex:
             shift = self.quantizer.bits - precision
             cand_idx = cand_idx >> shift
 
-        cand_norms = self.compressed.norms[cand]
+        norms = self.compressed.norms
+        cand_norms = None if norms is None else norms[cand]
         d = self.d
         dim_idx = np.arange(d)
         scores = np.empty(n_cand, dtype=np.float32)
@@ -362,7 +365,10 @@ class IVFCoarseIndex:
             end = min(start + chunk_size, n_cand)
             chunk_idx = cand_idx[start:end]
             chunk_scores = table[dim_idx, chunk_idx].sum(axis=1)
-            scores[start:end] = chunk_scores * cand_norms[start:end]
+            scores[start:end] = _apply_norms(
+                chunk_scores,
+                None if cand_norms is None else cand_norms[start:end],
+            )
 
         k_eff = min(k, n_cand)
         if k_eff >= n_cand:
@@ -420,7 +426,7 @@ class IVFCoarseIndex:
             )
 
         q = np.asarray(query, dtype=np.float32)
-        q_rot = self.quantizer.R @ q
+        q_rot = self.quantizer._rotate_query(q)
         fine_centroids = self.quantizer._resolve_centroids(
             self.compressed, None
         )
@@ -430,7 +436,11 @@ class IVFCoarseIndex:
             fine_indices = self.compressed.indices[coarse_idx]
         X_hat_cand = fine_centroids[fine_indices]
 
-        fine_scores = (X_hat_cand @ q_rot) * self.compressed.norms[coarse_idx]
+        norms = self.compressed.norms
+        fine_scores = _apply_norms(
+            X_hat_cand @ q_rot,
+            None if norms is None else norms[coarse_idx],
+        )
         k_eff = min(k, len(coarse_idx))
         order = np.argsort(-fine_scores)[:k_eff]
         return coarse_idx[order], fine_scores[order]

--- a/remex/mojo/README.md
+++ b/remex/mojo/README.md
@@ -144,7 +144,8 @@ guaranteed bit parity regardless of bit width or potential drift.
 
 ### The index records its rotation
 
-`.pq` byte 17 holds the rotation code (`0` = haar, `1` = rht) and
+`.pq` byte 17 holds the rotation code (`0` = haar, `1` = rht; Python also
+writes `2` = none, see below) and
 `.params` byte 9 mirrors it. Both were reserved-and-zero before the field
 existed, and haar is `0`, so every previously written file reads back as
 haar with no compatibility branch — which is the correct answer for all
@@ -154,6 +155,18 @@ rotation; the two constructions differ on roughly half their stored bits,
 so the results would look plausible and be wrong. `--params` skips the
 check, since the matrix comes from the file and there is nothing to
 disagree with.
+
+### Not ported: scalar mode
+
+Python's `Quantizer(normalize=False)` (remex #77) quantizes coordinates
+directly, storing no norms, and pairs with a third rotation code (`2` =
+none, the identity). `polarquant` implements neither, and needs no
+compatibility branch to stay safe: rotation code `2` fails the `> 1` check
+in `load_pq`, and a scalar-mode `.pq` has no norms section, so it is
+`n * 4` bytes shorter than the reader's length arithmetic expects and is
+rejected as truncated. The flag that marks it lives in byte 18, which was
+reserved-and-zero before, so files written by this port are unaffected in
+either direction.
 
 ### 8-bit byte-parity caveat
 

--- a/remex/mojo/src/pq_format.mojo
+++ b/remex/mojo/src/pq_format.mojo
@@ -7,12 +7,23 @@ Layout (all little-endian):
   bytes 4-7   : d (u32)
   bytes 8-15  : n (u64)
   byte 16     : bits (u8)
-  byte 17     : rotation code (u8) — 0 = haar, 1 = rht
-  bytes 18-31 : reserved (14 zero bytes) — header padded to 32 bytes
+  byte 17     : rotation code (u8) — 0 = haar, 1 = rht, 2 = none (identity)
+  byte 18     : flags (u8) — bit 0 set = scalar mode, norms section absent
+  bytes 19-31 : reserved (13 zero bytes) — header padded to 32 bytes
   bytes 32+   : packed_indices (length = packed_nbytes(n*d, bits))
   then        : norms (n × float32)
 
 The Python side mirrors this in `remex.pq_format.{save_pq, load_pq}`.
+
+This reader implements neither of the two values Python can now write:
+rotation code 2 and the scalar-mode flag both come from
+`Quantizer(normalize=False)` (remex #77), which has no Mojo encoder. Both
+fail loudly rather than silently. Code 2 is not a rotation this port can
+build, and a scalar-mode file carries no norms section, so it is `n * 4`
+bytes shorter than the length check below expects and is rejected as
+truncated. Neither can appear in a file this port wrote, and no file
+written before the flags byte existed sets it — byte 18 was reserved and
+zero.
 """
 
 from std.pathlib import Path

--- a/remex/pq_format.py
+++ b/remex/pq_format.py
@@ -7,14 +7,22 @@ Layout (little-endian):
     bytes 4-7   : d (u32)
     bytes 8-15  : n (u64)
     byte 16     : bits (u8)
-    byte 17     : rotation code (u8) — 0 = haar, 1 = rht
-    bytes 18-31 : reserved (14 zero bytes)
+    byte 17     : rotation code (u8) — 0 = haar, 1 = rht, 2 = none
+    byte 18     : flags (u8) — bit 0 set = scalar mode, no norms section
+    bytes 19-31 : reserved (13 zero bytes)
     bytes 32+   : packed_indices (length = packed_nbytes(n*d, bits))
-    then        : norms (n × float32, little-endian)
+    then        : norms (n × float32, little-endian), absent in scalar mode
 
 This is a minimal alternative to the Python `.npz` format that is trivially
 parseable from Mojo without unzip/numpy-header machinery. See
 `remex/mojo/src/pq_format.mojo`.
+
+The flags byte lives in what byte 18 already was — reserved and zero — so
+every file written before it existed reads back as "has norms", which they
+all do. In the other direction a scalar-mode file is *shorter* than an old
+reader's arithmetic expects, so it fails the length check as
+"truncated .pq data" rather than silently reading indices as norms. The
+Mojo port is one such reader: it does not implement scalar mode yet.
 """
 
 from __future__ import annotations
@@ -41,6 +49,9 @@ PARAMS_HEADER_BYTES = 16
 PARAMS_VERSION = 1
 PARAMS_MAGIC = b"PR\x00\x01"
 
+#: Byte 18, bit 0: the norms section is absent (scalar mode).
+PQ_FLAG_NO_NORMS = 0x01
+
 
 # Rotations the Mojo port can rebuild from `(d, seed)` alone, mapped to the
 # `polarquant` flag that selects each one. `--params` reads R straight out of
@@ -61,6 +72,15 @@ def save_params(path: str | Path, quantizer: "Quantizer") -> None:
     from the seed instead; that path needs a construction Mojo actually
     implements, which is what the check below is for.
     """
+    if not getattr(quantizer, "normalize", True):
+        raise ValueError(
+            "save_params does not support scalar-mode quantizers "
+            "(normalize=False). The Mojo encoder always normalizes and "
+            "always writes norms, so it would encode different codes from "
+            "these params, and a parity check against it would compare two "
+            "different pipelines."
+        )
+
     rotation = getattr(quantizer, "rotation", "haar")
     if rotation not in MOJO_ROTATIONS:
         raise ValueError(
@@ -95,7 +115,12 @@ def save_params(path: str | Path, quantizer: "Quantizer") -> None:
 
 
 def save_pq(path: str | Path, compressed: "CompressedVectors") -> None:
-    """Serialize a CompressedVectors to the .pq binary format."""
+    """Serialize a CompressedVectors to the .pq binary format.
+
+    A scalar-mode container (``norms is None``) sets the no-norms flag and
+    writes no norms section. Such a file is readable by ``load_pq`` but not
+    yet by the Mojo port.
+    """
     n, d, bits = int(compressed.n), int(compressed.d), int(compressed.bits)
     packed = pack(compressed.indices.ravel(), bits)
     expected_packed = packed_nbytes(n, d, bits)
@@ -111,13 +136,15 @@ def save_pq(path: str | Path, compressed: "CompressedVectors") -> None:
     header[8:16] = struct.pack("<Q", n)
     header[16] = bits & 0xFF
     header[17] = ROTATION_CODES[validate_rotation(compressed.rotation)]
-
-    norms = np.ascontiguousarray(compressed.norms, dtype=np.float32)
+    if compressed.norms is None:
+        header[18] = PQ_FLAG_NO_NORMS
 
     with open(path, "wb") as f:
         f.write(bytes(header))
         f.write(packed.tobytes())
-        f.write(norms.tobytes())
+        if compressed.norms is not None:
+            norms = np.ascontiguousarray(compressed.norms, dtype=np.float32)
+            f.write(norms.tobytes())
 
 
 def load_pq(path: str | Path) -> "CompressedVectors":
@@ -138,13 +165,22 @@ def load_pq(path: str | Path) -> "CompressedVectors":
     # Byte 17 was reserved-and-zero before this field existed, and 0 is
     # haar, so a pre-field file resolves to LEGACY_ROTATION for free.
     rotation = rotation_from_code(raw[17])
+    flags = raw[18]
+    unknown_flags = flags & ~PQ_FLAG_NO_NORMS
+    if unknown_flags:
+        raise ValueError(
+            f"unknown .pq flag bits 0x{unknown_flags:02x} in header; this "
+            f"file was written by a newer remex."
+        )
+    has_norms = not (flags & PQ_FLAG_NO_NORMS)
     if bits in (5, 6, 7):
         raise ValueError(
             f"bits={bits} is not supported. Use 1-4 or 8 bits."
         )
 
     expected_packed = packed_nbytes(n, d, bits)
-    expected_total = PQ_HEADER_BYTES + expected_packed + n * 4
+    norms_bytes = n * 4 if has_norms else 0
+    expected_total = PQ_HEADER_BYTES + expected_packed + norms_bytes
     if len(raw) < expected_total:
         raise ValueError("truncated .pq data")
 
@@ -153,11 +189,14 @@ def load_pq(path: str | Path) -> "CompressedVectors":
         count=expected_packed,
         offset=PQ_HEADER_BYTES,
     )
-    norms = np.frombuffer(
-        raw, dtype=np.float32,
-        count=n,
-        offset=PQ_HEADER_BYTES + expected_packed,
-    )
+    if has_norms:
+        norms = np.frombuffer(
+            raw, dtype=np.float32,
+            count=n,
+            offset=PQ_HEADER_BYTES + expected_packed,
+        ).copy()
+    else:
+        norms = None
 
     indices = unpack(packed, bits, n * d).reshape(n, d)
-    return CompressedVectors(indices.copy(), norms.copy(), d, bits, rotation)
+    return CompressedVectors(indices.copy(), norms, d, bits, rotation)

--- a/remex/rotation.py
+++ b/remex/rotation.py
@@ -28,7 +28,12 @@ LEGACY_ROTATION = "haar"
 #: lives in were already zero-filled in every file written before the field
 #: existed — so an old file decodes to ``LEGACY_ROTATION`` for free, with no
 #: "is the field present?" branch.
-ROTATION_CODES = {"haar": 0, "rht": 1}
+#:
+#: ``"none"`` is the identity — no rotation at all. It exists for
+#: ``Quantizer(normalize=False)``, where the caller has already conditioned
+#: the coordinate distribution and wants codes that are an exact,
+#: matmul-free function of the input (see ``identity_rotation``).
+ROTATION_CODES = {"haar": 0, "rht": 1, "none": 2}
 ROTATION_BY_CODE = {code: name for name, code in ROTATION_CODES.items()}
 
 
@@ -121,6 +126,35 @@ def haar_rotation(d: int, seed: int = 42) -> np.ndarray:
         Q[:, sign_flip] = -Q[:, sign_flip]
 
     return Q.astype(np.float32)
+
+
+def identity_rotation(d: int, seed: int = 42) -> np.ndarray:
+    """The (d, d) identity — ``rotation="none"``, i.e. no rotation at all.
+
+    Same signature as the real rotations so it drops into
+    ``Quantizer.ROTATIONS`` unchanged; ``seed`` is accepted and ignored,
+    because there is nothing random to seed.
+
+    Quantizing without a rotation gives up the property the rotation exists
+    for — that coordinates become approximately i.i.d. Gaussian, which is
+    what makes one data-oblivious Lloyd-Max codebook right for all of them.
+    It buys back two things that matter for the scalar/hash-key mode
+    (``Quantizer(normalize=False)``):
+
+    - **Exactness.** ``Quantizer`` skips the matmul entirely when R is the
+      identity, so a code is a pure ``searchsorted`` of the input value. No
+      floating-point summation order enters the encoding, so identical
+      inputs give identical codes across BLAS builds and thread counts, not
+      just within one process — which is the contract a hash key needs.
+    - **Interpretability.** Coordinate *j* of the code depends only on
+      coordinate *j* of the input, so a per-coordinate range argument
+      (bounded values, an ``arcsinh`` pre-transform) carries straight
+      through to the codes.
+
+    Use it when the caller has already conditioned each coordinate to a
+    comparable scale. Prefer ``"haar"`` or ``"rht"`` otherwise.
+    """
+    return np.eye(d, dtype=np.float32)
 
 
 def _fwht_inplace(y: np.ndarray) -> None:

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -98,7 +98,7 @@ def test_readme_quantizer_signature_claims_hold():
     that sentence becomes the kind of confident-and-wrong prose this file
     exists to catch."""
     text = README.read_text(encoding="utf-8")
-    assert "(d, bits, seed, rotation)" in text, (
+    assert "(d, bits, seed, rotation, normalize, scale)" in text, (
         "README no longer states the full determining tuple; if a determinant "
         "was added or removed, update the sentence and this assertion together"
     )

--- a/tests/test_scalar_mode.py
+++ b/tests/test_scalar_mode.py
@@ -1,0 +1,497 @@
+"""Scalar mode: ``Quantizer(normalize=False)`` (issue #77).
+
+Direct Lloyd-Max quantization of coordinates, with no unit-norm
+factorization and no stored norms. The motivating use case is codes as
+exact-match hash keys for a meet-in-the-middle join over enumerated
+algebraic values, where the default pipeline actively hurts:
+
+- unit-norm factorization maps every constant-direction family onto ONE
+  direction code, which is a mega-bucket rather than a key;
+- the float32 cast on the normalizing path turns large values into
+  ``inf`` and their codes into whatever ``searchsorted(nan)`` gives.
+
+Both properties are asserted here directly, not implied.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from remex import (
+    CompressedVectors, IVFCoarseIndex, PackedVectors, Quantizer,
+    load_pq, save_params, save_pq,
+)
+from remex.codebook import lloyd_max_codebook
+
+
+def _corpus(n=200, d=16, seed=0, scale=1.0):
+    rng = np.random.default_rng(seed)
+    return (rng.standard_normal((n, d)) * scale).astype(np.float64)
+
+
+class TestConstruction:
+    def test_scalar_mode_stores_no_norms(self):
+        pq = Quantizer(d=16, bits=4, normalize=False)
+        comp = pq.encode(_corpus())
+        assert comp.norms is None
+        assert comp.has_norms is False
+        assert comp.indices.shape == (200, 16)
+
+    def test_normalize_true_is_the_default_and_unchanged(self):
+        assert Quantizer(d=16, bits=4).normalize is True
+        comp = Quantizer(d=16, bits=4).encode(_corpus())
+        assert comp.norms is not None
+        assert comp.has_norms is True
+
+    def test_scale_defaults_to_unit_and_is_rejected_when_normalizing(self):
+        assert Quantizer(d=16, bits=4, normalize=False).scale == pytest.approx(1.0)
+        assert Quantizer(d=64, bits=4).scale == pytest.approx(1.0 / 8.0)
+        with pytest.raises(ValueError, match="normalize=False"):
+            Quantizer(d=16, bits=4, scale=2.0)
+
+    @pytest.mark.parametrize("bad", [0.0, -1.0, float("inf"), float("nan")])
+    def test_nonpositive_scale_rejected(self, bad):
+        with pytest.raises(ValueError, match="finite and positive"):
+            Quantizer(d=16, bits=4, normalize=False, scale=bad)
+
+    def test_codebook_is_the_unit_one_rescaled(self):
+        """Scalar mode changes only the coordinate sigma the cells are cut for."""
+        d, bits, scale = 16, 4, 2.5
+        pq = Quantizer(d=d, bits=bits, normalize=False, scale=scale)
+        expect_b, expect_c = lloyd_max_codebook(d, bits, sigma=scale)
+        np.testing.assert_array_equal(pq.boundaries, expect_b)
+        np.testing.assert_array_equal(pq.centroids, expect_c)
+        # ...and that is the unit codebook stretched by scale * sqrt(d).
+        unit_b, _ = lloyd_max_codebook(d, bits)
+        np.testing.assert_allclose(
+            expect_b, unit_b * scale * np.sqrt(d), rtol=1e-5, atol=1e-6
+        )
+
+
+class TestMotivatingProperties:
+    """The two behaviours the issue says block the hash-key use case."""
+
+    def test_constant_direction_family_collapses_only_when_normalizing(self):
+        """`c * ones(d)` is one direction and many values.
+
+        Normalized, the whole family shares a single direction code — the
+        mega-bucket that turned a 3-minute join into a collision storm.
+        Scalar mode keys them apart.
+        """
+        d = 16
+        family = np.array(
+            [[c] * d for c in (0.1, 0.4, 0.8, 1.2, 1.7, 2.3)], dtype=np.float64
+        )
+
+        normalized = Quantizer(d=d, bits=4).encode(family).indices
+        assert len({row.tobytes() for row in normalized}) == 1
+
+        scalar = Quantizer(d=d, bits=4, normalize=False).encode(family).indices
+        assert len({row.tobytes() for row in scalar}) == len(family)
+
+    def test_scalar_mode_survives_values_that_overflow_float32(self):
+        """Float32 max is ~3.4e38; the normalizing path casts to it."""
+        d = 4
+        X = np.array([[1e300, -1e300, 0.0, 1.0]], dtype=np.float64)
+
+        with np.errstate(over="ignore", invalid="ignore"):
+            normalized = Quantizer(d=d, bits=4).encode(X)
+        assert not np.isfinite(normalized.norms).all()
+
+        pq = Quantizer(d=d, bits=4, normalize=False, rotation="none")
+        codes = pq.encode(X).indices
+        n_levels = 2 ** pq.bits
+        assert (codes < n_levels).all()
+        # Saturation at the extreme cells, with the sign preserved.
+        assert codes[0, 0] == n_levels - 1
+        assert codes[0, 1] == 0
+        # ...and it is a code, not a crash: the same input encodes the same
+        # way every time.
+        np.testing.assert_array_equal(codes, pq.encode(X).indices)
+
+    def test_ordinary_magnitudes_are_not_saturated(self):
+        """Saturation is the tail behaviour, not the common case."""
+        pq = Quantizer(d=16, bits=4, normalize=False, rotation="none")
+        codes = pq.encode(_corpus(n=500, d=16)).indices
+        n_levels = 2 ** pq.bits
+        interior = (codes > 0) & (codes < n_levels - 1)
+        assert interior.mean() > 0.9
+
+
+class TestDeterminism:
+    """The property that makes a code usable as an exact-match hash key."""
+
+    def test_same_params_same_codes(self):
+        X = _corpus()
+        a = Quantizer(d=16, bits=4, seed=42, normalize=False).encode(X)
+        b = Quantizer(d=16, bits=4, seed=42, normalize=False).encode(X)
+        np.testing.assert_array_equal(a.indices, b.indices)
+
+    def test_equal_inputs_collide_unequal_inputs_mostly_do_not(self):
+        pq = Quantizer(d=16, bits=8, normalize=False, rotation="none")
+        X = _corpus(n=300, d=16)
+        keys = pq.encode(np.vstack([X, X])).indices
+        first, second = keys[:300], keys[300:]
+        np.testing.assert_array_equal(first, second)
+        assert len({row.tobytes() for row in first}) == 300
+
+    def test_scale_and_normalize_change_the_codes(self):
+        """Both are determinants of the encoding, like seed and rotation."""
+        X = _corpus()
+        base = Quantizer(d=16, bits=4, normalize=False).encode(X).indices
+        other = (
+            Quantizer(d=16, bits=4, normalize=False, scale=3.0)
+            .encode(X).indices
+        )
+        assert not np.array_equal(base, other)
+        assert not np.array_equal(
+            base, Quantizer(d=16, bits=4).encode(X).indices
+        )
+
+
+class TestIdentityRotation:
+    def test_encode_is_a_bare_searchsorted(self):
+        pq = Quantizer(d=16, bits=4, normalize=False, rotation="none")
+        X = _corpus()
+        expect = np.searchsorted(pq.boundaries, X).astype(np.uint8)
+        np.testing.assert_array_equal(pq.encode(X).indices, expect)
+
+    def test_R_is_the_identity(self):
+        pq = Quantizer(d=8, bits=4, rotation="none")
+        np.testing.assert_array_equal(pq.R, np.eye(8, dtype=np.float32))
+
+    def test_coordinate_j_depends_only_on_input_j(self):
+        pq = Quantizer(d=8, bits=4, normalize=False, rotation="none")
+        X = _corpus(n=1, d=8, seed=3)
+        perturbed = X.copy()
+        perturbed[0, 2] += 10.0
+        a, b = pq.encode(X).indices, pq.encode(perturbed).indices
+        np.testing.assert_array_equal(np.flatnonzero(a[0] != b[0]), [2])
+
+    def test_identity_rotation_still_round_trips_when_normalizing(self):
+        pq = Quantizer(d=16, bits=8, rotation="none")
+        X = _corpus(n=50, d=16).astype(np.float32)
+        comp = pq.encode(X)
+        assert comp.rotation == "none"
+        np.testing.assert_allclose(pq.decode(comp), X, atol=0.05)
+
+
+class TestReconstruction:
+    def test_decode_recovers_coordinates(self):
+        pq = Quantizer(d=16, bits=8, normalize=False, rotation="none")
+        X = _corpus(n=100, d=16)
+        err = np.abs(pq.decode(pq.encode(X)) - X)
+        # The outermost cells are open-ended, so a value past ~3 sigma is
+        # reconstructed at its cell's centroid and can miss by more than the
+        # interior cell width. Bound the bulk tightly and the tail loosely.
+        assert np.percentile(err, 99) < 0.03
+        assert err.max() < 0.2
+
+    def test_mse_improves_with_bits(self):
+        X = _corpus(n=200, d=16)
+        errs = [
+            Quantizer(d=16, bits=b, normalize=False).mse(X)
+            for b in (1, 2, 3, 4, 8)
+        ]
+        assert errs == sorted(errs, reverse=True)
+
+    def test_matching_scale_beats_mismatched_scale(self):
+        """`scale` is the knob the caller uses to declare their conditioning."""
+        X = _corpus(n=200, d=16, scale=5.0)
+        matched = Quantizer(d=16, bits=4, normalize=False, scale=5.0).mse(X)
+        wrong = Quantizer(d=16, bits=4, normalize=False, scale=0.2).mse(X)
+        assert matched < wrong / 10
+
+    def test_encode_accepts_a_single_vector(self):
+        pq = Quantizer(d=16, bits=4, normalize=False)
+        comp = pq.encode(_corpus(n=1, d=16)[0])
+        assert comp.n == 1
+        assert comp.norms is None
+
+    def test_dimension_mismatch_raises(self):
+        with pytest.raises(ValueError, match="Expected d=16"):
+            Quantizer(d=16, bits=4, normalize=False).encode(_corpus(d=8))
+
+
+class TestMatryoshka:
+    """Nested precision — the bit the caller-side int16 substitute gave up."""
+
+    def test_right_shift_is_a_valid_coarser_code(self):
+        pq8 = Quantizer(d=16, bits=8, normalize=False, rotation="none")
+        pq1 = Quantizer(d=16, bits=1, normalize=False, rotation="none")
+        X = _corpus(n=100, d=16)
+        np.testing.assert_array_equal(
+            pq8.encode(X).indices >> 7, pq1.encode(X).indices
+        )
+
+    def test_coarser_precision_collides_more(self):
+        """Nested precision is the collision/recall dial, per query."""
+        pq = Quantizer(d=4, bits=8, normalize=False, rotation="none")
+        codes = pq.encode(_corpus(n=2000, d=4)).indices
+        distinct = [
+            len({row.tobytes() for row in (codes >> (8 - p))})
+            for p in (8, 4, 2, 1)
+        ]
+        assert distinct == sorted(distinct, reverse=True)
+        assert distinct[0] > distinct[-1]
+        assert distinct[-1] <= 2 ** 4  # 1 bit x 4 coords = 16 buckets, at most
+
+    def test_decode_at_precision(self):
+        pq = Quantizer(d=16, bits=8, normalize=False, rotation="none")
+        X = _corpus(n=100, d=16)
+        comp = pq.encode(X)
+        coarse = pq.decode(comp, precision=2)
+        fine = pq.decode(comp, precision=8)
+        assert _rmse(coarse, X) > _rmse(fine, X)
+
+
+def _rmse(a, b):
+    return float(np.sqrt(np.mean((a - b) ** 2)))
+
+
+class TestSearch:
+    """Scoring in scalar mode is the raw quantized inner product."""
+
+    @staticmethod
+    def _fixture():
+        pq = Quantizer(d=16, bits=8, normalize=False)
+        X = _corpus(n=300, d=16, seed=5)
+        return pq, X, pq.encode(X)
+
+    def test_search_finds_the_query_itself(self):
+        pq, X, comp = self._fixture()
+        for row in (0, 7, 42):
+            idx, _ = pq.search(comp, X[row].astype(np.float32), k=5)
+            assert idx[0] == row
+
+    def test_search_scores_are_the_plain_inner_product(self):
+        pq, X, comp = self._fixture()
+        q = X[3].astype(np.float32)
+        idx, scores = pq.search(comp, q, k=10)
+        expect = pq.decode(comp)[idx] @ q
+        np.testing.assert_allclose(scores, expect, rtol=1e-4)
+
+    def test_adc_matches_cached_search(self):
+        pq, X, comp = self._fixture()
+        q = X[11].astype(np.float32)
+        a_idx, a_sc = pq.search(comp, q, k=10)
+        b_idx, b_sc = pq.search_adc(comp, q, k=10)
+        np.testing.assert_array_equal(a_idx, b_idx)
+        np.testing.assert_allclose(a_sc, b_sc, rtol=1e-5)
+
+    def test_twostage_matches_full_scan_when_candidates_is_everything(self):
+        pq, X, comp = self._fixture()
+        q = X[19].astype(np.float32)
+        a_idx, _ = pq.search(comp, q, k=10)
+        b_idx, _ = pq.search_twostage(comp, q, k=10, candidates=comp.n)
+        np.testing.assert_array_equal(a_idx, b_idx)
+
+    def test_search_batch_matches_per_query_search(self):
+        pq, X, comp = self._fixture()
+        queries = X[:4].astype(np.float32)
+        all_idx, all_sc = pq.search_batch(comp, queries, k=6)
+        for i, q in enumerate(queries):
+            idx, sc = pq.search(comp, q, k=6)
+            np.testing.assert_array_equal(all_idx[i], idx)
+            np.testing.assert_allclose(all_sc[i], sc, rtol=1e-5)
+
+    def test_ivf_flat_scan_matches_adc(self):
+        pq, X, comp = self._fixture()
+        ivf = IVFCoarseIndex(pq, comp, n_bits=4, mode="lsh", seed=0)
+        q = X[23].astype(np.float32)
+        a_idx, a_sc = pq.search_adc(comp, q, k=10)
+        b_idx, b_sc = ivf.search_coarse(q, k=10, nprobe=ivf.n_cells)
+        np.testing.assert_array_equal(a_idx, b_idx)
+        np.testing.assert_allclose(a_sc, b_sc, rtol=1e-5)
+
+    def test_gpu_numpy_backend_matches_search(self):
+        from remex.gpu import GPUSearcher
+
+        pq, X, comp = self._fixture()
+        searcher = GPUSearcher(pq, comp, backend="numpy")
+        q = X[31].astype(np.float32)
+        a_idx, a_sc = pq.search(comp, q, k=10)
+        b_idx, b_sc = searcher.search(q, k=10)
+        np.testing.assert_array_equal(a_idx, b_idx)
+        np.testing.assert_allclose(a_sc, b_sc, rtol=1e-5)
+
+    def test_gpu_does_not_pay_for_a_norms_column(self):
+        from remex.gpu import GPUSearcher
+
+        pq, X, comp = self._fixture()
+        normalizing = Quantizer(d=16, bits=8)
+        scalar_bytes = GPUSearcher(
+            pq, comp, backend="numpy"
+        ).resident_bytes_gpu
+        normalized_bytes = GPUSearcher(
+            normalizing, normalizing.encode(X.astype(np.float32)),
+            backend="numpy",
+        ).resident_bytes_gpu
+        assert normalized_bytes - scalar_bytes == comp.n * 4
+
+
+class TestMemory:
+    def test_norms_column_is_not_paid_for(self):
+        X = _corpus(n=1000, d=16)
+        scalar = Quantizer(d=16, bits=4, normalize=False).encode(X)
+        normalized = Quantizer(d=16, bits=4).encode(X)
+        assert normalized.nbytes - scalar.nbytes == 1000 * 4
+        assert scalar.nbytes_unpacked == scalar.indices.nbytes
+        assert scalar.resident_bytes == scalar.indices.nbytes
+        assert scalar.compression_ratio > normalized.compression_ratio
+
+    def test_packed_vectors_carry_the_absence_through(self):
+        comp = Quantizer(d=16, bits=4, normalize=False).encode(_corpus())
+        packed = PackedVectors.from_compressed(comp)
+        assert packed.norms is None
+        assert packed.has_norms is False
+        assert packed.nbytes == packed._packed.nbytes
+        assert packed.resident_bytes == packed._packed.nbytes
+
+        np.testing.assert_array_equal(
+            packed.to_compressed().indices, comp.indices
+        )
+        assert packed.to_compressed().norms is None
+        assert packed.subset(np.array([0, 3, 5])).norms is None
+        assert packed.at_precision(2).norms is None
+
+    def test_subset_keeps_scalar_mode(self):
+        comp = Quantizer(d=16, bits=4, normalize=False).encode(_corpus())
+        sub = comp.subset(np.array([1, 4, 9]))
+        assert sub.norms is None
+        assert sub.n == 3
+
+    def test_packed_adc_matches_unpacked(self):
+        pq = Quantizer(d=16, bits=4, normalize=False)
+        X = _corpus(n=200, d=16)
+        comp = pq.encode(X)
+        packed = PackedVectors.from_compressed(comp)
+        q = X[2].astype(np.float32)
+        a_idx, a_sc = pq.search_adc(comp, q, k=10)
+        b_idx, b_sc = pq.search_adc(packed, q, k=10)
+        np.testing.assert_array_equal(a_idx, b_idx)
+        np.testing.assert_allclose(a_sc, b_sc, rtol=1e-5)
+
+    def test_from_rows_accepts_no_norms(self):
+        comp = Quantizer(d=16, bits=4, normalize=False).encode(_corpus())
+        packed = PackedVectors.from_compressed(comp)
+        rows = [bytes(r) for r in packed._packed]
+        rebuilt = PackedVectors.from_rows(rows, None, 16, 4)
+        assert rebuilt.norms is None
+        np.testing.assert_array_equal(
+            rebuilt.to_compressed().indices, comp.indices
+        )
+
+
+class TestSerialization:
+    """Absence of the norms column is what marks a file as scalar mode."""
+
+    def test_npz_round_trip(self, tmp_path):
+        comp = Quantizer(d=16, bits=4, normalize=False).encode(_corpus())
+        path = str(tmp_path / "scalar.npz")
+        comp.save(path)
+        assert "norms" not in np.load(path)
+        loaded = CompressedVectors.load(path)
+        assert loaded.norms is None
+        np.testing.assert_array_equal(loaded.indices, comp.indices)
+
+    def test_packed_npz_round_trip(self, tmp_path):
+        comp = Quantizer(d=16, bits=4, normalize=False).encode(_corpus())
+        packed = PackedVectors.from_compressed(comp)
+        path = str(tmp_path / "scalar_packed.npz")
+        packed.save(path)
+        loaded = PackedVectors.load(path)
+        assert loaded.norms is None
+        np.testing.assert_array_equal(
+            loaded.to_compressed().indices, comp.indices
+        )
+
+    def test_pq_round_trip(self, tmp_path):
+        comp = Quantizer(
+            d=16, bits=4, normalize=False, rotation="none"
+        ).encode(_corpus())
+        path = tmp_path / "scalar.pq"
+        save_pq(path, comp)
+        loaded = load_pq(path)
+        assert loaded.norms is None
+        assert loaded.rotation == "none"
+        np.testing.assert_array_equal(loaded.indices, comp.indices)
+
+    def test_pq_scalar_file_is_shorter_by_exactly_the_norms(self, tmp_path):
+        X = _corpus()
+        scalar = Quantizer(d=16, bits=4, normalize=False).encode(X)
+        normalized = Quantizer(d=16, bits=4).encode(X)
+        a, b = tmp_path / "s.pq", tmp_path / "n.pq"
+        save_pq(a, scalar)
+        save_pq(b, normalized)
+        assert b.stat().st_size - a.stat().st_size == scalar.n * 4
+
+    def test_pq_flag_byte_defaults_off_for_normalized_files(self, tmp_path):
+        path = tmp_path / "n.pq"
+        save_pq(path, Quantizer(d=16, bits=4).encode(_corpus()))
+        assert path.read_bytes()[18] == 0
+
+    def test_pq_rejects_unknown_flag_bits(self, tmp_path):
+        path = tmp_path / "future.pq"
+        save_pq(path, Quantizer(d=16, bits=4).encode(_corpus()))
+        raw = bytearray(path.read_bytes())
+        raw[18] = 0x80
+        path.write_bytes(bytes(raw))
+        with pytest.raises(ValueError, match="unknown .pq flag bits"):
+            load_pq(path)
+
+    def test_save_params_refuses_scalar_quantizers(self, tmp_path):
+        pq = Quantizer(d=16, bits=4, normalize=False)
+        with pytest.raises(ValueError, match="scalar-mode"):
+            save_params(tmp_path / "p.params", pq)
+
+    def test_save_params_refuses_the_identity_rotation(self, tmp_path):
+        with pytest.raises(ValueError, match="save_params supports rotation"):
+            save_params(tmp_path / "p.params", Quantizer(d=16, rotation="none"))
+
+    def test_arrow_round_trip(self, tmp_path):
+        pytest.importorskip("pyarrow")
+        import pyarrow.feather as feather
+
+        comp = Quantizer(d=16, bits=4, normalize=False).encode(_corpus())
+        path = str(tmp_path / "scalar.arrow")
+        comp.save_arrow(path, seed=42)
+        assert "norms" not in feather.read_table(path).schema.names
+
+        loaded = CompressedVectors.load_arrow(path)
+        assert loaded.norms is None
+        np.testing.assert_array_equal(loaded.indices, comp.indices)
+
+
+class TestModeGuard:
+    """Crossing the two modes rescales every coordinate, so it must raise."""
+
+    def test_normalizing_quantizer_refuses_scalar_codes(self):
+        comp = Quantizer(d=16, bits=4, normalize=False).encode(_corpus())
+        with pytest.raises(ValueError, match="mode mismatch"):
+            Quantizer(d=16, bits=4).decode(comp)
+
+    def test_scalar_quantizer_refuses_normalized_codes(self):
+        comp = Quantizer(d=16, bits=4).encode(_corpus())
+        with pytest.raises(ValueError, match="mode mismatch"):
+            Quantizer(d=16, bits=4, normalize=False).decode(comp)
+
+    def test_guard_fires_on_the_search_paths_too(self):
+        comp = Quantizer(d=16, bits=4, normalize=False).encode(_corpus())
+        pq = Quantizer(d=16, bits=4)
+        q = np.zeros(16, dtype=np.float32)
+        for call in (
+            lambda: pq.search(comp, q, k=3),
+            lambda: pq.search_adc(comp, q, k=3),
+            lambda: pq.search_twostage(comp, q, k=3),
+            lambda: pq.search_batch(comp, q[None], k=3),
+        ):
+            with pytest.raises(ValueError, match="mode mismatch"):
+                call()
+
+    def test_rotation_guard_still_fires_within_scalar_mode(self):
+        comp = Quantizer(
+            d=16, bits=4, normalize=False, rotation="none"
+        ).encode(_corpus())
+        with pytest.raises(ValueError, match="rotation mismatch"):
+            Quantizer(d=16, bits=4, normalize=False).decode(comp)


### PR DESCRIPTION
Closes #77.

`Quantizer(d, bits, normalize=False, scale=...)` quantizes the (optionally rotated) coordinates directly with the Lloyd-Max codebook — no unit-sphere factorization, no norms computed or stored, codes are the whole output.

```python
pq = Quantizer(d=4, bits=4, normalize=False, rotation="none", scale=1.0)
codes = pq.encode(values).indices     # (n, 4) uint8, and no norms array
keys = [bytes(row) for row in codes]  # exact-match hash keys
coarse = codes >> 2                   # 2-bit keys: coarser, more collisions
```

## What it fixes

The two properties the issue names, asserted directly in `tests/test_scalar_mode.py::TestMotivatingProperties` rather than implied:

- **Constant-direction collapse.** Every `c * ones(d)` shares one direction code under normalization — the mega-bucket. `test_constant_direction_family_collapses_only_when_normalizing` shows a 6-member family going from 1 distinct code to 6.
- **float32 range.** The normalizing path casts input to float32 and stores float32 norms (the 1-ULP Mojo-parity fix). Scalar mode works in float64 throughout `encode`, so a value past ~3.4e38 saturates at the outermost cell — a well-defined, sign-preserving, reproducible code — instead of becoming `inf` and a `nan` norm.

Kept, per the issue: Lloyd-Max cell shaping, Matryoshka nesting (right-shift for a coarser key, i.e. a per-query collision/recall dial), and the determinism contract.

## Design

- **`scale`** is the coordinate sigma the cells are cut for; defaults to 1.0. remex stays data-oblivious — `scale` is a value the caller *declares* after conditioning their input (`arcsinh`/`log`/bounding), never one remex measures. `lloyd_max_codebook` / `nested_codebooks` grew a `sigma` argument for it; `sigma=None` is the unit-sphere `1/sqrt(d)`, unchanged bit-for-bit.
- **`rotation="none"`** (the identity, on-disk code 2) is added alongside. It strengthens the determinism the hash-key case needs: with the matmul short-circuited, a code is a bare `searchsorted` of the input value — identical across BLAS builds and thread counts, not just within a process — and coordinate *j* of the code depends only on coordinate *j* of the input.
- **`norms` is now optional** on both containers (`has_norms` exposes it), and its absence is how every serializer records the mode: no `norms` entry in `.npz`, no `norms` column in Arrow, and a no-norms flag at `.pq` byte 18 bit 0.
- **Mode mismatches raise**, alongside the existing rotation check — the two codebooks differ by `scale * sqrt(d)`, so crossing them would rescale every reconstructed coordinate rather than fail.

### `.pq` compatibility

Byte 18 was reserved-and-zero, so every existing file reads back as "has norms", which they all do. In the other direction a scalar-mode file is *shorter* than an old reader's arithmetic expects, so it fails as `truncated .pq data` rather than reading indices as norms. The Mojo port is one such reader — it has no scalar-mode encoder, and rotation code 2 fails its `> 1` check; both failure paths are documented in `mojo/src/pq_format.mojo` and `mojo/README.md`. `save_params` refuses a scalar quantizer for the same reason.

## Changed beyond the feature

`bench/gates/rotation_identity_gate.py::_flip_library_default` resolved `Quantizer`'s `rotation` default positionally as `__defaults__[-1]`. The two new keyword arguments would have shifted `scale` into that slot — the gate would have rebound the wrong default and stayed green while testing nothing. It now looks the slot up by name.

## Verification

- 280 tests pass (`tests/test_scalar_mode.py` adds 52), rotation identity gate passes.
- The default path is byte-for-byte unchanged: codes, norms, boundaries, centroids, nested tables and rotation matrices all digest identically against the merge base over a matrix of `(d, bits, rotation)`.
- The Arrow path was exercised locally with pyarrow installed, matching what the `pytest-arrow` CI job does; the new `test_arrow_round_trip` is named so the job's `-k arrow` filter selects it.
- The Mojo port was not built or run here — the claims about its readers are read off `load_pq`'s length check and rotation-code check in source, not executed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pEwE2bmbc2tAN17iXHrPp

---
_Generated by [Claude Code](https://claude.ai/code/session_013pEwE2bmbc2tAN17iXHrPp)_