### PR TITLE
One spelling per enumerated domain, plus oracles that loop them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ remex/mojo/polarquant
 remex/mojo/bench/bench_encode
 remex/mojo/bench/bench_search
 remex/mojo/bench/bench_twostage
+
+# Node tooling (coherence harness trial)
+node_modules/
+.coherence/

--- a/coherence.config.json
+++ b/coherence.config.json
@@ -1,0 +1,12 @@
+{
+  "name": "remex",
+  "language": "python",
+  "codeExt": ["py"],
+  "outputDir": ".coherence/public",
+  "sources": ["remex", "tests"],
+  "testDir": "tests/",
+  "test": ["python3", "-m", "pytest", "-q", "-k"],
+  "testMatch": "[1-9]\\d* passed",
+  "oracleExecution": "serial",
+  "ignore": ["node_modules", ".git", ".venv", "__pycache__", ".pytest_cache", "bench", "docs", "mojo"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,36 @@
+{
+  "name": "remex",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "@danilocampos/coherence": "^0.37.1"
+      }
+    },
+    "node_modules/@danilocampos/coherence": {
+      "version": "0.37.1",
+      "resolved": "https://registry.npmjs.org/@danilocampos/coherence/-/coherence-0.37.1.tgz",
+      "integrity": "sha512-1084I2ZFPfbX6GPqjajlICetNbb2MV9+bqntH2rbXs2IBwUXDuPls8uThyCMxyU8U0srZbStiguXvN4ydt/x2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "web-tree-sitter": "^0.26.12"
+      },
+      "bin": {
+        "coherence": "dist/cli.js",
+        "coherence-hook": "dist/hook-cli.js"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/web-tree-sitter": {
+      "version": "0.26.13",
+      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.26.13.tgz",
+      "integrity": "sha512-5bUZ7vbQ1kcondet96wzP974+JfCZDeQ7bTpacICm2nnvHpa5cO0ByRsoMcAhUP+743vpkb4m0BFlVSm+Ye9VA==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "@danilocampos/coherence": "^0.37.1"
+  }
+}

--- a/remex.spec.md
+++ b/remex.spec.md
@@ -1,0 +1,14 @@
+# remex
+
+Retrieval-validated embedding compression: quantize float32 embedding matrices to
+1-8 bit codes and search them without decompressing.
+
+## works when
+
+- pyproject.toml exists at root
+- remex/rotation.py exists at root
+
+## why
+
+The root establishes how the package is built and which module owns the on-disk
+format contract. Implementation claims belong to the component specs below it.

--- a/remex/core.py
+++ b/remex/core.py
@@ -5,7 +5,7 @@ from typing import Optional, Tuple, Iterable
 from remex.codebook import (
     coordinate_sigma, lloyd_max_codebook, nested_codebooks,
 )
-from remex.packing import pack, unpack, packed_nbytes
+from remex.packing import SUPPORTED_BITS, pack, unpack, packed_nbytes
 from remex.rotation import (
     LEGACY_ROTATION, haar_rotation, identity_rotation, rht_rotation,
     validate_rotation,
@@ -637,10 +637,11 @@ class Quantizer:
                  scale: Optional[float] = None):
         if bits < 1 or bits > 8:
             raise ValueError(f"bits must be 1-4 or 8, got {bits}")
-        if bits in (5, 6, 7):
+        if bits not in SUPPORTED_BITS:
             raise ValueError(
-                f"bits={bits} is not supported. Use 1-4 or 8 bits. "
-                f"5-7 bit widths offer negligible benefit over 4-bit or 8-bit."
+                f"bits={bits} is not supported. Use one of "
+                f"{list(SUPPORTED_BITS)}. 5-7 bit widths offer negligible "
+                f"benefit over 4-bit or 8-bit."
             )
 
         if rotation not in self.ROTATIONS:

--- a/remex/lib.spec.md
+++ b/remex/lib.spec.md
@@ -1,0 +1,56 @@
+# remex core
+
+The library: quantizer, packing, rotation, on-disk formats and search.
+
+## invariants
+
+- every declared rotation survives a round-trip through the on-disk formats
+- every supported bit width packs and unpacks losslessly
+- the constructible rotations and the persistable rotations are the same set
+
+## refutations
+
+- every declared rotation survives a round-trip through the on-disk formats:
+  added `"hadamard2": 3` to `ROTATION_CODES` with no construction behind it ->
+  the whole pre-existing suite stayed green (267 passed) while this claim went
+  red by name on `test_every_declared_rotation_round_trips[hadamard2]`.
+- the constructible rotations and the persistable rotations are the same set:
+  added `"hadamard2": identity_rotation` to `Quantizer.ROTATIONS` only -> the
+  pre-existing suite stayed green (267 passed) while this claim went red on
+  `test_constructible_and_persistable_rotations_agree`.
+- every supported bit width packs and unpacks losslessly: added `5` to
+  `SUPPORTED_BITS` with no packing branch behind it -> this claim went red on
+  `test_every_supported_width_round_trips[5]`. Co-detected: the pre-existing
+  `test_bits_validation` also fails, because it asserts 5 is refused. Recorded
+  as the weaker refutation it is.
+
+## works when
+
+- rotation.py exists at this node
+- packing.py exists at this node
+- boundary "every declared rotation survives a round-trip through the on-disk formats" at rotation_from_code via test "test_every_declared_rotation_round_trips"
+- boundary "every supported bit width packs and unpacks losslessly" at pack via test "test_every_supported_width_round_trips"
+- parity "the constructible rotations and the persistable rotations are the same set" over ROTATION_CODES between ROTATIONS and rotation_from_code via test "test_constructible_and_persistable_rotations_agree"
+
+## why
+
+Two domains in this package are enumerated in more than one place, with nothing
+tying the spellings together.
+
+`ROTATION_CODES` maps a rotation name to the byte that persists it;
+`Quantizer.ROTATIONS` maps the same names to the functions that build them. A
+name in one and not the other either cannot be built or cannot be read back, and
+a rotation decoded under the wrong basis comes back 50%-different rather than
+slightly off — the failure is total and silent. The parity claim is what keeps
+the two dicts equal; before it, the equality held only because both lists were
+short enough to remember.
+
+`SUPPORTED_BITS` was extracted for the same reason. The set was previously
+spelled five times as the negative guard `bits in (5, 6, 7)` across `packing.py`,
+`core.py` and `pq_format.py`, and twice more as `[1, 2, 3, 4, 8]` in the tests.
+Adding a width meant remembering seven sites; now the guards and the round-trip
+oracle read one tuple.
+
+Both oracles loop the live registry rather than a copied list, so a member added
+to a registry without the path behind it fails by name here instead of failing
+in whichever caller reaches it first.

--- a/remex/packing.py
+++ b/remex/packing.py
@@ -14,6 +14,15 @@ Packing ratios:
 
 import numpy as np
 
+#: The bit widths this library packs — the single source of truth for that
+#: domain. It was previously spelled five times as the negative check
+#: ``bits in (5, 6, 7)`` across ``packing.py``, ``core.py`` and
+#: ``pq_format.py``, and twice more as the literal ``[1, 2, 3, 4, 8]`` in the
+#: tests. Five sites held equal by memory is a convention; one exported tuple
+#: the guards and the oracle both read is a contract, and a width added here
+#: without a packing path fails the round-trip oracle by name.
+SUPPORTED_BITS = (1, 2, 3, 4, 8)
+
 
 def pack(indices: np.ndarray, bits: int) -> np.ndarray:
     """
@@ -26,10 +35,11 @@ def pack(indices: np.ndarray, bits: int) -> np.ndarray:
     Returns:
         Packed uint8 byte array.
     """
-    if bits in (5, 6, 7):
+    if bits not in SUPPORTED_BITS:
         raise ValueError(
-            f"Bit width {bits} is not supported. Use 1-4 or 8 bits. "
-            f"5-7 bit widths offer negligible benefit over 4-bit or 8-bit."
+            f"Bit width {bits} is not supported. Use one of "
+            f"{list(SUPPORTED_BITS)}. 5-7 bit widths offer negligible benefit "
+            f"over 4-bit or 8-bit."
         )
     flat = indices.ravel().astype(np.uint8)
     n = len(flat)
@@ -87,10 +97,11 @@ def unpack(packed: np.ndarray, bits: int, n_values: int) -> np.ndarray:
     Returns:
         (n_values,) uint8 array.
     """
-    if bits in (5, 6, 7):
+    if bits not in SUPPORTED_BITS:
         raise ValueError(
-            f"Bit width {bits} is not supported. Use 1-4 or 8 bits. "
-            f"5-7 bit widths offer negligible benefit over 4-bit or 8-bit."
+            f"Bit width {bits} is not supported. Use one of "
+            f"{list(SUPPORTED_BITS)}. 5-7 bit widths offer negligible benefit "
+            f"over 4-bit or 8-bit."
         )
     if bits == 8:
         return packed[:n_values].copy()
@@ -129,9 +140,10 @@ def unpack(packed: np.ndarray, bits: int, n_values: int) -> np.ndarray:
 
 def packed_nbytes(n_values: int, d: int, bits: int) -> int:
     """Compute packed byte count for n_values vectors of dimension d."""
-    if bits in (5, 6, 7):
+    if bits not in SUPPORTED_BITS:
         raise ValueError(
-            f"Bit width {bits} is not supported. Use 1-4 or 8 bits."
+            f"Bit width {bits} is not supported. Use one of "
+            f"{list(SUPPORTED_BITS)}."
         )
     total_values = n_values * d
     if bits == 8:

--- a/remex/pq_format.py
+++ b/remex/pq_format.py
@@ -33,7 +33,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-from remex.packing import pack, unpack, packed_nbytes
+from remex.packing import SUPPORTED_BITS, pack, unpack, packed_nbytes
 from remex.rotation import (
     ROTATION_CODES, rotation_from_code, validate_rotation,
 )
@@ -173,9 +173,10 @@ def load_pq(path: str | Path) -> "CompressedVectors":
             f"file was written by a newer remex."
         )
     has_norms = not (flags & PQ_FLAG_NO_NORMS)
-    if bits in (5, 6, 7):
+    if bits not in SUPPORTED_BITS:
         raise ValueError(
-            f"bits={bits} is not supported. Use 1-4 or 8 bits."
+            f"bits={bits} is not supported. Use one of "
+            f"{list(SUPPORTED_BITS)}."
         )
 
     expected_packed = packed_nbytes(n, d, bits)

--- a/tests/test_packing_totality.py
+++ b/tests/test_packing_totality.py
@@ -1,0 +1,44 @@
+"""Every bit width the library declares supported must pack and unpack losslessly.
+
+The domain is `SUPPORTED_BITS` itself. Before it existed the same set was
+spelled five times as the negative guard `bits in (5, 6, 7)` and twice more as
+the literal `[1, 2, 3, 4, 8]` in the tests, so adding a width meant remembering
+seven places. Looping the tuple means a width added without a packing path
+fails here by name instead of failing in whichever caller reaches it first.
+"""
+
+import numpy as np
+import pytest
+
+from remex.packing import SUPPORTED_BITS, pack, packed_nbytes, unpack
+
+
+def test_the_supported_widths_are_not_empty():
+    """Domain floor: an empty tuple must not pass this file vacuously."""
+    assert len(SUPPORTED_BITS) >= 5
+
+
+@pytest.mark.parametrize("bits", SUPPORTED_BITS)
+def test_every_supported_width_round_trips(bits):
+    rng = np.random.default_rng(bits)
+    values = rng.integers(0, 1 << bits, size=997, dtype=np.uint8)
+
+    packed = pack(values, bits)
+    assert packed.dtype == np.uint8
+    assert len(packed) == packed_nbytes(997, 1, bits)
+    np.testing.assert_array_equal(unpack(packed, bits, 997), values)
+
+
+@pytest.mark.parametrize("bits", SUPPORTED_BITS)
+def test_every_supported_width_is_accepted_by_every_guard(bits):
+    """The guards are the reason the tuple is exported; each must admit it."""
+    from remex.core import Quantizer
+
+    assert Quantizer(d=16, bits=bits).bits == bits
+    assert packed_nbytes(4, 16, bits) > 0
+
+
+@pytest.mark.parametrize("bits", [0, 5, 6, 7, 9])
+def test_every_unsupported_width_is_refused(bits):
+    with pytest.raises(ValueError, match="not supported"):
+        pack(np.zeros(8, dtype=np.uint8), bits)

--- a/tests/test_packing_totality.py
+++ b/tests/test_packing_totality.py
@@ -42,3 +42,25 @@ def test_every_supported_width_is_accepted_by_every_guard(bits):
 def test_every_unsupported_width_is_refused(bits):
     with pytest.raises(ValueError, match="not supported"):
         pack(np.zeros(8, dtype=np.uint8), bits)
+
+
+# totality: ratchet — every one of these widths has written indexes to disk;
+# dropping one silently orphans every file packed at that width
+def test_no_shipped_bit_width_is_ever_removed():
+    """invariant: a bit width that has shipped never leaves SUPPORTED_BITS.
+
+    The complement of the enumeration above. `test_every_supported_width_round_trips`
+    loops whatever the tuple now holds, so removing a width leaves it green over
+    the four that remain.
+
+    refuted: removed 3 from SUPPORTED_BITS and lowered the floor to >= 4, the
+    way a real removal would -> the enumeration, the guard test and the refusal
+    test all stayed green (14 passed) while this went red naming 3. Dropping 3
+    WITHOUT touching the floor is co-detected, because the floor is a
+    cardinality check; it cannot see a member substituted for another.
+    """
+    for shipped in (1, 2, 3, 4, 8):
+        assert shipped in SUPPORTED_BITS, (
+            f"{shipped}-bit left SUPPORTED_BITS; every index packed at that "
+            f"width becomes unreadable"
+        )

--- a/tests/test_rotation_totality.py
+++ b/tests/test_rotation_totality.py
@@ -1,0 +1,56 @@
+"""Every rotation the library declares must survive the on-disk formats.
+
+The domain is `ROTATION_CODES` itself, not a list someone typed. A rotation
+added to that dict without a persistence path decodes under the wrong basis,
+and the codes come back 50%-different rather than slightly off — so the whole
+registry is the domain, and a hand-written subset would hide exactly the
+member nobody remembered to add.
+"""
+
+import numpy as np
+import pytest
+
+from remex import CompressedVectors, load_pq, save_pq
+from remex.core import Quantizer
+from remex.rotation import ROTATION_CODES, rotation_from_code
+
+ROTATIONS = sorted(ROTATION_CODES)
+
+
+def test_the_registry_is_not_empty():
+    """Domain floor: a registry that collapses to zero must not pass vacuously."""
+    assert len(ROTATIONS) >= 3
+
+
+@pytest.mark.parametrize("rotation", ROTATIONS)
+def test_every_declared_rotation_round_trips(tmp_path, rotation):
+    X = np.random.default_rng(0).standard_normal((24, 64)).astype(np.float32)
+    cv = Quantizer(d=64, bits=4, seed=1, rotation=rotation).encode(X)
+    assert cv.rotation == rotation
+
+    pq = tmp_path / f"{rotation}.pq"
+    save_pq(pq, cv)
+    assert load_pq(pq).rotation == rotation
+
+    npz = tmp_path / f"{rotation}.npz"
+    cv.save(npz)
+    assert CompressedVectors.load(npz).rotation == rotation
+
+    assert rotation_from_code(ROTATION_CODES[rotation]) == rotation
+
+
+def test_constructible_and_persistable_rotations_agree():
+    """The two independent spellings of the rotation domain must stay equal.
+
+    `Quantizer.ROTATIONS` maps a name to the function that BUILDS it;
+    `ROTATION_CODES` maps a name to the byte that PERSISTS it. Nothing in the
+    type system ties them together, so a rotation added to one and not the
+    other either cannot be built or cannot be read back.
+    """
+    from remex.core import Quantizer
+
+    assert len(ROTATION_CODES) >= 3, "domain floor"
+    assert set(Quantizer.ROTATIONS) == set(ROTATION_CODES)
+    for name in ROTATION_CODES:
+        assert name in Quantizer.ROTATIONS
+        assert rotation_from_code(ROTATION_CODES[name]) == name

--- a/tests/test_rotation_totality.py
+++ b/tests/test_rotation_totality.py
@@ -54,3 +54,24 @@ def test_constructible_and_persistable_rotations_agree():
     for name in ROTATION_CODES:
         assert name in Quantizer.ROTATIONS
         assert rotation_from_code(ROTATION_CODES[name]) == name
+
+
+# totality: ratchet — these three have shipped; one leaving is a compatibility
+# break for every index already on disk, so the list is deliberately by hand
+def test_no_shipped_rotation_is_ever_removed():
+    """invariant: a rotation that has shipped never leaves ROTATION_CODES.
+
+    The complement of the enumeration above, and not a weaker version of it.
+    `test_every_declared_rotation_round_trips` loops whatever the registry now
+    holds, so it is structurally blind to the registry NARROWING: drop a member
+    and the loop simply ranges over fewer of them, green. This pins the floor.
+
+    refuted: substituted "xyz" for "none" in both ROTATION_CODES and
+    Quantizer.ROTATIONS -> the domain floor, the enumeration and the parity
+    check all stayed green (5 passed) while this went red naming 'none'.
+    """
+    for shipped in ("haar", "rht", "none"):
+        assert shipped in ROTATION_CODES, (
+            f"{shipped!r} left ROTATION_CODES; every index written with it "
+            f"decodes under the wrong basis"
+        )


### PR DESCRIPTION
Two enumerated domains in `remex` were spelled in more than one place with nothing keeping the spellings equal. This gives each one spelling and an oracle that loops it. A second, separable commit trials [daniloc/coherence](https://github.com/daniloc/coherence) as the enforcement layer.

## The two domains

**`SUPPORTED_BITS`** (`remex/packing.py`). The packable widths appeared five times as the negative guard `bits in (5, 6, 7)` across `packing.py`, `core.py` and `pq_format.py`, and twice more as `[1, 2, 3, 4, 8]` in the tests. Adding a width meant remembering seven places. It is now one exported tuple that all four guards read. The guards tighten as a side effect: `0` and `9` previously reached the general path in `pack`/`unpack` instead of being refused.

**The rotation domain** has two spellings that must stay equal: `ROTATION_CODES` (name to on-disk byte) and `Quantizer.ROTATIONS` (name to constructor). They agree today, and nothing checked that they do.

`tests/test_rotation_totality.py` loops `ROTATION_CODES`; `tests/test_packing_totality.py` loops `SUPPORTED_BITS`. Both carry a domain floor so an emptied registry cannot pass vacuously.

## Perturbation results

The existing `test_pq_and_npz_round_trip_rotation` parametrizes `["haar", "rht"]` and never sees `"none"`. That case is covered by a scalar-mode serialization test, which reaches it because scalar mode happens to use `rotation="none"`. The coverage is incidental rather than enumerated.

Three perturbations, each reverted:

| perturbation | pre-existing suite | the new oracle |
|---|---|---|
| `"hadamard2": 3` added to `ROTATION_CODES`, no construction behind it | 267 passed | red on `test_every_declared_rotation_round_trips[hadamard2]` |
| `"hadamard2"` added to `Quantizer.ROTATIONS` only | 267 passed | red on `test_constructible_and_persistable_rotations_agree` |
| `5` added to `SUPPORTED_BITS`, no packing branch | `test_bits_validation` also fails | red on `test_every_supported_width_round_trips[5]` |

In the first two the whole suite stays green while a member sits in a registry with no path behind it. The third is co-detected, and the spec records it as the weaker refutation it is.

Full suite after the change: 288 passed, 14 skipped.

## The second commit

`6a56384` adds `coherence.config.json` and two `*.spec.md` files. Drop it and the tests still stand.

Coherence reads spec files whose `## works when` blocks carry claim lines in a fixed grammar, derives a symbol graph through a tree-sitter Python grammar, and grades every claim per run. Its meta-oracle parses a `via test` claim's named test and refuses the claim when that test iterates a hand-written list rather than a live registry. Pointed at `test_pq_and_npz_round_trip_rotation` it reported:

> iterates a LITERAL domain (inline `["haar", "rht"]` literal) — a sampling oracle, not totality

Cost: a Node dev-dependency (~10 MB of `node_modules`, gitignored) and a `package.json` in a Python package, one config file, two spec files. `npx coherence verify` reports 7 claims, 7 green, 3 invariants each anchored and each carrying a recorded refutation. `.coherence/` is gitignored for the trial; a real adoption would commit `status.json`, which is the memory later runs compare against.

---
_Generated by [Claude Code](https://claude.ai/code/session_013GKuv51gAHoiNct31ha4rE)_